### PR TITLE
Add embeddings leaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ benchmark-runner/.env
 # Exclude uncompressed result files (keep only .gz versions)
 results/*.json
 !results/*.json.gz
+
+# Machine-specific benchmark metadata (temp dir paths)
+benchmark-runner/datasets/embedding_banks.json

--- a/benchmark-runner/datasets/locomo_embeddings_gt_all-minilm-l6-v2.json
+++ b/benchmark-runner/datasets/locomo_embeddings_gt_all-minilm-l6-v2.json
@@ -1,0 +1,1823 @@
+{
+  "annotations": [
+    {
+      "q_idx": 0,
+      "question": "what are John's goals with regards to his basketball career?",
+      "expected_answer": "improve shooting percentage, win a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John",
+        "John's current goals include improving his basketball performance (better shooting, more court impact, consistent performance, helping his team) and building his brand/seeking endorsements off-court, as he considers life after basketball. | Involving: John (user)",
+        "John's goal is to improve his shooting percentage and he is practicing hard to achieve it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 1,
+      "question": "What are John's goals for his career that are not related to his basketball skills?",
+      "expected_answer": "get endorsements, build his brand, do charity work",
+      "relevant_facts": [
+        "John also wants to make a difference away from the basketball court through charity work or inspiring people. | Involving: John | Basketball has been great to him, so he wants to give something back.",
+        "John's current goals include improving his basketball performance (better shooting, more court impact, consistent performance, helping his team) and building his brand/seeking endorsements off-court, as he considers life after basketball. | Involving: John (user)",
+        "John is improving his overall basketball game, has secured endorsement deals, and is learning to market himself and boost his brand. | Involving: John | These are aspects of his growth as a professional basketball player.",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John uses his contacts in the basketball industry and his marketing skills for networking to secure endorsements. | Involving: John",
+        "John plans to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and engage in charity work to leave a meaningful legacy. | Involving: John (user)",
+        "John is making progress with exploring endorsements and has talked to some big names, which looks promising. | Involving: John",
+        "John plans to keep Tim updated on which brands he chooses for endorsement. | Involving: John, Tim",
+        "John is considering sports brands like Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John is exploring endorsement opportunities and is excited about the possibilities of working with brands, feeling rewarded by his hard work paying off. | Involving: John",
+        "John received top-notch hiking and outdoor gear as part of his deal. | Involving: John",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John secured an endorsement with a popular beverage company, which felt like a dream come true and a payoff for his hard work and training. | When: Last week | Involving: John | It was a significant achievement that validated his efforts.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. | Involving: John",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform to have a positive impact on the community and inspire others.",
+        "John started doing seminars this week to help people with their sports and marketing. The seminars went really well, and the aspiring professionals were eager and motivated, making John happy to share his knowledge. | When: This week | Involving: John, aspiring professionals",
+        "Tim advised John to choose endorsements that align with his values and brand, specifically looking for companies that share his desire to make a positive change and ensuring authenticity for his followers. | Involving: Tim, John (user)",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He is very excited about it.",
+        "John asked Tim for advice on how to pick the right endorsements. | Involving: John (user), Tim"
+      ]
+    },
+    {
+      "q_idx": 2,
+      "question": "What items does John collect?",
+      "expected_answer": "sneakers, fantasy movie DVDs, jerseys",
+      "relevant_facts": [
+        "John loves the movie \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter collection. | Involving: John",
+        "John loves talking to people about his sneaker collection. | Involving: John",
+        "John likes to collect basketball jerseys. His favorite team is The Wolves, and his favorite player is LeBron, whom he admires for his skills, leadership, work ethic, and dedication. | Involving: John, LeBron, The Wolves"
+      ]
+    },
+    {
+      "q_idx": 3,
+      "question": "Would Tim enjoy reading books by C. S. Lewis or John Greene?",
+      "expected_answer": "C. S.Lewis",
+      "relevant_facts": [
+        "John knows that Tim finds peace in reading fantasy books. | Involving: John, Tim",
+        "Tim and John share a common interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim loves reading because it allows him to escape to other worlds, and he has a collection of books for this purpose. | When: Always | Involving: Tim | To escape to other worlds.",
+        "J.K. Rowling is an inspiring writer for Tim, who finds her books captivating due to their detail and creative storytelling. Tim has been reading her works for a long time, is still inspired by her stories, and takes notes on her style for his own writing. | When: For a long time (ongoing) | Involving: Tim, J.K. Rowling",
+        "Tim's favorite fantasy novels are Harry Potter and Game of Thrones, which he loves for their ability to transport him. He also enjoys books on growth, psychology, and self-improvement, viewing books as companions on his growth journey. | Involving: Tim",
+        "Tim is more into reading and fantasy novels, loves sinking into different magical worlds, and enjoys traveling to new places to experience a different kind of magic. He has never been part of a sports team. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and making his imagination soar. | When: Currently | Involving: Tim",
+        "Tim reads fantasy books as a way to relieve stress. | Involving: Tim | To take a break from stress",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John to read while traveling. | Involving: Tim, John (user)",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim loves to read books in his downtime, with the Harry Potter series being one of his favorites. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, and his favorite movie is \"Lord of the Rings\". | Involving: Tim",
+        "Tim finds bliss and a feeling of being in another world when reading in a comfy spot. | Involving: Tim",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings (LOTR) because they allow him to get lost in another world and appreciate intricate details. | Involving: Tim",
+        "Tim is currently reading an inspiring fantasy novel series that explores the themes of friendship and loyalty. | When: Currently | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum, shared his ideas, and they were accepted. He loves fantasy and enjoys spreading his passion. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting and joyful, and his hard work is paying off. | When: Currently | Involving: Tim",
+        "Tim loves fantasy books because they transport readers to different worlds, offering a break from reality and an awesome adventure. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes of various fantasy novels and making book recommendations. | Involving: Tim",
+        "Tim does not surf, but finds escape and freedom in reading great fantasy books. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because it is immersive. | Involving: Tim | Because it's immersive.",
+        "Tim is also a huge fan of Lord of the Rings. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, which he found enriching. | When: Last night (Wednesday, June 14, 2023) | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim is overwhelmed with assignments and exams and is trying to find a way to juggle studying with his fantasy reading hobby. | When: This week (relative to August 26, 2023) | Involving: Tim",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys discussing them. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim",
+        "Tim appreciates that fantasy stories allow him to explore other cultures and landscapes from the comfort of his home. | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to come out next month. | When: Next month (January 2024) | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds the experience rewarding. | Involving: Tim",
+        "Tim loves being lost in fantasy realms and considers \"That\" one of his favorite fantasy shows. | Involving: Tim",
+        "Tim finds Aragorn's story inspiring, noting his growth from a ranger to the king of Gondor and his journey of redemption. | Involving: Tim, Aragorn",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 4,
+      "question": "What books has Tim read?",
+      "expected_answer": "Harry Potter, Game of Thrones, the Name of the Wind, The Alchemist, The Hobbit, A Dance with Dragons, and the Wheel of Time.",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, who finds her books captivating due to their detail and creative storytelling. Tim has been reading her works for a long time, is still inspired by her stories, and takes notes on her style for his own writing. | When: For a long time (ongoing) | Involving: Tim, J.K. Rowling",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys discussing them. | Involving: Tim",
+        "Tim's favorite fantasy novels are Harry Potter and Game of Thrones, which he loves for their ability to transport him. He also enjoys books on growth, psychology, and self-improvement, viewing books as companions on his growth journey. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings (LOTR) because they allow him to get lost in another world and appreciate intricate details. | Involving: Tim",
+        "Tim loves to read books in his downtime, with the Harry Potter series being one of his favorites. | Involving: Tim",
+        "Tim recommended an \"awesome\" book by Patrick Rothfuss, praising its world-building and characters. | Involving: Tim, John | Tim shared his positive opinion and suggested John read it.",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because it is immersive. | Involving: Tim | Because it's immersive.",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to come out next month. | When: Next month (January 2024) | Involving: Tim",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John to read while traveling. | Involving: Tim, John (user)",
+        "Tim is also a huge fan of Lord of the Rings. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim",
+        "Tim finds Aragorn's story inspiring, noting his growth from a ranger to the king of Gondor and his journey of redemption. | Involving: Tim, Aragorn"
+      ]
+    },
+    {
+      "q_idx": 5,
+      "question": "Based on Tim's collections, what is a shop that he would enjoy visiting in New York city?",
+      "expected_answer": "House of MinaLima",
+      "relevant_facts": [
+        "Tim wants to visit New York City and has added it to his travel list, anticipating a great adventure with much to explore and try. | Involving: Tim",
+        "The picture on Tim's bookshelf is from MinaLima, who created all the props for the Harry Potter films. Tim loves their work and feels it's like having a piece of the wizarding world at home. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 6,
+      "question": "In which month's game did John achieve a career-high score in points?",
+      "expected_answer": "June 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 7,
+      "question": "Which geographical locations has Tim been to?",
+      "expected_answer": "California, London, the Smoky Mountains",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-themed place in London a few years ago, describing the tour as amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling a new lease of life and appreciating how his passion for fantasy connects him with people. | When: Last week | Involving: Tim",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last year | Involving: Tim",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 09, 2023 | Involving: Tim, Harry Potter fan | Tim enjoyed talking to someone who understands his interest.",
+        "Tim had a setback last week trying to write a story based on his experiences in the UK, which did not go as he wanted, and he finds it tough. | When: Last week (approx. November 12-18, 2023) | Involving: Tim",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 8,
+      "question": "Which outdoor gear company likely signed up John for an endorsement deal?",
+      "expected_answer": "Under Armour",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his deal. | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He is very excited about it.",
+        "John likes Under Armour and dreams of working with them. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 9,
+      "question": "Which endorsement deals has John been offered?",
+      "expected_answer": "basketball shoes and gear deal with Nike, potential sponsorship with Gatorade, Moxie a popular beverage company, outdoor gear company",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his deal. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He is very excited about it.",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John secured an endorsement with a popular beverage company, which felt like a dream come true and a payoff for his hard work and training. | When: Last week | Involving: John | It was a significant achievement that validated his efforts.",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 10,
+      "question": "When was John in Seattle for a game?",
+      "expected_answer": "early August, 2023",
+      "relevant_facts": [
+        "John's team won an intense basketball game last week by a tight score, with John scoring the last basket and hearing the crowd cheer. | When: Last week (approx. August 02, 2023) | Involving: John, John's team, crowd",
+        "John loves Seattle for its energy, diversity, awesome food (recommending local seafood), and the incredible support from fans at games. | Involving: John",
+        "John felt an amazing rush and was hyped after scoring the winning basket in the intense game. He only has one photo from the game. | When: Last week (approx. August 02, 2023) | Involving: John, John's team"
+      ]
+    },
+    {
+      "q_idx": 11,
+      "question": "What sports does John like besides basketball?",
+      "expected_answer": "surfing",
+      "relevant_facts": [
+        "John had an awesome summer surfing and riding waves with his friends, describing the feeling as unreal. | Involving: John, John's friends",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "John finds being in the water, experiencing waves and wind, super exciting and free-feeling, emphasizing nature's special quality. | Involving: John",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to practicing yoga. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John",
+        "Some of John's hiking club friends attended his wedding, even though he had just joined the club. | When: Last week | Involving: John, John's hiking club friends",
+        "John stumbled upon a peaceful spot while hiking, where the sound of the river was soothing and he felt at peace surrounded by rocks. | Involving: John",
+        "John started surfing five years ago and loves the connection to nature it provides. | When: Five years ago (around July 16, 2018) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 12,
+      "question": "What year did John start surfing?",
+      "expected_answer": "2018",
+      "relevant_facts": [
+        "John started surfing five years ago and loves the connection to nature it provides. | When: Five years ago (around July 16, 2018) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 13,
+      "question": "What does Tim do to escape reality?",
+      "expected_answer": "Read fantasy books.",
+      "relevant_facts": [
+        "Tim plans to visit more Harry Potter-related spots in the future, as it makes him feel like he's stepping into the books. | When: In the future | Involving: Tim | To feel like stepping into the books and escape reality.",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "John knows that Tim finds peace in reading fantasy books. | Involving: John, Tim",
+        "Tim reads fantasy books as a way to relieve stress. | Involving: Tim | To take a break from stress",
+        "Tim loves going on road trips with friends and family, exploring, hiking, and playing board games. In his free time, he enjoys curling up with a good book to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim loves reading because it allows him to escape to other worlds, and he has a collection of books for this purpose. | When: Always | Involving: Tim | To escape to other worlds.",
+        "Tim does not surf, but finds escape and freedom in reading great fantasy books. | Involving: Tim",
+        "Tim loves fantasy books because they transport readers to different worlds, offering a break from reality and an awesome adventure. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings (LOTR) because they allow him to get lost in another world and appreciate intricate details. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and making his imagination soar. | When: Currently | Involving: Tim",
+        "Tim finds bliss and a feeling of being in another world when reading in a comfy spot. | Involving: Tim",
+        "Tim is more into reading and fantasy novels, loves sinking into different magical worlds, and enjoys traveling to new places to experience a different kind of magic. He has never been part of a sports team. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 14,
+      "question": "What kind of writing does Tim do?",
+      "expected_answer": "comments on favorite books in a fantasy literature forum, articles on fantasy novels, studying characters, themes, and making book recommendations, writing a fantasy novel",
+      "relevant_facts": [
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing great stories. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds the experience rewarding. | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum, shared his ideas, and they were accepted. He loves fantasy and enjoys spreading his passion. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting and joyful, and his hard work is paying off. | When: Currently | Involving: Tim",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week (October 30 - November 5, 2023) | Involving: Tim",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, which he found enriching. | When: Last night (Wednesday, June 14, 2023) | Involving: Tim",
+        "Tim had a setback last week trying to write a story based on his experiences in the UK, which did not go as he wanted, and he finds it tough. | When: Last week (approx. November 12-18, 2023) | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes of various fantasy novels and making book recommendations. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 15,
+      "question": "Who is Anthony?",
+      "expected_answer": "likely John's friend, colleague or family",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 16,
+      "question": "After how many weeks did Tim reconnect with the fellow Harry Potter fan from California?",
+      "expected_answer": "three weeks",
+      "relevant_facts": [
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 09, 2023 | Involving: Tim, Harry Potter fan | Tim enjoyed talking to someone who understands his interest."
+      ]
+    },
+    {
+      "q_idx": 17,
+      "question": "How many games has John mentioned winning?",
+      "expected_answer": "6",
+      "relevant_facts": [
+        "For John, the best part of the recent basketball win was the camaraderie built with his team both on and off the court, and the win felt amazing, making the hard work worthwhile. | When: Recently | Involving: John, John's basketball team",
+        "John's favorite game was when he hit a buzzer-beater shot to win after his team was down 10 points in the 4th quarter. | Involving: John, John's team",
+        "John's basketball team was trailing significantly in the 4th quarter of a game last year, but they managed to overturn the deficit and win, which was an amazing and unforgettable feeling for John. | When: Last year (2022) | Involving: John, John's team",
+        "Tim congratulated John on winning a trophy and asked for tips on motivating others on his team. | Involving: Tim (user), John",
+        "John and his teammates celebrated their tough win at a restaurant, laughing and reliving the intense moments. | When: Last week | Involving: John, John's teammates | To celebrate their tough win.",
+        "John was elated about winning the trophy and expressed appreciation for Tim's support, stating he will continue to work hard. | Involving: John, Tim",
+        "John's basketball team recently played a tough game against a top team and secured a win. | When: Recently | Involving: John, John's basketball team",
+        "John felt an amazing rush and was hyped after scoring the winning basket in the intense game. He only has one photo from the game. | When: Last week (approx. August 02, 2023) | Involving: John, John's team",
+        "John's team won an intense basketball game last week by a tight score, with John scoring the last basket and hearing the crowd cheer. | When: Last week (approx. August 02, 2023) | Involving: John, John's team, crowd",
+        "John's basketball team won a close game against another team last week, with the win secured at the final buzzer. | When: Last week | Involving: John (and his team)",
+        "John and his teammates pulled off a tough win in a basketball game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates",
+        "John won a trophy and found the experience awesome. | Involving: John",
+        "John's team won a trophy, which made all their hard work and effort feel worthwhile. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 18,
+      "question": "What authors has Tim read books from?",
+      "expected_answer": "J.K. Rowling, R.R. Martin, Patrick Rothfuss, Paulo Coelho, and J. R. R. Tolkien.",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, who finds her books captivating due to their detail and creative storytelling. Tim has been reading her works for a long time, is still inspired by her stories, and takes notes on her style for his own writing. | When: For a long time (ongoing) | Involving: Tim, J.K. Rowling",
+        "Tim's favorite fantasy novels are Harry Potter and Game of Thrones, which he loves for their ability to transport him. He also enjoys books on growth, psychology, and self-improvement, viewing books as companions on his growth journey. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings (LOTR) because they allow him to get lost in another world and appreciate intricate details. | Involving: Tim",
+        "Tim recommended an \"awesome\" book by Patrick Rothfuss, praising its world-building and characters. | Involving: Tim, John | Tim shared his positive opinion and suggested John read it.",
+        "Tim loves to read books in his downtime, with the Harry Potter series being one of his favorites. | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John to read while traveling. | Involving: Tim, John (user)",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because it is immersive. | Involving: Tim | Because it's immersive.",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim",
+        "Tim is also a huge fan of Lord of the Rings. | Involving: Tim",
+        "Tim finds Aragorn's story inspiring, noting his growth from a ranger to the king of Gondor and his journey of redemption. | Involving: Tim, Aragorn"
+      ]
+    },
+    {
+      "q_idx": 19,
+      "question": "What is a prominent charity organization that John might want to work with and why?",
+      "expected_answer": "Good Sports, because they work with Nike, Gatorade, and Under Armour and they aim toprovide youth sports opportunities for kids ages 3-18 in high-need communities.",
+      "relevant_facts": [
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform to have a positive impact on the community and inspire others.",
+        "John also wants to make a difference away from the basketball court through charity work or inspiring people. | Involving: John | Basketball has been great to him, so he wants to give something back.",
+        "John plans to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and engage in charity work to leave a meaningful legacy. | Involving: John (user)",
+        "John believes basketball brings people together and creates a positive impact. | Involving: John",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and it helps him stay involved in the game during the off-season. | Involving: John, younger players",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John started doing seminars this week to help people with their sports and marketing. The seminars went really well, and the aspiring professionals were eager and motivated, making John happy to share his knowledge. | When: This week | Involving: John, aspiring professionals",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and hoping his experiences can help shape their future and inspire them to pursue their dreams. | Involving: John, young athletes",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is pleased to have a positive impact on their lives. | Involving: John, younger players",
+        "Some younger players view John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model for them. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 20,
+      "question": "Which city was John in before traveling to Chicago?",
+      "expected_answer": "Seattle",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 21,
+      "question": "Which US cities does John mention visiting to Tim?",
+      "expected_answer": "Seattle, Chicago, New York",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing with new and exciting things to explore and restaurants to try. He recommends it as a must-visit and an unforgettable adventure. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore due to its vibrancy. | Involving: John",
+        "John recently took a trip to Chicago, finding it awesome due to its energy and friendly locals, and values experiencing other cultures. | When: Recently | Involving: John",
+        "John initially had trouble figuring out the subway during his trip to NYC. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (recommending local seafood), and the incredible support from fans at games. | Involving: John",
+        "John found the subway easy to use after someone helped explain it to him. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 22,
+      "question": "When did John meet with his teammates after returning from Chicago?",
+      "expected_answer": "August 15, 2023",
+      "relevant_facts": [
+        "John recently took a trip to Chicago, finding it awesome due to its energy and friendly locals, and values experiencing other cultures. | When: Recently | Involving: John",
+        "John reunited with his teammates on the 15th after his trip, feeling very welcome and lucky to be part of the team, experiencing an electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball when they reunited, symbolizing their friendship and love for each other. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 23,
+      "question": "When is Tim attending a book conference?",
+      "expected_answer": "September 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 24,
+      "question": "Where was John between August 11 and August 15 2023?",
+      "expected_answer": "Chicago",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball when they reunited, symbolizing their friendship and love for each other. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love.",
+        "John reunited with his teammates on the 15th after his trip, feeling very welcome and lucky to be part of the team, experiencing an electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John recently took a trip to Chicago, finding it awesome due to its energy and friendly locals, and values experiencing other cultures. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 25,
+      "question": "What similar sports collectible do Tim and John own?",
+      "expected_answer": "signed basketball",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball when they reunited, symbolizing their friendship and love for each other. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love.",
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It serves as a reminder of hard work."
+      ]
+    },
+    {
+      "q_idx": 26,
+      "question": "Which TV series does Tim mention watching?",
+      "expected_answer": "That, Wheel of Time",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to come out next month. | When: Next month (January 2024) | Involving: Tim",
+        "Tim loves being lost in fantasy realms and considers \"That\" one of his favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 27,
+      "question": "Which popular time management technique does Tim use to prepare for exams?",
+      "expected_answer": "Pomodoro technique",
+      "relevant_facts": [
+        "Tim breaks up his studying into smaller parts, specifically 25 minutes on and 5 minutes off for something fun, to make it less overwhelming and stay on track. | Involving: Tim | To make studying less overwhelming and stay on track."
+      ]
+    },
+    {
+      "q_idx": 28,
+      "question": "Which popular music composer's tunes does Tim enjoy playing on the piano?",
+      "expected_answer": "John Williams",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is a movie theme that evokes great memories. | Involving: Tim | It brings back great memories",
+        "Tim is learning to play the violin and is mostly interested in classical music, but also keen to try jazz and film scores. He views it as a great way to chill and get creative. | Involving: Tim | To chill and get creative.",
+        "Tim has started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim, bringing back great memories of watching it with his family, getting comfy with snacks and a blanket, and being totally absorbed. | Involving: Tim, Tim's family | It was the first movie in the series and watching it with family was a magical and special experience.",
+        "Tim's favorite fantasy movie is Star Wars, which he finds never gets old. | Involving: Tim | He finds it never gets old."
+      ]
+    },
+    {
+      "q_idx": 29,
+      "question": "What schools did John play basketball in and how many years was he with his team during high school?",
+      "expected_answer": "Middle school, high school, and college and he was with his high school team for 4 years.",
+      "relevant_facts": [
+        "John continued playing basketball through middle and high school, which led to him earning a college scholarship. | When: During middle and high school | Involving: John | His dedication to playing basketball.",
+        "John was teammates with a group of friends for four years in high school. | Involving: John, John's friends",
+        "After college, John was drafted by a team, which he considers his childhood dream come true. | When: After college | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 30,
+      "question": "Which cities has John been to?",
+      "expected_answer": "Seattle, Chicago, New York, and Paris.",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing with new and exciting things to explore and restaurants to try. He recommends it as a must-visit and an unforgettable adventure. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore due to its vibrancy. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (recommending local seafood), and the incredible support from fans at games. | Involving: John",
+        "John has been to Paris, loved it, and found the view from the Eiffel Tower incredible. He also believes traveling helps you see new things and is cool and educational. | Involving: John",
+        "John initially had trouble figuring out the subway during his trip to NYC. | Involving: John",
+        "John recently took a trip to Chicago, finding it awesome due to its energy and friendly locals, and values experiencing other cultures. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 31,
+      "question": "What month did Tim plan on going to Universal Studios?",
+      "expected_answer": "September, 2023",
+      "relevant_facts": [
+        "Tim is planning a trip to Universal Studios. | When: Next month | Involving: Tim",
+        "This upcoming trip will be Tim's first time visiting Universal Studios. | When: Next month | Involving: Tim",
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 32,
+      "question": "Which US states might Tim be in during September 2023 based on his plans of visiting Universal Studios?",
+      "expected_answer": "California or Florida",
+      "relevant_facts": [
+        "Tim is planning a trip to Universal Studios. | When: Next month | Involving: Tim",
+        "Tim is overwhelmed with assignments and exams and is trying to find a way to juggle studying with his fantasy reading hobby. | When: This week (relative to August 26, 2023) | Involving: Tim",
+        "This upcoming trip will be Tim's first time visiting Universal Studios. | When: Next month | Involving: Tim",
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 33,
+      "question": "When does John plan on traveling with his team on a team trip?",
+      "expected_answer": "October, 2023",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip next month to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To explore a new city and have fun."
+      ]
+    },
+    {
+      "q_idx": 34,
+      "question": "What could John do after his basketball career?",
+      "expected_answer": "become a basketball coach since he likes giving back and leadership",
+      "relevant_facts": [
+        "John advises Tim to reflect on what went wrong and find ways to improve when facing challenges, similar to how he handles challenges on the basketball court. | Involving: John (advising Tim) | To help Tim overcome his storytelling setback.",
+        "John also wants to make a difference away from the basketball court through charity work or inspiring people. | Involving: John | Basketball has been great to him, so he wants to give something back.",
+        "John's benefit basketball game was a total success, attracting many people and raising money for charity. | When: Last week (around January 3, 2024) | Involving: John",
+        "John held a benefit basketball game. | When: Last week (around January 3, 2024) | Involving: John",
+        "John plans to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and engage in charity work to leave a meaningful legacy. | Involving: John (user)",
+        "John's tips for motivating teammates include showing care, celebrating achievements, providing constructive feedback, reminding them of the bigger goal, creating a positive environment, and giving pep talks before games. | Involving: John (giver of advice), teammates (recipients of advice)",
+        "John admires Aragorn for being a great leader who prioritizes others, which ultimately leads to him becoming king. | Involving: John, Aragorn | This is why Aragorn is John's favorite character.",
+        "Tim congratulated John on winning a trophy and asked for tips on motivating others on his team. | Involving: Tim (user), John",
+        "John is inspired by Aragorn's brave, selfless, and down-to-earth attitude, as well as his perseverance and commitment to justice. | Involving: John, Aragorn | These qualities make Aragorn inspiring to John.",
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and it helps him stay involved in the game during the off-season. | Involving: John, younger players",
+        "Some younger players view John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model for them. | Involving: John, younger players",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is pleased to have a positive impact on their lives. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential.",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and hoping his experiences can help shape their future and inspire them to pursue their dreams. | Involving: John, young athletes",
+        "John experiences challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them, finding it rewarding to see their development and goal achievement. | Involving: John, younger players",
+        "John started doing seminars this week to help people with their sports and marketing. The seminars went really well, and the aspiring professionals were eager and motivated, making John happy to share his knowledge. | When: This week | Involving: John, aspiring professionals",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform to have a positive impact on the community and inspire others.",
+        "John spoke at a charity event. | Involving: John",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. | Involving: John",
+        "John has a painting of Aragorn in his room that serves as a reminder for him to stay true and be a leader. | Involving: John, Aragorn | It reminds him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 35,
+      "question": "What outdoor activities does John enjoy?",
+      "expected_answer": "Hiking, surfing",
+      "relevant_facts": [
+        "John took a stunning trip to the Rocky Mountains last year, appreciating the fresh air and majestic peaks, which made him realize how incredible the world is. | When: Last year (2022) | Involving: John",
+        "John had an awesome summer surfing and riding waves with his friends, describing the feeling as unreal. | Involving: John, John's friends",
+        "John received top-notch hiking and outdoor gear as part of his deal. | Involving: John",
+        "John started surfing five years ago and loves the connection to nature it provides. | When: Five years ago (around July 16, 2018) | Involving: John",
+        "John went camping in the mountains, found it stunning, peaceful, and refreshing, and enjoyed disconnecting and chilling in nature. | Involving: John",
+        "John finds nature's beauty and grandeur amazing and enjoys escaping the city noise to relax in nature. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He is very excited about it.",
+        "John finds being in the water, experiencing waves and wind, super exciting and free-feeling, emphasizing nature's special quality. | Involving: John",
+        "John might visit The Cliffs of Moher after his season. | When: After his season | Involving: John",
+        "John finds that nature puts him in a great mood and energizes him. | Involving: John",
+        "John finds nature great for clearing the mind, calming the soul, humbling, amazing, and comforting. | Involving: John",
+        "John stumbled upon a peaceful spot while hiking, where the sound of the river was soothing and he felt at peace surrounded by rocks. | Involving: John",
+        "John loves the ocean and is looking forward to eating seafood. | Involving: John",
+        "Some of John's hiking club friends attended his wedding, even though he had just joined the club. | When: Last week | Involving: John, John's hiking club friends",
+        "John participated in a photoshoot in a gorgeous forest, where the photographer took epic shots of him. | When: Last week | Involving: John, photographer",
+        "John recommends Barcelona as a must-visit city, highlighting its culture, architecture, food, and nearby beaches. | Involving: John (recommender), Tim (recipient)"
+      ]
+    },
+    {
+      "q_idx": 36,
+      "question": "Who is Tim and John's favorite basketball player?",
+      "expected_answer": "LeBron James",
+      "relevant_facts": [
+        "Tim's favorite player is LeBron James, who inspires him, especially due to an epic block in a Finals game a few years ago that changed the game and led to a win. | Involving: Tim, LeBron James | LeBron James's actions inspire Tim.",
+        "John likes to collect basketball jerseys. His favorite team is The Wolves, and his favorite player is LeBron, whom he admires for his skills, leadership, work ethic, and dedication. | Involving: John, LeBron, The Wolves"
+      ]
+    },
+    {
+      "q_idx": 37,
+      "question": "Which week did Tim visit the UK for the Harry Potter Conference?",
+      "expected_answer": "The week before October 13th, 2023.",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling a new lease of life and appreciating how his passion for fantasy connects him with people. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 38,
+      "question": "which country has Tim visited most frequently in his travels?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-themed place in London a few years ago, describing the tour as amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling a new lease of life and appreciating how his passion for fantasy connects him with people. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 39,
+      "question": "What year did Tim go to the Smoky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last year | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 40,
+      "question": "Has Tim been to North Carolina and/or Tennesee states in the US?",
+      "expected_answer": "Yes",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last year | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 41,
+      "question": "What kind of fiction stories does Tim write?",
+      "expected_answer": "Fantasy stories with plot twists",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting and joyful, and his hard work is paying off. | When: Currently | Involving: Tim",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week (October 30 - November 5, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 42,
+      "question": "What has John cooked?",
+      "expected_answer": "Soup, a slow cooker meal, and honey garlic chicken with roasted veg.",
+      "relevant_facts": [
+        "John will write down and mail the honey garlic chicken with roasted vegetables recipe to Tim. | Involving: John, Tim",
+        "John recently made a tasty soup. | Involving: John",
+        "John improvised the soup he made and does not have a specific recipe for it. | Involving: John",
+        "John used sage as a spice in the soup he made. | Involving: John",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes. | Involving: John",
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables. | When: Saturday, October 21, 2023 | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 43,
+      "question": "What does John like about Lebron James?",
+      "expected_answer": "His heart, determination, skills, and leadership.",
+      "relevant_facts": [
+        "John likes to collect basketball jerseys. His favorite team is The Wolves, and his favorite player is LeBron, whom he admires for his skills, leadership, work ethic, and dedication. | Involving: John, LeBron, The Wolves",
+        "John remembers LeBron James's epic block in Game 7 of the 2016 Finals, where he chased down Iguodala and pinned the ball against the backboard, and this display of determination and heart is why John loves basketball. | When: 2016 Finals, Game 7 (June 19, 2016) | Involving: John, LeBron James, Iguodala | This moment exemplifies the determination and heart that makes John love basketball.",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 44,
+      "question": "When did John and his wife go on a European vacation?",
+      "expected_answer": "November, 2023.",
+      "relevant_facts": [
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 45,
+      "question": "Which country was Tim visiting in the second week of November?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling a new lease of life and appreciating how his passion for fantasy connects him with people. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 46,
+      "question": "Where was Tim in the week before 16 November 2023?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling a new lease of life and appreciating how his passion for fantasy connects him with people. | When: Last week | Involving: Tim",
+        "Tim had a setback last week trying to write a story based on his experiences in the UK, which did not go as he wanted, and he finds it tough. | When: Last week (approx. November 12-18, 2023) | Involving: Tim",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 47,
+      "question": "When did John get married at a greenhouse?",
+      "expected_answer": "last week of September 2023",
+      "relevant_facts": [
+        "John's wedding ceremony was held at a lovely greenhouse venue, which was a smaller, more intimate gathering, and necessary safety protocols were followed. | When: Last week | Involving: John, John's wife, their loved ones | To ensure everyone felt safe and to allow loved ones to celebrate during current times."
+      ]
+    },
+    {
+      "q_idx": 48,
+      "question": "When did John get an ankle injury in 2023?",
+      "expected_answer": "around November 16, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 49,
+      "question": "How many times has John injured his ankle?",
+      "expected_answer": "two times",
+      "relevant_facts": [
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy, preventing him from playing or helping his team. | When: Last season | Involving: John",
+        "John injured himself not too long ago, which caused him to miss some basketball games and be unable to help his team. | When: Not too long ago | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 50,
+      "question": "Which book was John reading during his recovery from an ankle injury?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently reread \"The Alchemist,\" finding it inspiring and motivating him to think about following dreams and personal legends, leaving him feeling hopeful. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 51,
+      "question": "What kind of yoga for building core strength might John benefit from?",
+      "expected_answer": "Hatha Yoga",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 52,
+      "question": "What does John do to supplement his basketball training?",
+      "expected_answer": "Yoga, strength training",
+      "relevant_facts": [
+        "John believes strength training is crucial for basketball because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism. | Involving: John | These benefits are essential for games and overall performance.",
+        "John developed a workout schedule that balances basketball and strength training, emphasizing listening to his body and ensuring enough rest. | Involving: John | To stay on track, push himself during practice, and look after himself.",
+        "Incorporating strength training significantly improved John's shooting accuracy, agility, and speed, which gave him an advantage over opponents and boosted his confidence on the court. | Involving: John | It changed the game for him and helped him up his game.",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to practicing yoga. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 53,
+      "question": "What other exercises can help John with his basketball performance?",
+      "expected_answer": "Sprinting, long-distance running, and boxing.",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 54,
+      "question": "When did John take a trip to the Rocky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "John took a stunning trip to the Rocky Mountains last year, appreciating the fresh air and majestic peaks, which made him realize how incredible the world is. | When: Last year (2022) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 55,
+      "question": "When did John start playing professionally?",
+      "expected_answer": "May, 2023",
+      "relevant_facts": [
+        "John has been playing professional basketball for just under a year. | When: Just under a year (as of December 6, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 56,
+      "question": "When did Tim start playing the violin?",
+      "expected_answer": "August 2023",
+      "relevant_facts": [
+        "Tim is learning to play the violin and is mostly interested in classical music, but also keen to try jazz and film scores. He views it as a great way to chill and get creative. | Involving: Tim | To chill and get creative.",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | Involving: Tim (user)",
+        "Tim recently started learning an instrument, which he finds challenging but fun, as he has always admired musicians. | When: Recently | Involving: Tim | Admiration for musicians and a desire for a challenging and fun activity."
+      ]
+    },
+    {
+      "q_idx": 57,
+      "question": "What instruments does Tim play?",
+      "expected_answer": "piano, violin",
+      "relevant_facts": [
+        "Tim has started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "Tim's favorite song to play on the piano is a movie theme that evokes great memories. | Involving: Tim | It brings back great memories",
+        "Tim is learning to play the violin and is mostly interested in classical music, but also keen to try jazz and film scores. He views it as a great way to chill and get creative. | Involving: Tim | To chill and get creative."
+      ]
+    },
+    {
+      "q_idx": 58,
+      "question": "When did John attend the Harry Potter trivia?",
+      "expected_answer": "August 2023.",
+      "relevant_facts": [
+        "John had a fun time at a charity event that featured Harry Potter trivia. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 59,
+      "question": "Which career-high performances did John achieve in 2023?",
+      "expected_answer": "highest point score, highest assist",
+      "relevant_facts": [
+        "John achieved a career-high in assists in a basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John",
+        "John scored 40 points in a basketball game, which is his highest score ever, indicating his hard work is paying off. | When: Last week | Involving: John | It was his personal best and felt like his hard work was paying off."
+      ]
+    },
+    {
+      "q_idx": 60,
+      "question": "When did John achieve a career-high assist performance?",
+      "expected_answer": "December 11, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 61,
+      "question": "What books has John read?",
+      "expected_answer": "inpsiring book on dreaming big, The Alchemist, fantasy series, non-fiction books on personal development, Dune",
+      "relevant_facts": [
+        "John is currently reading an inspiring book that reminds him to keep dreaming. | Involving: John",
+        "John likes fantasy books because they fuel his creativity, and non-fiction books about personal development and mindset because they help him know himself better. | Involving: John",
+        "John has read another popular fantasy series, which is also one of his favorites. | Involving: John",
+        "John read and loved \"The Alchemist\", which made him think about life and the importance of following one's dreams. He highly recommends it. | Involving: John",
+        "John recently finished an amazing fantasy series with many twists. | Involving: John",
+        "John is currently reading \"Dune\" by Frank Herbert, which he enjoys and highly recommends. The story is about religion and human control over ecology. | Involving: John",
+        "John is a huge fan of Lord of the Rings, appreciating its adventure, world, and characters. | Involving: John | He finds the adventure, world, and characters awesome.",
+        "John recently reread \"The Alchemist,\" finding it inspiring and motivating him to think about following dreams and personal legends, leaving him feeling hopeful. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 62,
+      "question": "What does John do to share his knowledge?",
+      "expected_answer": "gives seminars, mentors younger players.",
+      "relevant_facts": [
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and it helps him stay involved in the game during the off-season. | Involving: John, younger players",
+        "John started doing seminars this week to help people with their sports and marketing. The seminars went really well, and the aspiring professionals were eager and motivated, making John happy to share his knowledge. | When: This week | Involving: John, aspiring professionals",
+        "John experiences challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them, finding it rewarding to see their development and goal achievement. | Involving: John, younger players",
+        "Some younger players view John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model for them. | Involving: John, younger players",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is pleased to have a positive impact on their lives. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 63,
+      "question": "When did John organize a basketball camp for kids?",
+      "expected_answer": "summer 2023",
+      "relevant_facts": [
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 64,
+      "question": "Which month was John in Italy?",
+      "expected_answer": "December, 2023",
+      "relevant_facts": [
+        "John visited Italy last month and had a blast. | When: Last month (December 2023) | Involving: John",
+        "John found the food, history, and architecture in Italy amazing, and he bought a book there that inspires his cooking. | When: Last month (December 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 65,
+      "question": "What fantasy movies does Tim like?",
+      "expected_answer": "Lord of the Rings, Harry Potter, and Star Wars.",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-themed place in London a few years ago, describing the tour as amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, and his favorite movie is \"Lord of the Rings\". | Involving: Tim",
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim, bringing back great memories of watching it with his family, getting comfy with snacks and a blanket, and being totally absorbed. | Involving: Tim, Tim's family | It was the first movie in the series and watching it with family was a magical and special experience.",
+        "Tim has seen all the Harry Potter movies, enjoys comparing movies to their book counterparts, finds watching movies a fun way to relax, and loves having movie marathons with his friends. | Involving: Tim, Tim's friends",
+        "The picture on Tim's bookshelf is from MinaLima, who created all the props for the Harry Potter films. Tim loves their work and feels it's like having a piece of the wizarding world at home. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he finds never gets old. | Involving: Tim | He finds it never gets old.",
+        "Tim is showing a map of Middle-earth from Lord of the Rings, which he finds cool for its depiction of different realms and regions. | Involving: Tim",
+        "Tim finds Aragorn's story inspiring, noting his growth from a ranger to the king of Gondor and his journey of redemption. | Involving: Tim, Aragorn",
+        "Tim is also a huge fan of Lord of the Rings. | Involving: Tim",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys discussing them. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 66,
+      "question": "What is a Star Wars book that Tim might enjoy?",
+      "expected_answer": "Star Wars: Jedi Apprentice by Judy Blundell and David Farland. It is a highly rated and immersive series about his favorite movies.",
+      "relevant_facts": [
+        "Tim loves reading because it allows him to escape to other worlds, and he has a collection of books for this purpose. | When: Always | Involving: Tim | To escape to other worlds.",
+        "Tim and John share a common interest in fantasy books and movies. | Involving: Tim, John",
+        "John knows that Tim finds peace in reading fantasy books. | Involving: John, Tim",
+        "Tim plans to visit more Harry Potter-related spots in the future, as it makes him feel like he's stepping into the books. | When: In the future | Involving: Tim | To feel like stepping into the books and escape reality.",
+        "Tim is more into reading and fantasy novels, loves sinking into different magical worlds, and enjoys traveling to new places to experience a different kind of magic. He has never been part of a sports team. | Involving: Tim",
+        "Tim's favorite fantasy novels are Harry Potter and Game of Thrones, which he loves for their ability to transport him. He also enjoys books on growth, psychology, and self-improvement, viewing books as companions on his growth journey. | Involving: Tim",
+        "Tim loves going on road trips with friends and family, exploring, hiking, and playing board games. In his free time, he enjoys curling up with a good book to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and making his imagination soar. | When: Currently | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he finds never gets old. | Involving: Tim | He finds it never gets old.",
+        "Tim enjoys fantasy books like Lord of the Rings (LOTR) because they allow him to get lost in another world and appreciate intricate details. | Involving: Tim",
+        "Tim loves fantasy books because they transport readers to different worlds, offering a break from reality and an awesome adventure. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because it is immersive. | Involving: Tim | Because it's immersive.",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, and his favorite movie is \"Lord of the Rings\". | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim is always on the lookout for new books to read. | Involving: Tim",
+        "Tim loves to read books in his downtime, with the Harry Potter series being one of his favorites. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes of various fantasy novels and making book recommendations. | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum, shared his ideas, and they were accepted. He loves fantasy and enjoys spreading his passion. | Involving: Tim",
+        "Tim loves being lost in fantasy realms and considers \"That\" one of his favorite fantasy shows. | Involving: Tim",
+        "Tim does not surf, but finds escape and freedom in reading great fantasy books. | Involving: Tim",
+        "Tim finds bliss and a feeling of being in another world when reading in a comfy spot. | Involving: Tim",
+        "Tim appreciates that fantasy stories allow him to explore other cultures and landscapes from the comfort of his home. | Involving: Tim",
+        "Tim is also a huge fan of Lord of the Rings. | Involving: Tim",
+        "Tim is currently reading an inspiring fantasy novel series that explores the themes of friendship and loyalty. | When: Currently | Involving: Tim",
+        "Tim is overwhelmed with assignments and exams and is trying to find a way to juggle studying with his fantasy reading hobby. | When: This week (relative to August 26, 2023) | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds the experience rewarding. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 67,
+      "question": "What would be a good hobby related to his travel dreams for Tim to pick up?",
+      "expected_answer": "Writing a travel blog.",
+      "relevant_facts": [
+        "Tim loves traveling, believes it is eye-opening, and wants to visit Paris to see the Eiffel Tower for himself. | Involving: Tim",
+        "Tim is researching visa requirements for countries he wants to visit, feeling proud of taking initiative towards his travel dreams. | Involving: Tim | To make his travel dreams a reality.",
+        "Tim is reading stories from travelers around the world from a book to plan his next adventure. He read a story about two hikers who trekked through the Himalayas, which was tough but worth it, and motivated him. | Involving: Tim, two hikers (from the story) | To plan his next adventure and for motivation.",
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting and joyful, and his hard work is paying off. | When: Currently | Involving: Tim",
+        "Tim's passions are writing and reading, which help him stay motivated and push himself to get better when things get tough. | Involving: Tim | To stay motivated and improve in his areas of interest.",
+        "Tim joined a travel club because he is interested in different cultures and countries, and is excited to meet new people and learn about what makes them unique. | Involving: Tim | Interest in different cultures and countries, and a desire to meet new people and learn about them.",
+        "Tim is writing articles about fantasy novels for an online magazine and finds the experience rewarding. | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing great stories. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who finds her books captivating due to their detail and creative storytelling. Tim has been reading her works for a long time, is still inspired by her stories, and takes notes on her style for his own writing. | When: For a long time (ongoing) | Involving: Tim, J.K. Rowling",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last year | Involving: Tim",
+        "Tim believes creating a constructive atmosphere, setting an example by working hard, and using personal stories can inspire people. | Involving: Tim (user)",
+        "Tim joined a group of globetrotters who share his interests. | Involving: Tim, globetrotters",
+        "Tim offered to provide tips for visiting Harry Potter places. | Involving: Tim (to John)",
+        "Tim had a setback last week trying to write a story based on his experiences in the UK, which did not go as he wanted, and he finds it tough. | When: Last week (approx. November 12-18, 2023) | Involving: Tim",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week (October 30 - November 5, 2023) | Involving: Tim",
+        "Tim is going to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 68,
+      "question": "What day did Tim get into his study abroad program?",
+      "expected_answer": "Januarty 5, 2024",
+      "relevant_facts": [
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 69,
+      "question": "When will Tim leave for Ireland?",
+      "expected_answer": "February, 2024",
+      "relevant_facts": [
+        "Tim is going to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 70,
+      "question": "Which Star Wars-related locations would Tim enjoy during his visit to Ireland?",
+      "expected_answer": "Skellig Michael, Malin Head, Loop Head, Ceann Sib\u00e9al, and Brow Head because they are Star Wars filming locations.",
+      "relevant_facts": [
+        "Tim will stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he finds never gets old. | Involving: Tim | He finds it never gets old.",
+        "Tim is going to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 71,
+      "question": "Which team did John sign with on 21 May, 2023?",
+      "expected_answer": "The Minnesota Wolves",
+      "relevant_facts": [
+        "Things are going well with John's new team, The Minnesota Wolves; he is having fun and the team has been nice. | Involving: John, The Minnesota Wolves",
+        "John signed with The Minnesota Wolves. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 72,
+      "question": "What is John's position on the team he signed with?",
+      "expected_answer": "shooting guard",
+      "relevant_facts": [
+        "John plays as a shooting guard for The Minnesota Wolves. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 73,
+      "question": "What challenge did John encounter during pre-season training?",
+      "expected_answer": "fitting into the new team's style of play",
+      "relevant_facts": [
+        "John found it challenging to fit into the new team's style of play during pre-season training. | When: pre-season | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 74,
+      "question": "What aspects of the Harry Potter universe will be discussed in John's fan project collaborations?",
+      "expected_answer": "characters, spells, magical creatures",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 75,
+      "question": "What forum did Tim join recently?",
+      "expected_answer": "fantasy literature forum",
+      "relevant_facts": [
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, which he found enriching. | When: Last night (Wednesday, June 14, 2023) | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum, shared his ideas, and they were accepted. He loves fantasy and enjoys spreading his passion. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 76,
+      "question": "What kind of picture did Tim share as part of their Harry Potter book collection?",
+      "expected_answer": "MinaLima's creation from the Harry Potter films",
+      "relevant_facts": [
+        "The picture on Tim's bookshelf is from MinaLima, who created all the props for the Harry Potter films. Tim loves their work and feels it's like having a piece of the wizarding world at home. | Involving: Tim",
+        "Tim shared a photo of his bookshelf, which contains some of his favorite books. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 77,
+      "question": "What was the highest number of points John scored in a game recently?",
+      "expected_answer": "40 points",
+      "relevant_facts": [
+        "John scored 40 points in a basketball game, which is his highest score ever, indicating his hard work is paying off. | When: Last week | Involving: John | It was his personal best and felt like his hard work was paying off."
+      ]
+    },
+    {
+      "q_idx": 78,
+      "question": "What did John celebrate at a restaurant with teammates?",
+      "expected_answer": "a tough win",
+      "relevant_facts": [
+        "John and his teammates celebrated their tough win at a restaurant, laughing and reliving the intense moments. | When: Last week | Involving: John, John's teammates | To celebrate their tough win."
+      ]
+    },
+    {
+      "q_idx": 79,
+      "question": "What kind of deals did John sign with Nike and Gatorade?",
+      "expected_answer": "basketball shoe and gear deal with Nike, potential sponsorship deal with Gatorade",
+      "relevant_facts": [
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 80,
+      "question": "Which city is John excited to have a game at?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "John loves Seattle for its energy, diversity, awesome food (recommending local seafood), and the incredible support from fans at games. | Involving: John",
+        "John has a basketball game scheduled in Seattle next month. | When: Next month | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 81,
+      "question": "How long has John been surfing?",
+      "expected_answer": "five years",
+      "relevant_facts": [
+        "John started surfing five years ago and loves the connection to nature it provides. | When: Five years ago (around July 16, 2018) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 82,
+      "question": "How does John feel while surfing?",
+      "expected_answer": "super exciting and free-feeling",
+      "relevant_facts": [
+        "John had an awesome summer surfing and riding waves with his friends, describing the feeling as unreal. | Involving: John, John's friends",
+        "John finds being in the water, experiencing waves and wind, super exciting and free-feeling, emphasizing nature's special quality. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 83,
+      "question": "What kind of articles has Tim been writing about for the online magazine?",
+      "expected_answer": "different fantasy novels, characters, themes, and book recommendations",
+      "relevant_facts": [
+        "Tim recommended an \"awesome\" book by Patrick Rothfuss, praising its world-building and characters. | Involving: Tim, John | Tim shared his positive opinion and suggested John read it.",
+        "Tim is writing articles about fantasy novels for an online magazine and finds the experience rewarding. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes of various fantasy novels and making book recommendations. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John to read while traveling. | Involving: Tim, John (user)"
+      ]
+    },
+    {
+      "q_idx": 84,
+      "question": "Which two fantasy novels does Tim particularly enjoy writing about?",
+      "expected_answer": "Harry Potter and Game of Thrones",
+      "relevant_facts": [
+        "Tim is writing articles about fantasy novels for an online magazine and finds the experience rewarding. | Involving: Tim",
+        "Tim's favorite fantasy novels are Harry Potter and Game of Thrones, which he loves for their ability to transport him. He also enjoys books on growth, psychology, and self-improvement, viewing books as companions on his growth journey. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes of various fantasy novels and making book recommendations. | Involving: Tim",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because it is immersive. | Involving: Tim | Because it's immersive."
+      ]
+    },
+    {
+      "q_idx": 85,
+      "question": "What did Anthony and John end up playing during the charity event?",
+      "expected_answer": "an intense Harry Potter trivia contest",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony",
+        "John had a fun time at a charity event that featured Harry Potter trivia. | When: August 2023 | Involving: John",
+        "A \"super-nerd\" won a signed Harry Potter book as a prize at the trivia contest John and Anthony attended. | Involving: super-nerd"
+      ]
+    },
+    {
+      "q_idx": 86,
+      "question": "What did John share with the person he skyped about?",
+      "expected_answer": "Characters from Harry Potter",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 87,
+      "question": "How did John describe the team bond?",
+      "expected_answer": "Awesome",
+      "relevant_facts": [
+        "John finds it awesome to have his basketball team to push them all. | Involving: John, John's basketball team"
+      ]
+    },
+    {
+      "q_idx": 88,
+      "question": "How did John get introduced to basketball?",
+      "expected_answer": "Dad signed him up for a local league",
+      "relevant_facts": [
+        "John's dad signed him up for a local basketball league when John was ten years old. | When: When John was ten years old | Involving: John, John's dad"
+      ]
+    },
+    {
+      "q_idx": 89,
+      "question": "What is John's number one goal in his basketball career?",
+      "expected_answer": "Winning a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 90,
+      "question": "What organization is John teaming up with for his charity work?",
+      "expected_answer": "A local organization helping disadvantaged kids with sports and school",
+      "relevant_facts": [
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform to have a positive impact on the community and inspire others."
+      ]
+    },
+    {
+      "q_idx": 91,
+      "question": "When did John meet back up with his teammates after his trip in August 2023?",
+      "expected_answer": "Aug 15th",
+      "relevant_facts": [
+        "John reunited with his teammates on the 15th after his trip, feeling very welcome and lucky to be part of the team, experiencing an electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball when they reunited, symbolizing their friendship and love for each other. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 92,
+      "question": "What did John's teammates give him when they met on Aug 15th?",
+      "expected_answer": "a basketball with autographs on it",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball when they reunited, symbolizing their friendship and love for each other. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 93,
+      "question": "Why did John's teammates sign the basketball they gave him?",
+      "expected_answer": "to show their friendship and appreciation",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball when they reunited, symbolizing their friendship and love for each other. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 94,
+      "question": "What is the main intention behind Tim wanting to attend the book conference?",
+      "expected_answer": "to learn more about literature and create a stronger bond to it",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 95,
+      "question": "What new activity has Tim started learning in August 2023?",
+      "expected_answer": "play the piano",
+      "relevant_facts": [
+        "Tim recently started learning an instrument, which he finds challenging but fun, as he has always admired musicians. | When: Recently | Involving: Tim | Admiration for musicians and a desire for a challenging and fun activity.",
+        "Tim has started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 96,
+      "question": "Which movie's theme is Tim's favorite to play on the piano?",
+      "expected_answer": "\"Harry Potter and the Philosopher's Stone\"",
+      "relevant_facts": [
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim, bringing back great memories of watching it with his family, getting comfy with snacks and a blanket, and being totally absorbed. | Involving: Tim, Tim's family | It was the first movie in the series and watching it with family was a magical and special experience.",
+        "Tim's favorite song to play on the piano is a movie theme that evokes great memories. | Involving: Tim | It brings back great memories"
+      ]
+    },
+    {
+      "q_idx": 97,
+      "question": "What special memory does \"Harry Potter and the Philosopher's Stone\" bring to Tim?",
+      "expected_answer": "Watching it with his family",
+      "relevant_facts": [
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim, bringing back great memories of watching it with his family, getting comfy with snacks and a blanket, and being totally absorbed. | Involving: Tim, Tim's family | It was the first movie in the series and watching it with family was a magical and special experience."
+      ]
+    },
+    {
+      "q_idx": 98,
+      "question": "Which movie does Tim mention they enjoy watching during Thanksgiving?",
+      "expected_answer": "\"Home Alone\"",
+      "relevant_facts": [
+        "Tim and his family find Thanksgiving special, enjoying traditions like prepping a feast, discussing gratitude, and watching movies afterward. | Involving: Tim (and his family)",
+        "Tim and his family love watching \"Home Alone\" during Thanksgiving, as it always brings lots of laughs. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 99,
+      "question": "What tradition does Tim mention they love during Thanksgiving?",
+      "expected_answer": "Prepping the feast and talking about what they're thankful for",
+      "relevant_facts": [
+        "Tim and his family find Thanksgiving special, enjoying traditions like prepping a feast, discussing gratitude, and watching movies afterward. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 100,
+      "question": "How long did John and his high school basketball teammates play together?",
+      "expected_answer": "Four years",
+      "relevant_facts": [
+        "John was teammates with a group of friends for four years in high school. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 101,
+      "question": "How was John's experience in New York City?",
+      "expected_answer": "Amazing",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing with new and exciting things to explore and restaurants to try. He recommends it as a must-visit and an unforgettable adventure. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 102,
+      "question": "What did John say about NYC, enticing Tim to visit?",
+      "expected_answer": "It's got so much to check out - the culture, food - you won't regret it.",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing with new and exciting things to explore and restaurants to try. He recommends it as a must-visit and an unforgettable adventure. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 103,
+      "question": "What kind of soup did John make recently?",
+      "expected_answer": "tasty soup with sage",
+      "relevant_facts": [
+        "John recently made a tasty soup. | Involving: John",
+        "John used sage as a spice in the soup he made. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 104,
+      "question": "What spice did John add to the soup for flavor?",
+      "expected_answer": "sage",
+      "relevant_facts": [
+        "John used sage as a spice in the soup he made. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 105,
+      "question": "What is Tim excited to see at Universal Studios?",
+      "expected_answer": "The Harry Potter stuff",
+      "relevant_facts": [
+        "Tim is very excited for the Harry Potter attractions at Universal Studios. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 106,
+      "question": "Where are John and his teammates planning to explore on a team trip?",
+      "expected_answer": "a new city",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip next month to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To explore a new city and have fun."
+      ]
+    },
+    {
+      "q_idx": 107,
+      "question": "What city did Tim suggest to John for the team trip next month?",
+      "expected_answer": "Edinburgh, Scotland",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip next month to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To explore a new city and have fun.",
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, noting its magical vibe, history, architecture, beauty, and its status as the birthplace of Harry Potter. | Involving: Tim, John | As a suggestion for John's team trip."
+      ]
+    },
+    {
+      "q_idx": 108,
+      "question": "What does John want to do after his basketball career?",
+      "expected_answer": "positively influence and inspire others, potentially start a foundation and engage in charity work",
+      "relevant_facts": [
+        "John also wants to make a difference away from the basketball court through charity work or inspiring people. | Involving: John | Basketball has been great to him, so he wants to give something back.",
+        "John plans to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and engage in charity work to leave a meaningful legacy. | Involving: John (user)",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform to have a positive impact on the community and inspire others."
+      ]
+    },
+    {
+      "q_idx": 109,
+      "question": "What advice did Tim give John about picking endorsements?",
+      "expected_answer": "Ensure they align with values and brand, look for companies that share the desire to make a change and help others, make sure the endorsement feels authentic",
+      "relevant_facts": [
+        "John asked Tim for advice on how to pick the right endorsements. | Involving: John (user), Tim",
+        "Tim advised John to choose endorsements that align with his values and brand, specifically looking for companies that share his desire to make a positive change and ensuring authenticity for his followers. | Involving: Tim, John (user)"
+      ]
+    },
+    {
+      "q_idx": 110,
+      "question": "What book recommendation did Tim give to John for the trip?",
+      "expected_answer": "A fantasy novel by Patrick Rothfuss",
+      "relevant_facts": [
+        "John asked Tim for book recommendations for his trip. | Involving: John (user), Tim",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John to read while traveling. | Involving: Tim, John (user)",
+        "Tim recommended an \"awesome\" book by Patrick Rothfuss, praising its world-building and characters. | Involving: Tim, John | Tim shared his positive opinion and suggested John read it.",
+        "John plans to check out \"The Name of the Wind\" for his trip and shared a photo of his bookshelf, which contains books he has read and enjoyed. | Involving: John (user)",
+        "John likes fantasy novels with strong characters and good world-building, and he added \"The Name of the Wind\" to his reading list based on Tim's recommendation. | Involving: John",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 111,
+      "question": "What type of venue did John and his girlfriend choose for their wedding ceremony?",
+      "expected_answer": "Greenhouse",
+      "relevant_facts": [
+        "John's wedding ceremony was held at a lovely greenhouse venue, which was a smaller, more intimate gathering, and necessary safety protocols were followed. | When: Last week | Involving: John, John's wife, their loved ones | To ensure everyone felt safe and to allow loved ones to celebrate during current times."
+      ]
+    },
+    {
+      "q_idx": 112,
+      "question": "What was the setting for John and his wife's first dance?",
+      "expected_answer": "Cozy restaurant",
+      "relevant_facts": [
+        "John and his wife had their first dance at a cozy restaurant, which was described as dreamy with music and candlelight. | When: Last week | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 113,
+      "question": "Which basketball team does Tim support?",
+      "expected_answer": "The Wolves",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 114,
+      "question": "What passion does Tim mention connects him with people from all over the world?",
+      "expected_answer": "passion for fantasy stuff",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling a new lease of life and appreciating how his passion for fantasy connects him with people. | When: Last week | Involving: Tim",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 09, 2023 | Involving: Tim, Harry Potter fan | Tim enjoyed talking to someone who understands his interest.",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, which he found enriching. | When: Last night (Wednesday, June 14, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 115,
+      "question": "How does John describe the game season for his team?",
+      "expected_answer": "intense with tough losses and great wins",
+      "relevant_facts": [
+        "John's team had an intense season, experiencing both tough losses and great wins, but overall performed well. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 116,
+      "question": "How does John say his team handles tough opponents?",
+      "expected_answer": "by backing each other up and not quitting",
+      "relevant_facts": [
+        "John's team is driven to improve by facing tough opponents and they maintain a strong team spirit, backing each other up and refusing to quit. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 117,
+      "question": "What motivates John's team to get better, according to John?",
+      "expected_answer": "facing tough opponents",
+      "relevant_facts": [
+        "John's team is driven to improve by facing tough opponents and they maintain a strong team spirit, backing each other up and refusing to quit. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 118,
+      "question": "What did John's team win at the end of the season?",
+      "expected_answer": "a trophy",
+      "relevant_facts": [
+        "Tim congratulated John on winning a trophy and asked for tips on motivating others on his team. | Involving: Tim (user), John",
+        "John was elated about winning the trophy and expressed appreciation for Tim's support, stating he will continue to work hard. | Involving: John, Tim",
+        "John's team won a trophy, which made all their hard work and effort feel worthwhile. | Involving: John's team",
+        "John won a trophy and found the experience awesome. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 119,
+      "question": "Where did Tim capture the photography of the sunset over the mountain range?",
+      "expected_answer": "Smoky Mountains",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last year | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 120,
+      "question": "How does John feel about being seen as a mentor by some of the younger players?",
+      "expected_answer": "It feels great",
+      "relevant_facts": [
+        "Some younger players view John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model for them. | Involving: John, younger players",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is pleased to have a positive impact on their lives. | Involving: John, younger players",
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and it helps him stay involved in the game during the off-season. | Involving: John, younger players",
+        "John experiences challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them, finding it rewarding to see their development and goal achievement. | Involving: John, younger players",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and hoping his experiences can help shape their future and inspire them to pursue their dreams. | Involving: John, young athletes"
+      ]
+    },
+    {
+      "q_idx": 121,
+      "question": "What does John find rewarding about mentoring the younger players?",
+      "expected_answer": "Seeing their growth, improvement, and confidence",
+      "relevant_facts": [
+        "John experiences challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them, finding it rewarding to see their development and goal achievement. | Involving: John, younger players",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is pleased to have a positive impact on their lives. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 122,
+      "question": "What has John been able to help the younger players achieve?",
+      "expected_answer": "reach their goals",
+      "relevant_facts": [
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is pleased to have a positive impact on their lives. | Involving: John, younger players",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and hoping his experiences can help shape their future and inspire them to pursue their dreams. | Involving: John, young athletes",
+        "John experiences challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them, finding it rewarding to see their development and goal achievement. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 123,
+      "question": "What genre is the novel that Tim is writing?",
+      "expected_answer": "Fantasy",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting and joyful, and his hard work is paying off. | When: Currently | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 124,
+      "question": "Who is one of Tim's sources of inspiration for writing?",
+      "expected_answer": "J.K. Rowling",
+      "relevant_facts": [
+        "Tim's creativity for writing is inspired by books, movies, real-life experiences (like reading about UK castles), and certain authors. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who finds her books captivating due to their detail and creative storytelling. Tim has been reading her works for a long time, is still inspired by her stories, and takes notes on her style for his own writing. | When: For a long time (ongoing) | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 125,
+      "question": "What J.K. Rowling quote does Tim resonate with?",
+      "expected_answer": "\"Turn on the light - happiness hides in the darkest of times.\"",
+      "relevant_facts": [
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 126,
+      "question": "What does John write on the whiteboard to help him stay motivated?",
+      "expected_answer": "motivational quotes and strategies",
+      "relevant_facts": [
+        "John wrote motivational quotes and strategies on a whiteboard to help him stay focused and motivated, especially during tough workouts, and to keep improving. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 127,
+      "question": "What hobby is a therapy for John when away from the court?",
+      "expected_answer": "Cooking",
+      "relevant_facts": [
+        "John enjoys cuddling up with a book as his chill time. He also finds cooking therapeutic, a way to be creative and experiment with flavors, especially when he's away from the court. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 128,
+      "question": "What type of meal does John often cook using a slow cooker?",
+      "expected_answer": "honey garlic chicken with roasted veg",
+      "relevant_facts": [
+        "John will write down and mail the honey garlic chicken with roasted vegetables recipe to Tim. | Involving: John, Tim",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes. | Involving: John",
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables. | When: Saturday, October 21, 2023 | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 129,
+      "question": "How will John share the honey garlic chicken recipe with the other person?",
+      "expected_answer": "write it down and mail it",
+      "relevant_facts": [
+        "John will write down and mail the honey garlic chicken with roasted vegetables recipe to Tim. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 130,
+      "question": "What was Tim's huge writing issue last week,as mentioned on November 6, 2023?",
+      "expected_answer": "He got stuck on a plot twist",
+      "relevant_facts": [
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week (October 30 - November 5, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 131,
+      "question": "What does Tim have that serves as a reminder of hard work and is his prized possession?",
+      "expected_answer": "a basketball signed by his favorite player",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It serves as a reminder of hard work."
+      ]
+    },
+    {
+      "q_idx": 132,
+      "question": "Why do Tim and John find LeBron inspiring?",
+      "expected_answer": "LeBron's determination and the epic block in Game 7 of the '16 Finals",
+      "relevant_facts": [
+        "Tim's favorite player is LeBron James, who inspires him, especially due to an epic block in a Finals game a few years ago that changed the game and led to a win. | Involving: Tim, LeBron James | LeBron James's actions inspire Tim.",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John",
+        "John remembers LeBron James's epic block in Game 7 of the 2016 Finals, where he chased down Iguodala and pinned the ball against the backboard, and this display of determination and heart is why John loves basketball. | When: 2016 Finals, Game 7 (June 19, 2016) | Involving: John, LeBron James, Iguodala | This moment exemplifies the determination and heart that makes John love basketball.",
+        "John likes to collect basketball jerseys. His favorite team is The Wolves, and his favorite player is LeBron, whom he admires for his skills, leadership, work ethic, and dedication. | Involving: John, LeBron, The Wolves"
+      ]
+    },
+    {
+      "q_idx": 133,
+      "question": "How did John describe the views during their road trip out on the European coastline?",
+      "expected_answer": "Spectacular",
+      "relevant_facts": [
+        "John and his wife went on an amazing road trip on the European coastline, enjoying spectacular views, bonding, and creating memories, which was a nice change from his regular life. | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 134,
+      "question": "What is one of Tim's favorite fantasy TV shows, as mentioned on November 11, 2023?",
+      "expected_answer": "\"That\"",
+      "relevant_facts": [
+        "Tim loves being lost in fantasy realms and considers \"That\" one of his favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 135,
+      "question": "How does Tim stay motivated during difficult study sessions?",
+      "expected_answer": "Visualizing goals and success",
+      "relevant_facts": [
+        "Tim plans to keep in mind the value of having something meaningful to stay motivated, inspired by John's experience, for when he needs a push to reach his own goals. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 136,
+      "question": "What did Tim say about his injury on 16 November, 2023?",
+      "expected_answer": "The doctor said it's not too serious",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 137,
+      "question": "What was the setback Tim faced in his writing project on 21 November, 2023?",
+      "expected_answer": "Story based on experiences in the UK didn't go as planned",
+      "relevant_facts": [
+        "Tim had a setback last week trying to write a story based on his experiences in the UK, which did not go as he wanted, and he finds it tough. | When: Last week (approx. November 12-18, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 138,
+      "question": "How did John overcome his ankle injury from last season?",
+      "expected_answer": "stayed focused on recovery and worked hard to strengthen his body",
+      "relevant_facts": [
+        "John is doing physical therapy exercises every day to stay active and rehab his injury. | When: Every day (ongoing) | Involving: John",
+        "John overcame his ankle injury by staying focused on recovery and working hard to strengthen his body. | Involving: John | To recover from his injury and return to playing.",
+        "John believes strength training is crucial for basketball because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism. | Involving: John | These benefits are essential for games and overall performance.",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to practicing yoga. | Involving: John",
+        "John plans to keep pushing and staying positive regarding his recovery and progress. | Involving: John",
+        "Basketball is John's passion; he practices and trains every day to stay in shape and improve. | When: Every day | Involving: John | To stay in shape and improve, as it is his passion.",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John",
+        "John developed a workout schedule that balances basketball and strength training, emphasizing listening to his body and ensuring enough rest. | Involving: John | To stay on track, push himself during practice, and look after himself.",
+        "Incorporating strength training significantly improved John's shooting accuracy, agility, and speed, which gave him an advantage over opponents and boosted his confidence on the court. | Involving: John | It changed the game for him and helped him up his game.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "John had to adapt and tweak his routine at the new gym, finding the right balance tricky but eventually succeeding. | Involving: John",
+        "John found a new gym to help him stay on top of his professional basketball game, a process he found challenging. | Involving: John | Staying fit is essential for his pro ball career.",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a huge relief and success after being out for so long. | When: Last Friday | Involving: John | It was a significant personal achievement after a period of being unable to jog without pain.",
+        "John wrote motivational quotes and strategies on a whiteboard to help him stay focused and motivated, especially during tough workouts, and to keep improving. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 139,
+      "question": "What motivated Tim to keep pushing himself to get better in writing and reading?",
+      "expected_answer": "Love for writing and reading",
+      "relevant_facts": [
+        "Tim's passions are writing and reading, which help him stay motivated and push himself to get better when things get tough. | Involving: Tim | To stay motivated and improve in his areas of interest."
+      ]
+    },
+    {
+      "q_idx": 140,
+      "question": "How did John overcome a mistake he made during a big game in basketball?",
+      "expected_answer": "Worked hard to get better and focused on growth",
+      "relevant_facts": [
+        "John messed up during a big basketball game, found it hard to accept, but worked hard to improve, learning that resilience is key and owning up to mistakes is important for growth as a player and teammate. | Involving: John",
+        "John advises Tim to reflect on what went wrong and find ways to improve when facing challenges, similar to how he handles challenges on the basketball court. | Involving: John (advising Tim) | To help Tim overcome his storytelling setback.",
+        "John cares about improving, admits mistakes, and uses them to get better, valuing growth both on and off the court. | Involving: John",
+        "John wrote motivational quotes and strategies on a whiteboard to help him stay focused and motivated, especially during tough workouts, and to keep improving. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 141,
+      "question": "What book did John recently finish rereading that left him feeling inspired and hopeful about following dreams?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently reread \"The Alchemist,\" finding it inspiring and motivating him to think about following dreams and personal legends, leaving him feeling hopeful. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 142,
+      "question": "How did \"The Alchemist\" impact John's perspective on following dreams?",
+      "expected_answer": "made him think again about following dreams and searching for personal legends",
+      "relevant_facts": [
+        "John read and loved \"The Alchemist\", which made him think about life and the importance of following one's dreams. He highly recommends it. | Involving: John",
+        "John recently reread \"The Alchemist,\" finding it inspiring and motivating him to think about following dreams and personal legends, leaving him feeling hopeful. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 143,
+      "question": "What is John trying out to improve his strength and flexibility after recovery from ankle injury?",
+      "expected_answer": "yoga",
+      "relevant_facts": [
+        "John overcame his ankle injury by staying focused on recovery and working hard to strengthen his body. | Involving: John | To recover from his injury and return to playing.",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to practicing yoga. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy, preventing him from playing or helping his team. | When: Last season | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John",
+        "John is doing physical therapy exercises every day to stay active and rehab his injury. | When: Every day (ongoing) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 144,
+      "question": "How long does John usually hold the yoga pose he shared with Tim?",
+      "expected_answer": "30-60 seconds",
+      "relevant_facts": [
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 145,
+      "question": "Where was the forest picture shared by John on December 1,2023 taken?",
+      "expected_answer": "near his hometown",
+      "relevant_facts": [
+        "Tim and John both appreciate having beautiful natural places, like the forest in John's photo, near their homes. | Involving: Tim, John",
+        "John shared a photo of a tranquil forest located near his hometown. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 146,
+      "question": "What did Tim recently start learning in addition to being part of a travel club and working on studies?",
+      "expected_answer": "an instrument",
+      "relevant_facts": [
+        "Tim recently started learning an instrument, which he finds challenging but fun, as he has always admired musicians. | When: Recently | Involving: Tim | Admiration for musicians and a desire for a challenging and fun activity.",
+        "Tim has started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "Tim is learning to play the violin and is mostly interested in classical music, but also keen to try jazz and film scores. He views it as a great way to chill and get creative. | Involving: Tim | To chill and get creative.",
+        "Tim's favorite song to play on the piano is a movie theme that evokes great memories. | Involving: Tim | It brings back great memories"
+      ]
+    },
+    {
+      "q_idx": 147,
+      "question": "What instrument is Tim learning to play in December 2023?",
+      "expected_answer": "violin",
+      "relevant_facts": [
+        "Tim is learning to play the violin and is mostly interested in classical music, but also keen to try jazz and film scores. He views it as a great way to chill and get creative. | Involving: Tim | To chill and get creative."
+      ]
+    },
+    {
+      "q_idx": 148,
+      "question": "How long has Tim been playing the piano for, as of December 2023?",
+      "expected_answer": "about four months",
+      "relevant_facts": [
+        "Tim has started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 149,
+      "question": "What book did Tim just finish reading on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 150,
+      "question": "Which book did Tim recommend to John as a good story on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "John has not yet read George R. R. Martin's books but plans to check them out. | Involving: John",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "John plans to check out the book recommended by Tim. | Involving: John, Tim",
+        "John asked Tim for book recommendations for his trip. | Involving: John (user), Tim",
+        "John has heard that \"A Dance with Dragons\" is an inspiring book. | Involving: John",
+        "John felt great making plays for his team, loves seeing his teammates succeed from his opportunities, and found the arena atmosphere electric and the game against rivals intense, making it a memorable night. | When: Last Friday (December 8, 2023) | Involving: John, John's teammates, John's rivals",
+        "John achieved a career-high in assists in a basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 151,
+      "question": "What is the topic of discussion between John and Tim on 11 December, 2023?",
+      "expected_answer": "Academic achievements and sports successes",
+      "relevant_facts": [
+        "John was elated about winning the trophy and expressed appreciation for Tim's support, stating he will continue to work hard. | Involving: John, Tim",
+        "Tim congratulated John on winning a trophy and asked for tips on motivating others on his team. | Involving: Tim (user), John",
+        "Tim has been swamped with exams this week, but he is putting in his best effort and feeling optimistic. | When: This week | Involving: Tim",
+        "John felt great making plays for his team, loves seeing his teammates succeed from his opportunities, and found the arena atmosphere electric and the game against rivals intense, making it a memorable night. | When: Last Friday (December 8, 2023) | Involving: John, John's teammates, John's rivals",
+        "John achieved a career-high in assists in a basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a huge relief and success after being out for so long. | When: Last Friday | Involving: John | It was a significant personal achievement after a period of being unable to jog without pain."
+      ]
+    },
+    {
+      "q_idx": 152,
+      "question": "What kind of game did John have a career-high in assists in?",
+      "expected_answer": "basketball",
+      "relevant_facts": [
+        "John achieved a career-high in assists in a basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 153,
+      "question": "What was John's way of dealing with doubts and stress when he was younger?",
+      "expected_answer": "practicing basketball outside for hours",
+      "relevant_facts": [
+        "John used basketball practice as a way to deal with doubts and stress when he was younger. | When: When John was younger | Involving: John",
+        "The picture reminds John of when he was younger, practicing basketball outside for hours and dreaming of playing in big games. | When: When John was younger | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 154,
+      "question": "How did John feel about the atmosphere during the big game against the rival team?",
+      "expected_answer": "electric and intense",
+      "relevant_facts": [
+        "John felt great making plays for his team, loves seeing his teammates succeed from his opportunities, and found the arena atmosphere electric and the game against rivals intense, making it a memorable night. | When: Last Friday (December 8, 2023) | Involving: John, John's teammates, John's rivals"
+      ]
+    },
+    {
+      "q_idx": 155,
+      "question": "How did John feel after being able to jog without pain?",
+      "expected_answer": "It was a huge success.",
+      "relevant_facts": [
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a huge relief and success after being out for so long. | When: Last Friday | Involving: John | It was a significant personal achievement after a period of being unable to jog without pain."
+      ]
+    },
+    {
+      "q_idx": 156,
+      "question": "What kind of deal did John get in December?",
+      "expected_answer": "Deal with a renowned outdoor gear company",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his deal. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He is very excited about it."
+      ]
+    },
+    {
+      "q_idx": 157,
+      "question": "Where was the photoshoot done for John's gear deal?",
+      "expected_answer": "In a gorgeous forest",
+      "relevant_facts": [
+        "John participated in a photoshoot in a gorgeous forest, where the photographer took epic shots of him. | When: Last week | Involving: John, photographer"
+      ]
+    },
+    {
+      "q_idx": 158,
+      "question": "In which area has John's team seen the most growth during training?",
+      "expected_answer": "Communication and bonding",
+      "relevant_facts": [
+        "John's team has experienced significant growth in communication and bonding, which has improved their performance by allowing them to understand each other's strengths and weaknesses. | Involving: John, John's team | The improved communication and bonding led to better team performance and mutual understanding."
+      ]
+    },
+    {
+      "q_idx": 159,
+      "question": "What type of seminars is John conducting?",
+      "expected_answer": "Sports and marketing seminars",
+      "relevant_facts": [
+        "John started doing seminars this week to help people with their sports and marketing. The seminars went really well, and the aspiring professionals were eager and motivated, making John happy to share his knowledge. | When: This week | Involving: John, aspiring professionals"
+      ]
+    },
+    {
+      "q_idx": 160,
+      "question": "What activity did Tim do after reading the stories about the Himalayan trek?",
+      "expected_answer": "visited a travel agency",
+      "relevant_facts": [
+        "Tim is reading stories from travelers around the world from a book to plan his next adventure. He read a story about two hikers who trekked through the Himalayas, which was tough but worth it, and motivated him. | Involving: Tim, two hikers (from the story) | To plan his next adventure and for motivation.",
+        "Tim visited a travel agency to see the requirements for his next dream trip. | When: Recently | Involving: Tim | To understand the requirements for his dream trip."
+      ]
+    },
+    {
+      "q_idx": 161,
+      "question": "What is one cause that John supports with his influence and resources?",
+      "expected_answer": "youth sports and fair chances in sports",
+      "relevant_facts": [
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform to have a positive impact on the community and inspire others.",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 162,
+      "question": "What new fantasy TV series is Tim excited about?",
+      "expected_answer": "\"The Wheel of Time\"",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to come out next month. | When: Next month (January 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 163,
+      "question": "Which language is Tim learning?",
+      "expected_answer": "German",
+      "relevant_facts": [
+        "Tim finds learning German tough but worth it, appreciating its structure, which he finds easier than French, a language he studied in high school. | Involving: Tim",
+        "Tim is currently learning German, which he finds tough but fun. | Involving: Tim",
+        "Tim plans to continue with his German lessons. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 164,
+      "question": "What language does Tim know besides German?",
+      "expected_answer": "Spanish",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 165,
+      "question": "What book did Tim get in Italy that inspired him to cook?",
+      "expected_answer": "a cooking book",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 166,
+      "question": "What is John's favorite book series?",
+      "expected_answer": "Harry Potter",
+      "relevant_facts": [
+        "John loves the movie \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 167,
+      "question": "According to John, who is his favorite character from Lord of the Rings?",
+      "expected_answer": "Aragorn",
+      "relevant_facts": [
+        "John admires Aragorn for being a great leader who prioritizes others, which ultimately leads to him becoming king. | Involving: John, Aragorn | This is why Aragorn is John's favorite character.",
+        "John's favorite character is Aragorn, who he finds inspiring due to his significant growth throughout the story. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 168,
+      "question": "Why does John like Aragorn from Lord of the Rings?",
+      "expected_answer": "brave, selfless, down-to-earth attitude",
+      "relevant_facts": [
+        "John admires Aragorn for being a great leader who prioritizes others, which ultimately leads to him becoming king. | Involving: John, Aragorn | This is why Aragorn is John's favorite character.",
+        "John is inspired by Aragorn's brave, selfless, and down-to-earth attitude, as well as his perseverance and commitment to justice. | Involving: John, Aragorn | These qualities make Aragorn inspiring to John."
+      ]
+    },
+    {
+      "q_idx": 169,
+      "question": "What kind of painting does John have in his room as a reminder?",
+      "expected_answer": "a painting of Aragorn",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room that serves as a reminder for him to stay true and be a leader. | Involving: John, Aragorn | It reminds him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 170,
+      "question": "What is the painting of Aragorn a reminder for John to be in everything he does?",
+      "expected_answer": "be a leader",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room that serves as a reminder for him to stay true and be a leader. | Involving: John, Aragorn | It reminds him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 171,
+      "question": "What map does Tim show to his friend John?",
+      "expected_answer": "a map of Middle-earth from LOTR",
+      "relevant_facts": [
+        "John loves the map of Middle-earth (shown by Tim) because it helps him get lost in another world. | Involving: John, Tim",
+        "Tim is showing a map of Middle-earth from Lord of the Rings, which he finds cool for its depiction of different realms and regions. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 172,
+      "question": "Where will Tim be going for a semester abroad?",
+      "expected_answer": "Ireland",
+      "relevant_facts": [
+        "Tim is going to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher, which he describes as having amazing ocean views and awesome cliffs. | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 173,
+      "question": "Which city in Ireland will Tim be staying in during his semester abroad?",
+      "expected_answer": "Galway",
+      "relevant_facts": [
+        "Tim will stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 174,
+      "question": "What charity event did John organize recently in 2024?",
+      "expected_answer": "benefit basketball game",
+      "relevant_facts": [
+        "John held a benefit basketball game. | When: Last week (around January 3, 2024) | Involving: John",
+        "John's benefit basketball game was a total success, attracting many people and raising money for charity. | When: Last week (around January 3, 2024) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 175,
+      "question": "What achievement did John share with Tim in January 2024?",
+      "expected_answer": "endorsement with a popular beverage company",
+      "relevant_facts": [
+        "Tim advised John to choose endorsements that align with his values and brand, specifically looking for companies that share his desire to make a positive change and ensuring authenticity for his followers. | Involving: Tim, John (user)",
+        "John asked Tim for advice on how to pick the right endorsements. | Involving: John (user), Tim",
+        "John's benefit basketball game was a total success, attracting many people and raising money for charity. | When: Last week (around January 3, 2024) | Involving: John",
+        "John held a benefit basketball game. | When: Last week (around January 3, 2024) | Involving: John",
+        "John secured an endorsement with a popular beverage company, which felt like a dream come true and a payoff for his hard work and training. | When: Last week | Involving: John | It was a significant achievement that validated his efforts."
+      ]
+    },
+    {
+      "q_idx": 176,
+      "question": "What was Johns's reaction to sealing the deal with the beverage company?",
+      "expected_answer": "crazy feeling, sense of accomplishment",
+      "relevant_facts": [
+        "John secured an endorsement with a popular beverage company, which felt like a dream come true and a payoff for his hard work and training. | When: Last week | Involving: John | It was a significant achievement that validated his efforts."
+      ]
+    },
+    {
+      "q_idx": 177,
+      "question": "Which city did John recommend to Tim in January 2024?",
+      "expected_answer": "Barcelona",
+      "relevant_facts": [
+        "John recommends Barcelona as a must-visit city, highlighting its culture, architecture, food, and nearby beaches. | Involving: John (recommender), Tim (recipient)"
+      ]
+    }
+  ],
+  "embedding_id": "all-minilm-l6-v2",
+  "bank_id": "emb_all-minilm-l6-v2_1772557344"
+}

--- a/benchmark-runner/datasets/locomo_embeddings_gt_bge-base-en-v1-5.json
+++ b/benchmark-runner/datasets/locomo_embeddings_gt_bge-base-en-v1-5.json
@@ -1,0 +1,1836 @@
+{
+  "annotations": [
+    {
+      "q_idx": 0,
+      "question": "what are John's goals with regards to his basketball career?",
+      "expected_answer": "improve shooting percentage, win a championship",
+      "relevant_facts": [
+        "John's primary goal for his basketball career is to win a championship. | Involving: John",
+        "John's on-court goals include improving shooting, making more impact, being a consistent performer, and helping his team. Off-court, he aims for more endorsements and building his brand. | Involving: John",
+        "John's goal is to improve his shooting percentage, and he is practicing hard to achieve it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 1,
+      "question": "What are John's goals for his career that are not related to his basketball skills?",
+      "expected_answer": "get endorsements, build his brand, do charity work",
+      "relevant_facts": [
+        "John uses his contacts in the basketball industry and his marketing skills for networking to secure endorsements. | Involving: John",
+        "John also wants to make a difference off the court through charity or inspiring people, aiming to give back to basketball. | Involving: John | To give back to basketball, which has been great to him.",
+        "John's on-court goals include improving shooting, making more impact, being a consistent performer, and helping his team. Off-court, he aims for more endorsements and building his brand. | Involving: John",
+        "John is improving his overall basketball game, has secured endorsement deals, and is learning to market himself and boost his brand. He finds this progress rewarding. | Involving: John",
+        "John held a benefit basketball game to raise money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "John is exploring endorsement opportunities with various brands. | Involving: John | He finds it rewarding and exciting, seeing his hard work pay off.",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is teaming up with a local organization that assists disadvantaged kids with sports and school, aiming to use his platform for positive community impact and inspiration. | Involving: John | To have a positive impact on the community and inspire others.",
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. | Involving: John",
+        "John is making progress with exploring endorsements and has talked to some big names, which looks promising. | Involving: John",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John's seminars were successful, with aspiring professionals showing eagerness and motivation. | Involving: John, aspiring professionals",
+        "John is considering sports brands like Nike and Under Armour for endorsements, but is also open to other brands that align with his values and interests. | Involving: John",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "John felt crazy and accomplished, believing his hard work and training hours paid off, after securing the endorsement deal. | Involving: John | The endorsement deal validated his efforts.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd",
+        "John started conducting seminars to assist individuals with sports and marketing. | When: Recently | Involving: John",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and a significant achievement.",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John is trying to figure out how to pick the right endorsements and asked Tim for advice. | Involving: John, Tim",
+        "Tim advised John to choose endorsements that align with his values and brand, are from companies sharing his desire to make a change and help others, and feel authentic to his followers. | Involving: Tim, John",
+        "As part of his endorsement deal, John received top-notch hiking and outdoor gear and had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | When: Last week | Involving: John, photographer | Part of the endorsement deal"
+      ]
+    },
+    {
+      "q_idx": 2,
+      "question": "What items does John collect?",
+      "expected_answer": "sneakers, fantasy movie DVDs, jerseys",
+      "relevant_facts": [
+        "John likes to collect jerseys. | Involving: John",
+        "John loves the first Harry Potter movie and owns the entire collection. | Involving: John",
+        "John loves talking to people about his sneaker collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 3,
+      "question": "Would Tim enjoy reading books by C. S. Lewis or John Greene?",
+      "expected_answer": "C. S.Lewis",
+      "relevant_facts": [
+        "John is aware that Tim finds peace and enjoyment in reading fantasy books. | Involving: John, Tim",
+        "John feels that his passion connects him with his team, similar to how Tim's passion for fantasy connects him with others. | Involving: John, Tim",
+        "Tim considers books companions on his growth journey. He loves fantasy novels, specifically Harry Potter and Game of Thrones, because they transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim does not surf, but finds escape, freedom, and bliss in reading great fantasy books, especially in a comfy spot, which makes him feel like he's in another world. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that he finds transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | Involving: Tim",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John's trip. | Involving: Tim, John, Patrick Rothfuss",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim has been focusing on school, reading a bunch of fantasy books, and started learning to play the piano, finding the progress satisfying. | When: Since the last conversation (before August 21, 2023) | Involving: Tim",
+        "Tim and John value each other's friendship and share a mutual interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim is currently reading an inspiring fantasy novel series about the power of friendship and loyalty. | When: Currently (December 8, 2023) | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim shared a photo of his book collection, which includes a picture from MinaLima, the creators of props for the Harry Potter films. | Involving: Tim, MinaLima | Tim loves MinaLima's work and feels it's like having a piece of the wizarding world at home.",
+        "Tim is overwhelmed by assignments and exams but is trying to balance studying with his fantasy reading hobby, as he loves sinking into different magical worlds. | When: This week | Involving: Tim (user)",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising the author's amazing world-building and characters. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim loves fantasy novels because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim uses his Harry Potter-related items as a way to escape reality. | Involving: Tim",
+        "Tim is currently writing articles about fantasy novels for an online magazine, an activity he finds very rewarding. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim loves reading to escape to other worlds and has a collection of books for this purpose. | Involving: Tim",
+        "Tim found an opportunity to write articles for an online magazine on a fantasy literature forum, and the magazine liked his ideas, allowing him to spread his love for fantasy. | Involving: Tim | Because he loves fantasy.",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on studying characters, themes, and making book recommendations. | Involving: Tim",
+        "\"The Wheel of Time\" TV series is based on a book series that Tim loves. | Involving: Tim",
+        "Tim reorganized his bookshelf and shared a photo of it, which contains fantasy books like Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds. | Involving: Tim",
+        "Tim's favorite movie is Lord of the Rings. | Involving: Tim",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim loves traveling to new places to experience a different kind of magic, which connects to his love for fantasy novels. | Involving: Tim (user)",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim loves being lost in fantasy realms and considers \"That\" one of his favorite fantasy shows, viewing it as an escape. | Involving: Tim | He views it as an escape.",
+        "Tim is \"totally hooked\" on Harry Potter and Game of Thrones and loves writing about them. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, and he takes notes on her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim is excited to watch \"The Wheel of Time\" TV series. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars. | Involving: Tim",
+        "Tim decorated his Christmas tree himself with a Harry Potter theme, which he found to be a fun project and was happy with the result. | When: Last year | Involving: Tim | He found it a fun project and was happy with the result.",
+        "Tim recently attended a Harry Potter party where he met many like-minded people and had a lot of fun. | When: Recently, before December 8, 2023 | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching discussion about his favorite books. | When: Last night | Involving: Tim",
+        "Tim had an incredible time meeting with the Harry Potter fan, feeling the love and strong connection from sharing the same passion. | When: Last week | Involving: Tim, a Harry Potter fan | The shared passion for Harry Potter created a strong bond and an incredible experience.",
+        "Tim talked to his friend, a Harry Potter fan, last week to figure out ideas for his fan project. | When: Last week | Involving: Tim, Tim's friend | To figure out ideas for the Harry Potter fan project.",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 9, 2023 | Involving: Tim, Harry Potter fan (Tim met in CA)",
+        "Tim wore his Gryffindor scarf to the Harry Potter party and received a chocolate frog as a treat. | When: During the Harry Potter party (before December 8, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 4,
+      "question": "What books has Tim read?",
+      "expected_answer": "Harry Potter, Game of Thrones, the Name of the Wind, The Alchemist, The Hobbit, A Dance with Dragons, and the Wheel of Time.",
+      "relevant_facts": [
+        "Tim recommended a book by Patrick Rothfuss, praising the author's amazing world-building and characters. | Involving: Tim, John, Patrick Rothfuss",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim is \"totally hooked\" on Harry Potter and Game of Thrones and loves writing about them. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "Tim considers books companions on his growth journey. He loves fantasy novels, specifically Harry Potter and Game of Thrones, because they transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim plans to visit more Harry Potter-related spots in the future. | When: In the future | Involving: Tim | It makes him feel like he's stepping into the books.",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back (prior to November 21, 2023) | Involving: Tim | The book changed his perspective on his goals.",
+        "Tim uses his Harry Potter-related items as a way to escape reality. | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim shared a photo of his book collection, which includes a picture from MinaLima, the creators of props for the Harry Potter films. | Involving: Tim, MinaLima | Tim loves MinaLima's work and feels it's like having a piece of the wizarding world at home.",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as an amazing tour and like walking into a movie. | When: a few years ago | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "\"The Wheel of Time\" TV series is based on a book series that Tim loves. | Involving: Tim",
+        "Tim loves experimenting with spices and is planning his first trip to Universal Studios next month, where he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim",
+        "Tim reorganized his bookshelf and shared a photo of it, which contains fantasy books like Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim is working on a Harry Potter fan project and has been discussing collaborations for it. | Involving: Tim",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim",
+        "Tim would love to explore more real Harry Potter places someday. | When: someday | Involving: Tim",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, and he takes notes on her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "Tim offered to provide tips for visiting Harry Potter places. | Involving: Tim",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 9, 2023 | Involving: Tim, Harry Potter fan (Tim met in CA)",
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim",
+        "Tim recently attended a Harry Potter party where he met many like-minded people and had a lot of fun. | When: Recently, before December 8, 2023 | Involving: Tim",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John's trip. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim talked to his friend, a Harry Potter fan, last week to figure out ideas for his fan project. | When: Last week | Involving: Tim, Tim's friend | To figure out ideas for the Harry Potter fan project.",
+        "Tim decorated his Christmas tree himself with a Harry Potter theme, which he found to be a fun project and was happy with the result. | When: Last year | Involving: Tim | He found it a fun project and was happy with the result.",
+        "Tim had an incredible time meeting with the Harry Potter fan, feeling the love and strong connection from sharing the same passion. | When: Last week | Involving: Tim, a Harry Potter fan | The shared passion for Harry Potter created a strong bond and an incredible experience.",
+        "Tim had a nice chat with a Harry Potter fan in California, which he described as magical. | When: Last week | Involving: Tim, a Harry Potter fan | It was a magical experience due to shared passion.",
+        "Tim wore his Gryffindor scarf to the Harry Potter party and received a chocolate frog as a treat. | When: During the Harry Potter party (before December 8, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 5,
+      "question": "Based on Tim's collections, what is a shop that he would enjoy visiting in New York city?",
+      "expected_answer": "House of MinaLima",
+      "relevant_facts": [
+        "Tim plans to visit more Harry Potter-related spots in the future. | When: In the future | Involving: Tim | It makes him feel like he's stepping into the books.",
+        "Tim reorganized his bookshelf and shared a photo of it, which contains fantasy books like Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim shared a photo of his book collection, which includes a picture from MinaLima, the creators of props for the Harry Potter films. | Involving: Tim, MinaLima | Tim loves MinaLima's work and feels it's like having a piece of the wizarding world at home.",
+        "Tim wants to visit New York City and has added it to his travel list, excited to experience its culture and food. | Involving: Tim (user)",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim loves experimenting with spices and is planning his first trip to Universal Studios next month, where he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 6,
+      "question": "In which month's game did John achieve a career-high score in points?",
+      "expected_answer": "June 2023",
+      "relevant_facts": [
+        "John scored 40 points in a game, his highest ever, indicating his hard work is paying off. | When: Last week | Involving: John | It was his personal best score, showing the results of his hard work."
+      ]
+    },
+    {
+      "q_idx": 7,
+      "question": "Which geographical locations has Tim been to?",
+      "expected_answer": "California, London, the Smoky Mountains",
+      "relevant_facts": [
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 9, 2023 | Involving: Tim, Harry Potter fan (Tim met in CA)",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as an amazing tour and like walking into a movie. | When: a few years ago | Involving: Tim",
+        "Tim had a nice chat with a Harry Potter fan in California, which he described as magical. | When: Last week | Involving: Tim, a Harry Potter fan | It was a magical experience due to shared passion."
+      ]
+    },
+    {
+      "q_idx": 8,
+      "question": "Which outdoor gear company likely signed up John for an endorsement deal?",
+      "expected_answer": "Under Armour",
+      "relevant_facts": [
+        "John is considering sports brands like Nike and Under Armour for endorsements, but is also open to other brands that align with his values and interests. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "As part of his endorsement deal, John received top-notch hiking and outdoor gear and had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | When: Last week | Involving: John, photographer | Part of the endorsement deal",
+        "John likes Under Armour and dreams of working with them. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 9,
+      "question": "Which endorsement deals has John been offered?",
+      "expected_answer": "basketball shoes and gear deal with Nike, potential sponsorship with Gatorade, Moxie a popular beverage company, outdoor gear company",
+      "relevant_facts": [
+        "As part of his endorsement deal, John received top-notch hiking and outdoor gear and had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | When: Last week | Involving: John, photographer | Part of the endorsement deal",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and a significant achievement.",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 10,
+      "question": "When was John in Seattle for a game?",
+      "expected_answer": "early August, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 11,
+      "question": "What sports does John like besides basketball?",
+      "expected_answer": "surfing",
+      "relevant_facts": [
+        "John started surfing five years ago, had an awesome summer surfing with friends, and finds being in the water (waves, wind) super exciting and free-feeling, loving the connection to nature it provides. | When: Started five years ago | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 12,
+      "question": "What year did John start surfing?",
+      "expected_answer": "2018",
+      "relevant_facts": [
+        "John started surfing five years ago, had an awesome summer surfing with friends, and finds being in the water (waves, wind) super exciting and free-feeling, loving the connection to nature it provides. | When: Started five years ago | Involving: John, John's friends",
+        "John has been playing professional basketball for just under a year. | When: just under a year as of December 6, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 13,
+      "question": "What does Tim do to escape reality?",
+      "expected_answer": "Read fantasy books.",
+      "relevant_facts": [
+        "Tim loves fantasy novels because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim considers books companions on his growth journey. He loves fantasy novels, specifically Harry Potter and Game of Thrones, because they transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim loves reading to escape to other worlds and has a collection of books for this purpose. | Involving: Tim",
+        "Tim does not surf, but finds escape, freedom, and bliss in reading great fantasy books, especially in a comfy spot, which makes him feel like he's in another world. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that he finds transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | Involving: Tim",
+        "Tim is overwhelmed by assignments and exams but is trying to balance studying with his fantasy reading hobby, as he loves sinking into different magical worlds. | When: This week | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 14,
+      "question": "What kind of writing does Tim do?",
+      "expected_answer": "comments on favorite books in a fantasy literature forum, articles on fantasy novels, studying characters, themes, and making book recommendations, writing a fantasy novel",
+      "relevant_facts": [
+        "Tim's fantasy writing is going well, and he is currently writing a fantasy novel. | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing stories. | Involving: Tim",
+        "Tim is currently writing articles about fantasy novels for an online magazine, an activity he finds very rewarding. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching discussion about his favorite books. | When: Last night | Involving: Tim",
+        "Tim found an opportunity to write articles for an online magazine on a fantasy literature forum, and the magazine liked his ideas, allowing him to spread his love for fantasy. | Involving: Tim | Because he loves fantasy.",
+        "Tim is \"totally hooked\" on Harry Potter and Game of Thrones and loves writing about them. | Involving: Tim",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week | Involving: Tim",
+        "Last week, Tim experienced a setback while trying to write a story based on his experiences in the UK, as it did not go as he wanted. He finds this tough and is seeking advice on how to improve his storytelling. | When: Last week | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on studying characters, themes, and making book recommendations. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 15,
+      "question": "Who is Anthony?",
+      "expected_answer": "likely John's friend, colleague or family",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd"
+      ]
+    },
+    {
+      "q_idx": 16,
+      "question": "After how many weeks did Tim reconnect with the fellow Harry Potter fan from California?",
+      "expected_answer": "three weeks",
+      "relevant_facts": [
+        "Tim had a nice chat with a Harry Potter fan in California, which he described as magical. | When: Last week | Involving: Tim, a Harry Potter fan | It was a magical experience due to shared passion.",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 9, 2023 | Involving: Tim, Harry Potter fan (Tim met in CA)"
+      ]
+    },
+    {
+      "q_idx": 17,
+      "question": "How many games has John mentioned winning?",
+      "expected_answer": "6",
+      "relevant_facts": [
+        "Tim is proud of John and congratulates him on his team winning a trophy, acknowledging that John's hard work paid off. | Involving: Tim, John",
+        "John's team won an intense basketball game last week, with John scoring the last basket. | When: Last week (e.g., August 5, 2023) | Involving: John, John's team",
+        "John's favorite game was when he hit a buzzer-beater shot to win after his team was down by 10 points in the 4th quarter. | Involving: John, John's team",
+        "John's basketball team recently played a tough game against a top team and secured a win, which he finds awesome for pushing them. | When: Lately, before December 8, 2023 | Involving: John (and his basketball team)",
+        "John's team won a trophy, and John feels great that their hard work and effort were worth it. | Involving: John's team, John",
+        "John considers the camaraderie built with his basketball team, both on and off the court, as the best part of their recent win. | Involving: John (and his basketball team)",
+        "John and his teammates won a tough game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates | It was a challenging game that resulted in a victory.",
+        "John and his teammates, though exhausted, celebrated their tough win at a restaurant, laughing and reliving the intense moments. | When: After the game last week | Involving: John, John's teammates | To celebrate their victory in a tough game.",
+        "John found winning the trophy to be awesome. | Involving: John | Expresses his positive feeling about the achievement.",
+        "John was elated about his team winning a trophy and appreciates Tim's support, stating he will continue to work hard. | Involving: John, Tim",
+        "John loves basketball because of thrilling moments like hitting a buzzer-beater shot. | Involving: John",
+        "John's basketball team was trailing significantly in the 4th quarter of a game last year, but they managed to overturn the deficit and win, which was an amazing and unforgettable feeling. | When: Last year | Involving: John",
+        "John won a trophy. | Involving: John",
+        "John's basketball team won a close game against another team. | When: Last week | Involving: John and his team"
+      ]
+    },
+    {
+      "q_idx": 18,
+      "question": "What authors has Tim read books from?",
+      "expected_answer": "J.K. Rowling, R.R. Martin, Patrick Rothfuss, Paulo Coelho, and J. R. R. Tolkien.",
+      "relevant_facts": [
+        "Tim recommended a book by Patrick Rothfuss, praising the author's amazing world-building and characters. | Involving: Tim, John, Patrick Rothfuss",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim is \"totally hooked\" on Harry Potter and Game of Thrones and loves writing about them. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back (prior to November 21, 2023) | Involving: Tim | The book changed his perspective on his goals.",
+        "Tim considers books companions on his growth journey. He loves fantasy novels, specifically Harry Potter and Game of Thrones, because they transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "Tim shared a photo of his book collection, which includes a picture from MinaLima, the creators of props for the Harry Potter films. | Involving: Tim, MinaLima | Tim loves MinaLima's work and feels it's like having a piece of the wizarding world at home.",
+        "J.K. Rowling is an inspiring writer for Tim, and he takes notes on her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim reorganized his bookshelf and shared a photo of it, which contains fantasy books like Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John's trip. | Involving: Tim, John, Patrick Rothfuss"
+      ]
+    },
+    {
+      "q_idx": 19,
+      "question": "What is a prominent charity organization that John might want to work with and why?",
+      "expected_answer": "Good Sports, because they work with Nike, Gatorade, and Under Armour and they aim toprovide youth sports opportunities for kids ages 3-18 in high-need communities.",
+      "relevant_facts": [
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. | Involving: John",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "John also wants to make a difference off the court through charity or inspiring people, aiming to give back to basketball. | Involving: John | To give back to basketball, which has been great to him.",
+        "John is teaming up with a local organization that assists disadvantaged kids with sports and school, aiming to use his platform for positive community impact and inspiration. | Involving: John | To have a positive impact on the community and inspire others.",
+        "John held a benefit basketball game to raise money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsements, but is also open to other brands that align with his values and interests. | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 20,
+      "question": "Which city was John in before traveling to Chicago?",
+      "expected_answer": "Seattle",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 21,
+      "question": "Which US cities does John mention visiting to Tim?",
+      "expected_answer": "Seattle, Chicago, New York",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing, exciting, with great exploration and restaurants, and recommends it as a must-visit. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore due to its vibrant nature. | Involving: John",
+        "John initially struggled with the subway system during his trip to NYC but found it easy after receiving help. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John took a trip to Chicago, which he found amazing due to its energy and friendly locals. | When: Recently, before Friday, August 11, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 22,
+      "question": "When did John meet with his teammates after returning from Chicago?",
+      "expected_answer": "August 15, 2023",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and lucky to be part of the team. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John took a trip to Chicago, which he found amazing due to its energy and friendly locals. | When: Recently, before Friday, August 11, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 23,
+      "question": "When is Tim attending a book conference?",
+      "expected_answer": "September 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond to it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 24,
+      "question": "Where was John between August 11 and August 15 2023?",
+      "expected_answer": "Chicago",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and lucky to be part of the team. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John took a trip to Chicago, which he found amazing due to its energy and friendly locals. | When: Recently, before Friday, August 11, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 25,
+      "question": "What similar sports collectible do Tim and John own?",
+      "expected_answer": "signed basketball",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and to serve as a reminder of their bond.",
+        "Tim owns a basketball signed by his favorite player, which is his prized possession and serves as a reminder of hard work. | Involving: Tim | It serves as a reminder of hard work."
+      ]
+    },
+    {
+      "q_idx": 26,
+      "question": "Which TV series does Tim mention watching?",
+      "expected_answer": "That, Wheel of Time",
+      "relevant_facts": [
+        "Tim is excited to watch \"The Wheel of Time\" TV series. | Involving: Tim",
+        "Tim loves being lost in fantasy realms and considers \"That\" one of his favorite fantasy shows, viewing it as an escape. | Involving: Tim | He views it as an escape."
+      ]
+    },
+    {
+      "q_idx": 27,
+      "question": "Which popular time management technique does Tim use to prepare for exams?",
+      "expected_answer": "Pomodoro technique",
+      "relevant_facts": [
+        "Tim's study trick involves breaking studying into 25-minute segments followed by 5-minute fun breaks, which he finds less overwhelming and effective for staying on track. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 28,
+      "question": "Which popular music composer's tunes does Tim enjoy playing on the piano?",
+      "expected_answer": "John Williams",
+      "relevant_facts": [
+        "Tim loves playing different songs on the piano, with his favorite being a theme from a movie that brings back many great memories. | Involving: Tim",
+        "Tim has been focusing on school, reading a bunch of fantasy books, and started learning to play the piano, finding the progress satisfying. | When: Since the last conversation (before August 21, 2023) | Involving: Tim",
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie from the series and watching it with his family was an amazing, magical, dream-like experience where they would get comfy with snacks and a blanket, creating special memories. | Involving: Tim, Tim's family | The movie brings back great memories and was a shared magical experience.",
+        "Tim's favorite fantasy movie is Star Wars. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 29,
+      "question": "What schools did John play basketball in and how many years was he with his team during high school?",
+      "expected_answer": "Middle school, high school, and college and he was with his high school team for 4 years.",
+      "relevant_facts": [
+        "John played basketball through middle and high school, which led to him earning a college scholarship. | When: Through middle and high school | Involving: John",
+        "John and his friends were teammates for four years in high school. | Involving: John, John's friends",
+        "After college, John was drafted by a team, fulfilling his dream of playing professionally. | When: After college | Involving: John | It was a dream come true for him."
+      ]
+    },
+    {
+      "q_idx": 30,
+      "question": "Which cities has John been to?",
+      "expected_answer": "Seattle, Chicago, New York, and Paris.",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing, exciting, with great exploration and restaurants, and recommends it as a must-visit. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore due to its vibrant nature. | Involving: John",
+        "John initially struggled with the subway system during his trip to NYC but found it easy after receiving help. | Involving: John",
+        "John has been to Paris before and loved it. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John finds Paris amazing and the view from the Eiffel Tower incredible. | Involving: John",
+        "John took a trip to Chicago, which he found amazing due to its energy and friendly locals. | When: Recently, before Friday, August 11, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 31,
+      "question": "What month did Tim plan on going to Universal Studios?",
+      "expected_answer": "September, 2023",
+      "relevant_facts": [
+        "Tim loves experimenting with spices and is planning his first trip to Universal Studios next month, where he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 32,
+      "question": "Which US states might Tim be in during September 2023 based on his plans of visiting Universal Studios?",
+      "expected_answer": "California or Florida",
+      "relevant_facts": [
+        "Tim loves experimenting with spices and is planning his first trip to Universal Studios next month, where he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 33,
+      "question": "When does John plan on traveling with his team on a team trip?",
+      "expected_answer": "October, 2023",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip for next month to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To explore a new city and have fun."
+      ]
+    },
+    {
+      "q_idx": 34,
+      "question": "What could John do after his basketball career?",
+      "expected_answer": "become a basketball coach since he likes giving back and leadership",
+      "relevant_facts": [
+        "John advises Tim to reflect on what went wrong and find ways to improve when facing challenges, drawing from his own experience on the basketball court. | Involving: John, Tim | To help Tim overcome his storytelling setback.",
+        "John also wants to make a difference off the court through charity or inspiring people, aiming to give back to basketball. | Involving: John | To give back to basketball, which has been great to him.",
+        "John considers it important to think about life after basketball. | Involving: John",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is glad he could make a positive impact on their lives. | Involving: John, younger players",
+        "John is mentoring younger players on his team, finding it super rewarding and enjoying sharing his skills and knowledge, which also helps him stay involved in the game during the off-season. | Involving: John, younger players (on his team)",
+        "Tim asked John for tips on motivating others on his team. | Involving: Tim, John",
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires. | Involving: John, LeBron",
+        "John's tips for motivating others include showing care for teammates, celebrating achievements, providing constructive feedback, reminding them of the bigger goal, creating a positive environment, and giving pep talks before a game. | Involving: John (giving advice to Tim) | In response to Tim's request for advice.",
+        "Some of the younger players see John as a mentor, and he enjoys providing them with advice and support both on and off the court, embracing his role as a positive role model. | Involving: John, younger players",
+        "John is teaming up with a local organization that assists disadvantaged kids with sports and school, aiming to use his platform for positive community impact and inspiration. | Involving: John | To have a positive impact on the community and inspire others.",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding his role as a role model fulfilling and believing his experiences can help shape their future and inspire their dreams. | Involving: John, young athletes (younger players)",
+        "John faces challenges in mentoring due to individual differences among players but gains experience in adapting, motivating, and encouraging them, and finds it great to watch them develop and reach their goals. | Involving: John, younger players",
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership qualities, bravery, selflessness, down-to-earth attitude, perseverance, and commitment to justice. | Involving: John",
+        "John has a painting of Aragorn in his room that serves as a reminder for him to stay true and be a leader. | Involving: John | To inspire him to stay true and be a leader.",
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. | Involving: John",
+        "John's seminars were successful, with aspiring professionals showing eagerness and motivation. | Involving: John, aspiring professionals",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential.",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John",
+        "John started conducting seminars to assist individuals with sports and marketing. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 35,
+      "question": "What outdoor activities does John enjoy?",
+      "expected_answer": "Hiking, surfing",
+      "relevant_facts": [
+        "John started surfing five years ago, had an awesome summer surfing with friends, and finds being in the water (waves, wind) super exciting and free-feeling, loving the connection to nature it provides. | When: Started five years ago | Involving: John, John's friends",
+        "John's loved ones, including some friends from his hiking club, celebrated with him and his wife at their wedding, making him feel an immense amount of love and happiness. | When: Last week (Saturday, September 30, 2023) | Involving: John, John's wife, John's loved ones, John's hiking club friends | The presence of loved ones contributed to his joy.",
+        "John finds that nature puts him in a great mood and energizes him. He stumbled upon a peaceful spot while hiking, characterized by a soothing river sound and surrounding rocks, which made him feel at peace and admire nature's beauty. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 36,
+      "question": "Who is Tim and John's favorite basketball player?",
+      "expected_answer": "LeBron James",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires. | Involving: John, LeBron",
+        "Tim's favorite basketball player is LeBron James. | Involving: Tim, LeBron James"
+      ]
+    },
+    {
+      "q_idx": 37,
+      "question": "Which week did Tim visit the UK for the Harry Potter Conference?",
+      "expected_answer": "The week before October 13th, 2023.",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 38,
+      "question": "which country has Tim visited most frequently in his travels?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as an amazing tour and like walking into a movie. | When: a few years ago | Involving: Tim",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim",
+        "Last week, Tim experienced a setback while trying to write a story based on his experiences in the UK, as it did not go as he wanted. He finds this tough and is seeking advice on how to improve his storytelling. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 39,
+      "question": "What year did Tim go to the Smoky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 40,
+      "question": "Has Tim been to North Carolina and/or Tennesee states in the US?",
+      "expected_answer": "Yes",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 41,
+      "question": "What kind of fiction stories does Tim write?",
+      "expected_answer": "Fantasy stories with plot twists",
+      "relevant_facts": [
+        "Tim's fantasy writing is going well, and he is currently writing a fantasy novel. | Involving: Tim",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 42,
+      "question": "What has John cooked?",
+      "expected_answer": "Soup, a slow cooker meal, and honey garlic chicken with roasted veg.",
+      "relevant_facts": [
+        "John will write down and mail his honey garlic chicken with roasted vegetables recipe to Tim. Tim is eager to try it and will inform John about the outcome. | Involving: John, Tim",
+        "John has been trying out cooking recipes and recently made a tasty, improvised soup using sage. | Involving: John",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes. He also enjoys trying new recipes. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 43,
+      "question": "What does John like about Lebron James?",
+      "expected_answer": "His heart, determination, skills, and leadership.",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires. | Involving: John, LeBron",
+        "John remembers and admires LeBron James's epic block in Game 7 of the 2016 Finals against Iguodala, citing this determination and heart as a reason he loves basketball. | When: 2016 Finals (Game 7) | Involving: John, LeBron James, Iguodala | The determination and heart shown are a reason he loves basketball.",
+        "John enjoys playing and pushing himself, inspired by LeBron's moments of determination and heart. | Involving: John, LeBron"
+      ]
+    },
+    {
+      "q_idx": 44,
+      "question": "When did John and his wife go on a European vacation?",
+      "expected_answer": "November, 2023.",
+      "relevant_facts": [
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 45,
+      "question": "Which country was Tim visiting in the second week of November?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Last week, Tim experienced a setback while trying to write a story based on his experiences in the UK, as it did not go as he wanted. He finds this tough and is seeking advice on how to improve his storytelling. | When: Last week | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 46,
+      "question": "Where was Tim in the week before 16 November 2023?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim",
+        "Last week, Tim experienced a setback while trying to write a story based on his experiences in the UK, as it did not go as he wanted. He finds this tough and is seeking advice on how to improve his storytelling. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 47,
+      "question": "When did John get married at a greenhouse?",
+      "expected_answer": "last week of September 2023",
+      "relevant_facts": [
+        "John and his girlfriend had an amazing and emotional wedding ceremony last week in a lovely greenhouse venue, which was a smaller, more intimate gathering where necessary safety protocols were followed. | When: Last week (Saturday, September 30, 2023) | Involving: John, John's girlfriend (now wife)"
+      ]
+    },
+    {
+      "q_idx": 48,
+      "question": "When did John get an ankle injury in 2023?",
+      "expected_answer": "around November 16, 2023",
+      "relevant_facts": [
+        "Last season, John suffered a major ankle injury that required him to take time off and undergo physical therapy. | When: Last season | Involving: John",
+        "John found his ankle injury frustrating because it prevented him from playing basketball or helping his team. | When: Last season | Involving: John",
+        "John overcame his ankle injury by staying focused on his recovery and diligently working to strengthen his body, which taught him the importance of patience and perseverance. | When: Last season | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 49,
+      "question": "How many times has John injured his ankle?",
+      "expected_answer": "two times",
+      "relevant_facts": [
+        "Last season, John suffered a major ankle injury that required him to take time off and undergo physical therapy. | When: Last season | Involving: John",
+        "John injured himself recently, which caused him to miss basketball games and be unable to help his team. | When: Not too long ago | Involving: John, John's team | The injury prevented him from playing and helping his team.",
+        "John found his ankle injury frustrating because it prevented him from playing basketball or helping his team. | When: Last season | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 50,
+      "question": "Which book was John reading during his recovery from an ankle injury?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "Last season, John suffered a major ankle injury that required him to take time off and undergo physical therapy. | When: Last season | Involving: John",
+        "John recently finished rereading \"The Alchemist,\" which he found inspiring, motivating, and hopeful, making him think about following dreams and searching for personal legends. | When: Recently (prior to November 21, 2023) | Involving: John | The book inspired him to think about following dreams and personal legends, and he felt motivated and hopeful.",
+        "John is recovering from an injury, finding the process tough but maintaining a positive attitude and taking it slow. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 51,
+      "question": "What kind of yoga for building core strength might John benefit from?",
+      "expected_answer": "Hatha Yoga",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 52,
+      "question": "What does John do to supplement his basketball training?",
+      "expected_answer": "Yoga, strength training",
+      "relevant_facts": [
+        "John includes strength training in his basketball routine to build muscle, increase power, prevent injuries, become more explosive, and boost overall athleticism. | Involving: John | These are the benefits he seeks from strength training for basketball.",
+        "John's incorporation of strength training has improved his shooting accuracy, agility, and speed in basketball, giving him an advantage over opponents and boosting his confidence. | Involving: John | These are the positive impacts on his performance and confidence.",
+        "John developed a workout schedule that balances basketball practice and strength training. | Involving: John | To balance his training and stay on track.",
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability, and good for working out legs and core. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as these poses challenge his body and mind. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worth it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 53,
+      "question": "What other exercises can help John with his basketball performance?",
+      "expected_answer": "Sprinting, long-distance running, and boxing.",
+      "relevant_facts": [
+        "John's incorporation of strength training has improved his shooting accuracy, agility, and speed in basketball, giving him an advantage over opponents and boosting his confidence. | Involving: John | These are the positive impacts on his performance and confidence.",
+        "John includes strength training in his basketball routine to build muscle, increase power, prevent injuries, become more explosive, and boost overall athleticism. | Involving: John | These are the benefits he seeks from strength training for basketball.",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worth it. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability, and good for working out legs and core. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as these poses challenge his body and mind. | Involving: John",
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John developed a workout schedule that balances basketball practice and strength training. | Involving: John | To balance his training and stay on track.",
+        "John started surfing five years ago, had an awesome summer surfing with friends, and finds being in the water (waves, wind) super exciting and free-feeling, loving the connection to nature it provides. | When: Started five years ago | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 54,
+      "question": "When did John take a trip to the Rocky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "John took a stunning trip to the Rocky Mountains, experiencing fresh air and majestic peaks. | When: Last year (2022) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 55,
+      "question": "When did John start playing professionally?",
+      "expected_answer": "May, 2023",
+      "relevant_facts": [
+        "John has been playing professional basketball for just under a year. | When: just under a year as of December 6, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 56,
+      "question": "When did Tim start playing the violin?",
+      "expected_answer": "August 2023",
+      "relevant_facts": [
+        "Tim is learning to play the violin. He is mostly interested in classical music but also keen to try jazz and film scores, finding it a great way to relax and be creative. | Involving: Tim | Finds it a great way to chill and get creative.",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months, ongoing as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 57,
+      "question": "What instruments does Tim play?",
+      "expected_answer": "piano, violin",
+      "relevant_facts": [
+        "Tim loves playing different songs on the piano, with his favorite being a theme from a movie that brings back many great memories. | Involving: Tim",
+        "Tim is learning to play the violin. He is mostly interested in classical music but also keen to try jazz and film scores, finding it a great way to relax and be creative. | Involving: Tim | Finds it a great way to chill and get creative.",
+        "Tim has been focusing on school, reading a bunch of fantasy books, and started learning to play the piano, finding the progress satisfying. | When: Since the last conversation (before August 21, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 58,
+      "question": "When did John attend the Harry Potter trivia?",
+      "expected_answer": "August 2023.",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd",
+        "John previously attended a charity event that featured Harry Potter trivia in August and enjoys being with people who are passionate about Harry Potter. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 59,
+      "question": "Which career-high performances did John achieve in 2023?",
+      "expected_answer": "highest point score, highest assist",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Last Friday | Involving: John",
+        "John scored 40 points in a game, his highest ever, indicating his hard work is paying off. | When: Last week | Involving: John | It was his personal best score, showing the results of his hard work."
+      ]
+    },
+    {
+      "q_idx": 60,
+      "question": "When did John achieve a career-high assist performance?",
+      "expected_answer": "December 11, 2023",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 61,
+      "question": "What books has John read?",
+      "expected_answer": "inpsiring book on dreaming big, The Alchemist, fantasy series, non-fiction books on personal development, Dune",
+      "relevant_facts": [
+        "John loves fantasy books because they fuel his creativity. He also loves non-fiction books about personal development and mindset, as they help him know himself better. | Involving: John",
+        "John read and loved \"The Alchemist\", finding that it made him think about life and the importance of following one's dreams. He highly recommends the book. | Involving: John",
+        "John's favorite fantasy books include \"The Hobbit\" and another popular fantasy series. | Involving: John",
+        "John is currently reading \"Dune\" by Frank Herbert, which he describes as a great story about religion and human control over ecology. | Involving: John",
+        "John recently finished rereading \"The Alchemist,\" which he found inspiring, motivating, and hopeful, making him think about following dreams and searching for personal legends. | When: Recently (prior to November 21, 2023) | Involving: John | The book inspired him to think about following dreams and personal legends, and he felt motivated and hopeful.",
+        "John recently finished an amazing fantasy series with many twists and loves getting lost in fantasy worlds created by authors with awesome storylines and characters. | When: Recently | Involving: John | He enjoys getting lost in fantasy worlds."
+      ]
+    },
+    {
+      "q_idx": 62,
+      "question": "What does John do to share his knowledge?",
+      "expected_answer": "gives seminars, mentors younger players.",
+      "relevant_facts": [
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is glad he could make a positive impact on their lives. | Involving: John, younger players",
+        "John is mentoring younger players on his team, finding it super rewarding and enjoying sharing his skills and knowledge, which also helps him stay involved in the game during the off-season. | Involving: John, younger players (on his team)",
+        "Some of the younger players see John as a mentor, and he enjoys providing them with advice and support both on and off the court, embracing his role as a positive role model. | Involving: John, younger players",
+        "John faces challenges in mentoring due to individual differences among players but gains experience in adapting, motivating, and encouraging them, and finds it great to watch them develop and reach their goals. | Involving: John, younger players",
+        "John's seminars were successful, with aspiring professionals showing eagerness and motivation. | Involving: John, aspiring professionals",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding his role as a role model fulfilling and believing his experiences can help shape their future and inspire their dreams. | Involving: John, young athletes (younger players)",
+        "John started conducting seminars to assist individuals with sports and marketing. | When: Recently | Involving: John",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 63,
+      "question": "When did John organize a basketball camp for kids?",
+      "expected_answer": "summer 2023",
+      "relevant_facts": [
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 64,
+      "question": "Which month was John in Italy?",
+      "expected_answer": "December, 2023",
+      "relevant_facts": [
+        "John visited Italy last month and enjoyed the trip. | When: Last month | Involving: John",
+        "John found Italy's food, history, and architecture amazing, and bought a book there that inspires his cooking. | When: Last month | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 65,
+      "question": "What fantasy movies does Tim like?",
+      "expected_answer": "Lord of the Rings, Harry Potter, and Star Wars.",
+      "relevant_facts": [
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie from the series and watching it with his family was an amazing, magical, dream-like experience where they would get comfy with snacks and a blanket, creating special memories. | Involving: Tim, Tim's family | The movie brings back great memories and was a shared magical experience.",
+        "Tim's favorite fantasy movie is Star Wars. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim's favorite movie is Lord of the Rings. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 66,
+      "question": "What is a Star Wars book that Tim might enjoy?",
+      "expected_answer": "Star Wars: Jedi Apprentice by Judy Blundell and David Farland. It is a highly rated and immersive series about his favorite movies.",
+      "relevant_facts": [
+        "Tim is doing well in school, is busy with studies, and balances this by relaxing with books. He is currently hooked on a book he is reading. | Involving: Tim",
+        "John is aware that Tim finds peace and enjoyment in reading fantasy books. | Involving: John, Tim",
+        "Tim and John value each other's friendship and share a mutual interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim is \"totally hooked\" on Harry Potter and Game of Thrones and loves writing about them. | Involving: Tim",
+        "Tim does not surf, but finds escape, freedom, and bliss in reading great fantasy books, especially in a comfy spot, which makes him feel like he's in another world. | Involving: Tim",
+        "Tim considers books companions on his growth journey. He loves fantasy novels, specifically Harry Potter and Game of Thrones, because they transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars. | Involving: Tim",
+        "Tim is always on the lookout for new books to read. | Involving: Tim",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim loves fantasy novels because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds. | Involving: Tim",
+        "Tim is overwhelmed by assignments and exams but is trying to balance studying with his fantasy reading hobby, as he loves sinking into different magical worlds. | When: This week | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 67,
+      "question": "What would be a good hobby related to his travel dreams for Tim to pick up?",
+      "expected_answer": "Writing a travel blog.",
+      "relevant_facts": [
+        "Tim would love to explore more real Harry Potter places someday. | When: someday | Involving: Tim",
+        "The book described the Himalayan trek as tough, involving challenging terrain, altitude sickness, and bad weather, but ultimately rewarding with amazing sights, which motivated Tim. | Involving: Tim, hikers (from the story) | The challenging nature and rewarding outcome of the trek motivated Tim.",
+        "Tim feels proud of researching visa requirements, viewing it as taking initiative towards his travel dreams. | Involving: Tim | It's a step towards making his travel dreams a reality.",
+        "Tim is researching visa requirements for various places he wants to visit, finding the process overwhelming but exciting. | Involving: Tim | To make his travel dreams a reality.",
+        "Tim loves going on road trips with friends and family, exploring, hiking, and playing board games. In his free time, he enjoys curling up with a good book. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim is reading a book containing travel stories from around the world to help plan his next adventure. | Involving: Tim | To plan his next adventure.",
+        "Tim's passions are writing and reading, which help him stay motivated and push himself to get better. | Involving: Tim",
+        "Tim's inspiration for writing comes from books, movies, real-life experiences (such as reading about UK castles), and certain authors. | Involving: Tim",
+        "Tim loves traveling. | Involving: Tim",
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | When: During his semester abroad (February 2024 onwards) | Involving: Tim",
+        "Tim read an interesting book about castles in the UK and dreams of visiting them. | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as an amazing tour and like walking into a movie. | When: a few years ago | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing stories. | Involving: Tim",
+        "Tim thinks the Eiffel Tower is cool. | Involving: Tim",
+        "Tim visited a travel agency to determine the requirements for his upcoming dream trip. | When: Recently | Involving: Tim | To plan his dream trip.",
+        "Tim loves traveling to new places to experience a different kind of magic, which connects to his love for fantasy novels. | Involving: Tim (user)",
+        "Tim plans to visit more Harry Potter-related spots in the future. | When: In the future | Involving: Tim | It makes him feel like he's stepping into the books.",
+        "Tim wants to visit New York City and has added it to his travel list, excited to experience its culture and food. | Involving: Tim (user)",
+        "Tim recommends visiting castles in Europe, describing them as magical. | Involving: Tim",
+        "Tim is adding Barcelona to his travel list. | Involving: Tim | Based on John's recommendation.",
+        "Tim joined a travel club because he is interested in different cultures and countries, and is excited to meet new people and learn about what makes them unique. | Involving: Tim | Interest in different cultures and countries, and a desire to meet new people and learn about them.",
+        "Tim has been to Europe before. | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) - during his semester abroad | Involving: Tim",
+        "Tim loves experimenting with spices and is planning his first trip to Universal Studios next month, where he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim",
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on studying characters, themes, and making book recommendations. | Involving: Tim",
+        "Tim joined a group of globetrotters who share his interests. | Involving: Tim",
+        "Tim found an opportunity to write articles for an online magazine on a fantasy literature forum, and the magazine liked his ideas, allowing him to spread his love for fantasy. | Involving: Tim | Because he loves fantasy.",
+        "Tim is currently writing articles about fantasy novels for an online magazine, an activity he finds very rewarding. | Involving: Tim",
+        "Italy is on Tim's list of places he wants to visit. | Involving: Tim",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim",
+        "Tim wants to visit Paris and see the Eiffel Tower for himself. | Involving: Tim",
+        "Tim finds writing nerve-wracking but exciting, and it brings him joy. | Involving: Tim",
+        "Tim's fantasy writing is going well, and he is currently writing a fantasy novel. | Involving: Tim",
+        "Tim is working on a Harry Potter fan project and has been discussing collaborations for it. | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Last week, Tim experienced a setback while trying to write a story based on his experiences in the UK, as it did not go as he wanted. He finds this tough and is seeking advice on how to improve his storytelling. | When: Last week | Involving: Tim",
+        "Tim took a trip. | When: Summer 2023 | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, and he takes notes on her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim",
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, emphasizing its magical vibe, connection to Harry Potter, rich history, impressive architecture, and overall beauty. | When: Thursday, September 21, 2023 | Involving: Tim, John | In response to John's request for suggestions."
+      ]
+    },
+    {
+      "q_idx": 68,
+      "question": "What day did Tim get into his study abroad program?",
+      "expected_answer": "Januarty 5, 2024",
+      "relevant_facts": [
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 69,
+      "question": "When will Tim leave for Ireland?",
+      "expected_answer": "February, 2024",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | When: During his semester abroad (February 2024 onwards) | Involving: Tim",
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) - during his semester abroad | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 70,
+      "question": "Which Star Wars-related locations would Tim enjoy during his visit to Ireland?",
+      "expected_answer": "Skellig Michael, Malin Head, Loop Head, Ceann Sib\u00e9al, and Brow Head because they are Star Wars filming locations.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars. | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) - during his semester abroad | Involving: Tim",
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 71,
+      "question": "Which team did John sign with on 21 May, 2023?",
+      "expected_answer": "The Minnesota Wolves",
+      "relevant_facts": [
+        "John signed with the Minnesota Wolves team. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 72,
+      "question": "What is John's position on the team he signed with?",
+      "expected_answer": "shooting guard",
+      "relevant_facts": [
+        "John plays as a shooting guard for the Minnesota Wolves. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 73,
+      "question": "What challenge did John encounter during pre-season training?",
+      "expected_answer": "fitting into the new team's style of play",
+      "relevant_facts": [
+        "John encountered a challenge during pre-season training, which was fitting into the new team's style of play. | When: Pre-season | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 74,
+      "question": "What aspects of the Harry Potter universe will be discussed in John's fan project collaborations?",
+      "expected_answer": "characters, spells, magical creatures",
+      "relevant_facts": [
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 75,
+      "question": "What forum did Tim join recently?",
+      "expected_answer": "fantasy literature forum",
+      "relevant_facts": [
+        "Tim found an opportunity to write articles for an online magazine on a fantasy literature forum, and the magazine liked his ideas, allowing him to spread his love for fantasy. | Involving: Tim | Because he loves fantasy.",
+        "Tim joined a fantasy literature forum and had an enriching discussion about his favorite books. | When: Last night | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 76,
+      "question": "What kind of picture did Tim share as part of their Harry Potter book collection?",
+      "expected_answer": "MinaLima's creation from the Harry Potter films",
+      "relevant_facts": [
+        "Tim shared a photo of his book collection, which includes a picture from MinaLima, the creators of props for the Harry Potter films. | Involving: Tim, MinaLima | Tim loves MinaLima's work and feels it's like having a piece of the wizarding world at home."
+      ]
+    },
+    {
+      "q_idx": 77,
+      "question": "What was the highest number of points John scored in a game recently?",
+      "expected_answer": "40 points",
+      "relevant_facts": [
+        "John scored 40 points in a game, his highest ever, indicating his hard work is paying off. | When: Last week | Involving: John | It was his personal best score, showing the results of his hard work."
+      ]
+    },
+    {
+      "q_idx": 78,
+      "question": "What did John celebrate at a restaurant with teammates?",
+      "expected_answer": "a tough win",
+      "relevant_facts": [
+        "John and his teammates, though exhausted, celebrated their tough win at a restaurant, laughing and reliving the intense moments. | When: After the game last week | Involving: John, John's teammates | To celebrate their victory in a tough game."
+      ]
+    },
+    {
+      "q_idx": 79,
+      "question": "What kind of deals did John sign with Nike and Gatorade?",
+      "expected_answer": "basketball shoe and gear deal with Nike, potential sponsorship deal with Gatorade",
+      "relevant_facts": [
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 80,
+      "question": "Which city is John excited to have a game at?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "John loves Seattle for its energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John has a game scheduled in Seattle next month. | When: Next month | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 81,
+      "question": "How long has John been surfing?",
+      "expected_answer": "five years",
+      "relevant_facts": [
+        "John started surfing five years ago, had an awesome summer surfing with friends, and finds being in the water (waves, wind) super exciting and free-feeling, loving the connection to nature it provides. | When: Started five years ago | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 82,
+      "question": "How does John feel while surfing?",
+      "expected_answer": "super exciting and free-feeling",
+      "relevant_facts": [
+        "John started surfing five years ago, had an awesome summer surfing with friends, and finds being in the water (waves, wind) super exciting and free-feeling, loving the connection to nature it provides. | When: Started five years ago | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 83,
+      "question": "What kind of articles has Tim been writing about for the online magazine?",
+      "expected_answer": "different fantasy novels, characters, themes, and book recommendations",
+      "relevant_facts": [
+        "Tim is currently writing articles about fantasy novels for an online magazine, an activity he finds very rewarding. | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on studying characters, themes, and making book recommendations. | Involving: Tim",
+        "Tim is \"totally hooked\" on Harry Potter and Game of Thrones and loves writing about them. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 84,
+      "question": "Which two fantasy novels does Tim particularly enjoy writing about?",
+      "expected_answer": "Harry Potter and Game of Thrones",
+      "relevant_facts": [
+        "Tim is \"totally hooked\" on Harry Potter and Game of Thrones and loves writing about them. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 85,
+      "question": "What did Anthony and John end up playing during the charity event?",
+      "expected_answer": "an intense Harry Potter trivia contest",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd"
+      ]
+    },
+    {
+      "q_idx": 86,
+      "question": "What did John share with the person he skyped about?",
+      "expected_answer": "Characters from Harry Potter",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 87,
+      "question": "How did John describe the team bond?",
+      "expected_answer": "Awesome",
+      "relevant_facts": [
+        "John finds the strong bond with his team to be awesome and it makes all the hard work worthwhile. | Involving: John, John's team"
+      ]
+    },
+    {
+      "q_idx": 88,
+      "question": "How did John get introduced to basketball?",
+      "expected_answer": "Dad signed him up for a local league",
+      "relevant_facts": [
+        "John's dad signed him up for a local basketball league when John was ten years old. | When: When John was ten | Involving: John, John's dad"
+      ]
+    },
+    {
+      "q_idx": 89,
+      "question": "What is John's number one goal in his basketball career?",
+      "expected_answer": "Winning a championship",
+      "relevant_facts": [
+        "John's primary goal for his basketball career is to win a championship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 90,
+      "question": "What organization is John teaming up with for his charity work?",
+      "expected_answer": "A local organization helping disadvantaged kids with sports and school",
+      "relevant_facts": [
+        "John is teaming up with a local organization that assists disadvantaged kids with sports and school, aiming to use his platform for positive community impact and inspiration. | Involving: John | To have a positive impact on the community and inspire others.",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs."
+      ]
+    },
+    {
+      "q_idx": 91,
+      "question": "When did John meet back up with his teammates after his trip in August 2023?",
+      "expected_answer": "Aug 15th",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and lucky to be part of the team. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and to serve as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 92,
+      "question": "What did John's teammates give him when they met on Aug 15th?",
+      "expected_answer": "a basketball with autographs on it",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and to serve as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 93,
+      "question": "Why did John's teammates sign the basketball they gave him?",
+      "expected_answer": "to show their friendship and appreciation",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and to serve as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 94,
+      "question": "What is the main intention behind Tim wanting to attend the book conference?",
+      "expected_answer": "to learn more about literature and create a stronger bond to it",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond to it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 95,
+      "question": "What new activity has Tim started learning in August 2023?",
+      "expected_answer": "play the piano",
+      "relevant_facts": [
+        "Tim has been focusing on school, reading a bunch of fantasy books, and started learning to play the piano, finding the progress satisfying. | When: Since the last conversation (before August 21, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 96,
+      "question": "Which movie's theme is Tim's favorite to play on the piano?",
+      "expected_answer": "\"Harry Potter and the Philosopher's Stone\"",
+      "relevant_facts": [
+        "Tim loves playing different songs on the piano, with his favorite being a theme from a movie that brings back many great memories. | Involving: Tim",
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie from the series and watching it with his family was an amazing, magical, dream-like experience where they would get comfy with snacks and a blanket, creating special memories. | Involving: Tim, Tim's family | The movie brings back great memories and was a shared magical experience."
+      ]
+    },
+    {
+      "q_idx": 97,
+      "question": "What special memory does \"Harry Potter and the Philosopher's Stone\" bring to Tim?",
+      "expected_answer": "Watching it with his family",
+      "relevant_facts": [
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie from the series and watching it with his family was an amazing, magical, dream-like experience where they would get comfy with snacks and a blanket, creating special memories. | Involving: Tim, Tim's family | The movie brings back great memories and was a shared magical experience."
+      ]
+    },
+    {
+      "q_idx": 98,
+      "question": "Which movie does Tim mention they enjoy watching during Thanksgiving?",
+      "expected_answer": "\"Home Alone\"",
+      "relevant_facts": [
+        "Tim's family considers Thanksgiving special, enjoying preparing the feast, discussing gratitude, and watching movies afterward. | Involving: Tim, Tim's family",
+        "Tim's family enjoys watching \"Home Alone\", \"Elf\", and \"The Santa Clause\" during the holidays, finding them funny, festive, and heartwarming. | Involving: Tim's family"
+      ]
+    },
+    {
+      "q_idx": 99,
+      "question": "What tradition does Tim mention they love during Thanksgiving?",
+      "expected_answer": "Prepping the feast and talking about what they're thankful for",
+      "relevant_facts": [
+        "Tim's family considers Thanksgiving special, enjoying preparing the feast, discussing gratitude, and watching movies afterward. | Involving: Tim, Tim's family"
+      ]
+    },
+    {
+      "q_idx": 100,
+      "question": "How long did John and his high school basketball teammates play together?",
+      "expected_answer": "Four years",
+      "relevant_facts": [
+        "John and his friends were teammates for four years in high school. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 101,
+      "question": "How was John's experience in New York City?",
+      "expected_answer": "Amazing",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing, exciting, with great exploration and restaurants, and recommends it as a must-visit. | Involving: John",
+        "John initially struggled with the subway system during his trip to NYC but found it easy after receiving help. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 102,
+      "question": "What did John say about NYC, enticing Tim to visit?",
+      "expected_answer": "It's got so much to check out - the culture, food - you won't regret it.",
+      "relevant_facts": [
+        "John loves discovering new cities and visited New York City, finding it amazing, exciting, with great exploration and restaurants, and recommends it as a must-visit. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 103,
+      "question": "What kind of soup did John make recently?",
+      "expected_answer": "tasty soup with sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty, improvised soup using sage. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 104,
+      "question": "What spice did John add to the soup for flavor?",
+      "expected_answer": "sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty, improvised soup using sage. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 105,
+      "question": "What is Tim excited to see at Universal Studios?",
+      "expected_answer": "The Harry Potter stuff",
+      "relevant_facts": [
+        "Tim loves experimenting with spices and is planning his first trip to Universal Studios next month, where he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 106,
+      "question": "Where are John and his teammates planning to explore on a team trip?",
+      "expected_answer": "a new city",
+      "relevant_facts": [
+        "John and his teammates are currently deciding on the destination for their upcoming team trip. | When: Thursday, September 21, 2023 | Involving: John, John's teammates",
+        "John and his teammates are planning a team trip for next month to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To explore a new city and have fun.",
+        "John asked Tim for suggestions regarding the destination for his team's upcoming trip. | When: Thursday, September 21, 2023 | Involving: John, Tim | John and his teammates are still deciding on the destination.",
+        "John found Tim's suggestion of Edinburgh, Scotland, to be a great idea and plans to consider it for his team's trip. | When: Thursday, September 21, 2023 | Involving: John, Tim",
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, emphasizing its magical vibe, connection to Harry Potter, rich history, impressive architecture, and overall beauty. | When: Thursday, September 21, 2023 | Involving: Tim, John | In response to John's request for suggestions.",
+        "John confirmed he would reach out to Tim if he needs more suggestions for the team trip. | When: Thursday, September 21, 2023 | Involving: John, Tim | In response to Tim's offer for more suggestions."
+      ]
+    },
+    {
+      "q_idx": 107,
+      "question": "What city did Tim suggest to John for the team trip next month?",
+      "expected_answer": "Edinburgh, Scotland",
+      "relevant_facts": [
+        "John found Tim's suggestion of Edinburgh, Scotland, to be a great idea and plans to consider it for his team's trip. | When: Thursday, September 21, 2023 | Involving: John, Tim",
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, emphasizing its magical vibe, connection to Harry Potter, rich history, impressive architecture, and overall beauty. | When: Thursday, September 21, 2023 | Involving: Tim, John | In response to John's request for suggestions."
+      ]
+    },
+    {
+      "q_idx": 108,
+      "question": "What does John want to do after his basketball career?",
+      "expected_answer": "positively influence and inspire others, potentially start a foundation and engage in charity work",
+      "relevant_facts": [
+        "John also wants to make a difference off the court through charity or inspiring people, aiming to give back to basketball. | Involving: John | To give back to basketball, which has been great to him.",
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. | Involving: John",
+        "John held a benefit basketball game to raise money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John is teaming up with a local organization that assists disadvantaged kids with sports and school, aiming to use his platform for positive community impact and inspiration. | Involving: John | To have a positive impact on the community and inspire others.",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 109,
+      "question": "What advice did Tim give John about picking endorsements?",
+      "expected_answer": "Ensure they align with values and brand, look for companies that share the desire to make a change and help others, make sure the endorsement feels authentic",
+      "relevant_facts": [
+        "John is trying to figure out how to pick the right endorsements and asked Tim for advice. | Involving: John, Tim",
+        "Tim advised John to choose endorsements that align with his values and brand, are from companies sharing his desire to make a change and help others, and feel authentic to his followers. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 110,
+      "question": "What book recommendation did Tim give to John for the trip?",
+      "expected_answer": "A fantasy novel by Patrick Rothfuss",
+      "relevant_facts": [
+        "Tim recommended \"The Name of the Wind\" by Patrick Rothfuss, a fantasy novel, as a good book for John's trip. | Involving: Tim, John, Patrick Rothfuss"
+      ]
+    },
+    {
+      "q_idx": 111,
+      "question": "What type of venue did John and his girlfriend choose for their wedding ceremony?",
+      "expected_answer": "Greenhouse",
+      "relevant_facts": [
+        "John and his girlfriend had an amazing and emotional wedding ceremony last week in a lovely greenhouse venue, which was a smaller, more intimate gathering where necessary safety protocols were followed. | When: Last week (Saturday, September 30, 2023) | Involving: John, John's girlfriend (now wife)"
+      ]
+    },
+    {
+      "q_idx": 112,
+      "question": "What was the setting for John and his wife's first dance?",
+      "expected_answer": "Cozy restaurant",
+      "relevant_facts": [
+        "John and his wife had their first dance at a cozy restaurant, which was described as dreamy with music and candlelight. | When: Last week (Saturday, September 30, 2023) | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 113,
+      "question": "Which basketball team does Tim support?",
+      "expected_answer": "The Wolves",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 114,
+      "question": "What passion does Tim mention connects him with people from all over the world?",
+      "expected_answer": "passion for fantasy stuff",
+      "relevant_facts": [
+        "Tim had a nice chat with a Harry Potter fan in California, which he described as magical. | When: Last week | Involving: Tim, a Harry Potter fan | It was a magical experience due to shared passion.",
+        "Tim attended a Harry Potter conference in the UK last week, which he found incredible and inspiring, giving him a new lease of life. He appreciates how his passion for fantasy connects him with people worldwide. | When: Last week | Involving: Tim",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: August 9, 2023 | Involving: Tim, Harry Potter fan (Tim met in CA)"
+      ]
+    },
+    {
+      "q_idx": 115,
+      "question": "How does John describe the game season for his team?",
+      "expected_answer": "intense with tough losses and great wins",
+      "relevant_facts": [
+        "John's team had an intense season with both tough losses and great wins, and overall performed pretty well. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 116,
+      "question": "How does John say his team handles tough opponents?",
+      "expected_answer": "by backing each other up and not quitting",
+      "relevant_facts": [
+        "John's motivation during challenging times comes from his teammates' belief in him and his love for improving his skills, driven by a desire not to let them down. | Involving: John, John's teammates",
+        "John's team is driven to improve by tough opponents, and they support each other and are resilient. | Involving: John's team",
+        "John views his team as a supportive \"family away from home\" who motivate each other to improve, and he is thankful for them. They also encourage him when he's down, not just in sport but in other aspects of life, and they often hang out. | Involving: John, John's team",
+        "John finds comfort and motivation in a ball that reminds him of the bond and support from his teammates and his basketball journey, which encourages him to stay strong, give his all, and never give up. He views supportive people as a \"cheer team\" that helps through tough times. | Involving: John, his teammates | The ball and his teammates' support are significant sources of personal strength and motivation for John in his basketball endeavors."
+      ]
+    },
+    {
+      "q_idx": 117,
+      "question": "What motivates John's team to get better, according to John?",
+      "expected_answer": "facing tough opponents",
+      "relevant_facts": [
+        "John's team is driven to improve by tough opponents, and they support each other and are resilient. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 118,
+      "question": "What did John's team win at the end of the season?",
+      "expected_answer": "a trophy",
+      "relevant_facts": [
+        "John was elated about his team winning a trophy and appreciates Tim's support, stating he will continue to work hard. | Involving: John, Tim",
+        "John's team won a trophy, and John feels great that their hard work and effort were worth it. | Involving: John's team, John",
+        "Tim is proud of John and congratulates him on his team winning a trophy, acknowledging that John's hard work paid off. | Involving: Tim, John",
+        "John found winning the trophy to be awesome. | Involving: John | Expresses his positive feeling about the achievement.",
+        "John won a trophy. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 119,
+      "question": "Where did Tim capture the photography of the sunset over the mountain range?",
+      "expected_answer": "Smoky Mountains",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 120,
+      "question": "How does John feel about being seen as a mentor by some of the younger players?",
+      "expected_answer": "It feels great",
+      "relevant_facts": [
+        "Some of the younger players see John as a mentor, and he enjoys providing them with advice and support both on and off the court, embracing his role as a positive role model. | Involving: John, younger players",
+        "John is mentoring younger players on his team, finding it super rewarding and enjoying sharing his skills and knowledge, which also helps him stay involved in the game during the off-season. | Involving: John, younger players (on his team)",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding his role as a role model fulfilling and believing his experiences can help shape their future and inspire their dreams. | Involving: John, young athletes (younger players)",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is glad he could make a positive impact on their lives. | Involving: John, younger players",
+        "John faces challenges in mentoring due to individual differences among players but gains experience in adapting, motivating, and encouraging them, and finds it great to watch them develop and reach their goals. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 121,
+      "question": "What does John find rewarding about mentoring the younger players?",
+      "expected_answer": "Seeing their growth, improvement, and confidence",
+      "relevant_facts": [
+        "John faces challenges in mentoring due to individual differences among players but gains experience in adapting, motivating, and encouraging them, and finds it great to watch them develop and reach their goals. | Involving: John, younger players",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is glad he could make a positive impact on their lives. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 122,
+      "question": "What has John been able to help the younger players achieve?",
+      "expected_answer": "reach their goals",
+      "relevant_facts": [
+        "John is mentoring younger players on his team, finding it super rewarding and enjoying sharing his skills and knowledge, which also helps him stay involved in the game during the off-season. | Involving: John, younger players (on his team)",
+        "John finds it fulfilling to witness the growth, improvement, and confidence of the younger players he mentors, and is glad he could make a positive impact on their lives. | Involving: John, younger players",
+        "Some of the younger players see John as a mentor, and he enjoys providing them with advice and support both on and off the court, embracing his role as a positive role model. | Involving: John, younger players",
+        "John faces challenges in mentoring due to individual differences among players but gains experience in adapting, motivating, and encouraging them, and finds it great to watch them develop and reach their goals. | Involving: John, younger players",
+        "John feels great about having the trust and admiration of the young athletes he mentors, finding his role as a role model fulfilling and believing his experiences can help shape their future and inspire their dreams. | Involving: John, young athletes (younger players)",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 123,
+      "question": "What genre is the novel that Tim is writing?",
+      "expected_answer": "Fantasy",
+      "relevant_facts": [
+        "Tim's fantasy writing is going well, and he is currently writing a fantasy novel. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 124,
+      "question": "Who is one of Tim's sources of inspiration for writing?",
+      "expected_answer": "J.K. Rowling",
+      "relevant_facts": [
+        "Tim's inspiration for writing comes from books, movies, real-life experiences (such as reading about UK castles), and certain authors. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, and he takes notes on her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 125,
+      "question": "What J.K. Rowling quote does Tim resonate with?",
+      "expected_answer": "\"Turn on the light - happiness hides in the darkest of times.\"",
+      "relevant_facts": [
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 126,
+      "question": "What does John write on the whiteboard to help him stay motivated?",
+      "expected_answer": "motivational quotes and strategies",
+      "relevant_facts": [
+        "John writes motivational quotes and strategies on a whiteboard to help him stay focused, push through tough workouts, and remain motivated for improvement. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 127,
+      "question": "What hobby is a therapy for John when away from the court?",
+      "expected_answer": "Cooking",
+      "relevant_facts": [
+        "Cuddling up with a book is John's chill time. He also finds cooking therapeutic, a way to be creative and experiment with flavors, especially when he's away from the court. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 128,
+      "question": "What type of meal does John often cook using a slow cooker?",
+      "expected_answer": "honey garlic chicken with roasted veg",
+      "relevant_facts": [
+        "John will write down and mail his honey garlic chicken with roasted vegetables recipe to Tim. Tim is eager to try it and will inform John about the outcome. | Involving: John, Tim",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes. He also enjoys trying new recipes. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 129,
+      "question": "How will John share the honey garlic chicken recipe with the other person?",
+      "expected_answer": "write it down and mail it",
+      "relevant_facts": [
+        "John will write down and mail his honey garlic chicken with roasted vegetables recipe to Tim. Tim is eager to try it and will inform John about the outcome. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 130,
+      "question": "What was Tim's huge writing issue last week,as mentioned on November 6, 2023?",
+      "expected_answer": "He got stuck on a plot twist",
+      "relevant_facts": [
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 131,
+      "question": "What does Tim have that serves as a reminder of hard work and is his prized possession?",
+      "expected_answer": "a basketball signed by his favorite player",
+      "relevant_facts": [
+        "Tim owns a basketball signed by his favorite player, which is his prized possession and serves as a reminder of hard work. | Involving: Tim | It serves as a reminder of hard work."
+      ]
+    },
+    {
+      "q_idx": 132,
+      "question": "Why do Tim and John find LeBron inspiring?",
+      "expected_answer": "LeBron's determination and the epic block in Game 7 of the '16 Finals",
+      "relevant_facts": [
+        "John remembers and admires LeBron James's epic block in Game 7 of the 2016 Finals against Iguodala, citing this determination and heart as a reason he loves basketball. | When: 2016 Finals (Game 7) | Involving: John, LeBron James, Iguodala | The determination and heart shown are a reason he loves basketball.",
+        "Tim was inspired by LeBron James's epic block in a Finals game a few years ago, which changed the game and led to a win, reinforcing the 'never give up' mentality. | When: A few years back (2016 Finals) | Involving: Tim, LeBron James | It reinforced the 'never give up' mentality."
+      ]
+    },
+    {
+      "q_idx": 133,
+      "question": "How did John describe the views during their road trip out on the European coastline?",
+      "expected_answer": "Spectacular",
+      "relevant_facts": [
+        "John and his wife went on a road trip along the European coastline, which they found amazing with spectacular views, and it was a nice change from his regular life. | When: Recently | Involving: John, John's wife | To bond, create memories, and experience a change from regular life."
+      ]
+    },
+    {
+      "q_idx": 134,
+      "question": "What is one of Tim's favorite fantasy TV shows, as mentioned on November 11, 2023?",
+      "expected_answer": "\"That\"",
+      "relevant_facts": [
+        "Tim loves being lost in fantasy realms and considers \"That\" one of his favorite fantasy shows, viewing it as an escape. | Involving: Tim | He views it as an escape."
+      ]
+    },
+    {
+      "q_idx": 135,
+      "question": "How does Tim stay motivated during difficult study sessions?",
+      "expected_answer": "Visualizing goals and success",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 136,
+      "question": "What did Tim say about his injury on 16 November, 2023?",
+      "expected_answer": "The doctor said it's not too serious",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 137,
+      "question": "What was the setback Tim faced in his writing project on 21 November, 2023?",
+      "expected_answer": "Story based on experiences in the UK didn't go as planned",
+      "relevant_facts": [
+        "Last week, Tim experienced a setback while trying to write a story based on his experiences in the UK, as it did not go as he wanted. He finds this tough and is seeking advice on how to improve his storytelling. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 138,
+      "question": "How did John overcome his ankle injury from last season?",
+      "expected_answer": "stayed focused on recovery and worked hard to strengthen his body",
+      "relevant_facts": [
+        "Last season, John suffered a major ankle injury that required him to take time off and undergo physical therapy. | When: Last season | Involving: John",
+        "John overcame his ankle injury by staying focused on his recovery and diligently working to strengthen his body, which taught him the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John is doing physical therapy exercises daily as part of his rehabilitation to stay active after his injury. | When: Every day | Involving: John | To recover from his injury and stay active.",
+        "John is recovering from an injury, finding the process tough but maintaining a positive attitude and taking it slow. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as these poses challenge his body and mind. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worth it. | Involving: John",
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John developed a workout schedule that balances basketball practice and strength training. | Involving: John | To balance his training and stay on track.",
+        "John writes motivational quotes and strategies on a whiteboard to help him stay focused, push through tough workouts, and remain motivated for improvement. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability, and good for working out legs and core. | Involving: John",
+        "John keeps a plaque on his desk that serves as a constant physical reminder to believe in himself, trust his abilities, and stay motivated when facing obstacles. | Involving: John",
+        "John visualizes his goals and success to stay focused and motivated during difficult study sessions. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 139,
+      "question": "What motivated Tim to keep pushing himself to get better in writing and reading?",
+      "expected_answer": "Love for writing and reading",
+      "relevant_facts": [
+        "Tim's passions are writing and reading, which help him stay motivated and push himself to get better. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 140,
+      "question": "How did John overcome a mistake he made during a big game in basketball?",
+      "expected_answer": "Worked hard to get better and focused on growth",
+      "relevant_facts": [
+        "From his experience of messing up during a big basketball game and subsequently working hard to improve, John learned that resilience is key and owning up to mistakes is important for growth as a player and teammate. | Involving: John",
+        "John advises Tim to reflect on what went wrong and find ways to improve when facing challenges, drawing from his own experience on the basketball court. | Involving: John, Tim | To help Tim overcome his storytelling setback.",
+        "John cares about improving, admits mistakes, and uses them to get better, focusing on growth both on and off the court. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 141,
+      "question": "What book did John recently finish rereading that left him feeling inspired and hopeful about following dreams?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently finished rereading \"The Alchemist,\" which he found inspiring, motivating, and hopeful, making him think about following dreams and searching for personal legends. | When: Recently (prior to November 21, 2023) | Involving: John | The book inspired him to think about following dreams and personal legends, and he felt motivated and hopeful."
+      ]
+    },
+    {
+      "q_idx": 142,
+      "question": "How did \"The Alchemist\" impact John's perspective on following dreams?",
+      "expected_answer": "made him think again about following dreams and searching for personal legends",
+      "relevant_facts": [
+        "John recently finished rereading \"The Alchemist,\" which he found inspiring, motivating, and hopeful, making him think about following dreams and searching for personal legends. | When: Recently (prior to November 21, 2023) | Involving: John | The book inspired him to think about following dreams and personal legends, and he felt motivated and hopeful.",
+        "John read and loved \"The Alchemist\", finding that it made him think about life and the importance of following one's dreams. He highly recommends the book. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 143,
+      "question": "What is John trying out to improve his strength and flexibility after recovery from ankle injury?",
+      "expected_answer": "yoga",
+      "relevant_facts": [
+        "John overcame his ankle injury by staying focused on his recovery and diligently working to strengthen his body, which taught him the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worth it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 144,
+      "question": "How long does John usually hold the yoga pose he shared with Tim?",
+      "expected_answer": "30-60 seconds",
+      "relevant_facts": [
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as these poses challenge his body and mind. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability, and good for working out legs and core. | Involving: John",
+        "Tim plans to try the Warrior II yoga pose. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 145,
+      "question": "Where was the forest picture shared by John on December 1,2023 taken?",
+      "expected_answer": "near his hometown",
+      "relevant_facts": [
+        "John shared a photo of a tranquil forest located near his hometown. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 146,
+      "question": "What did Tim recently start learning in addition to being part of a travel club and working on studies?",
+      "expected_answer": "an instrument",
+      "relevant_facts": [
+        "Tim joined a travel club because he is interested in different cultures and countries, and is excited to meet new people and learn about what makes them unique. | Involving: Tim | Interest in different cultures and countries, and a desire to meet new people and learn about them.",
+        "Tim is working on his studies and recently started learning an instrument, which he finds challenging but fun, as he has always admired musicians. | Involving: Tim | Always admired musicians, finds it challenging but fun.",
+        "Tim is learning to play the violin. He is mostly interested in classical music but also keen to try jazz and film scores, finding it a great way to relax and be creative. | Involving: Tim | Finds it a great way to chill and get creative.",
+        "Tim has been focusing on school, reading a bunch of fantasy books, and started learning to play the piano, finding the progress satisfying. | When: Since the last conversation (before August 21, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 147,
+      "question": "What instrument is Tim learning to play in December 2023?",
+      "expected_answer": "violin",
+      "relevant_facts": [
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months, ongoing as of December 6, 2023 | Involving: Tim (user)",
+        "Tim is learning to play the violin. He is mostly interested in classical music but also keen to try jazz and film scores, finding it a great way to relax and be creative. | Involving: Tim | Finds it a great way to chill and get creative."
+      ]
+    },
+    {
+      "q_idx": 148,
+      "question": "How long has Tim been playing the piano for, as of December 2023?",
+      "expected_answer": "about four months",
+      "relevant_facts": [
+        "Tim has been focusing on school, reading a bunch of fantasy books, and started learning to play the piano, finding the progress satisfying. | When: Since the last conversation (before August 21, 2023) | Involving: Tim",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months, ongoing as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 149,
+      "question": "What book did Tim just finish reading on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 150,
+      "question": "Which book did Tim recommend to John as a good story on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "John plans to check out the book recommended by Tim. | Involving: John, Tim",
+        "John asked Tim for book recommendations for his trip. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 151,
+      "question": "What is the topic of discussion between John and Tim on 11 December, 2023?",
+      "expected_answer": "Academic achievements and sports successes",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 152,
+      "question": "What kind of game did John have a career-high in assists in?",
+      "expected_answer": "basketball",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 153,
+      "question": "What was John's way of dealing with doubts and stress when he was younger?",
+      "expected_answer": "practicing basketball outside for hours",
+      "relevant_facts": [
+        "Practicing basketball was John's way of dealing with doubts and stress when he was younger. | When: When John was younger | Involving: John",
+        "A picture reminds John of his younger self practicing basketball outside for hours, dreaming of playing in big games. | When: When John was younger | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 154,
+      "question": "How did John feel about the atmosphere during the big game against the rival team?",
+      "expected_answer": "electric and intense",
+      "relevant_facts": [
+        "John felt great making plays for his team, loved seeing teammates succeed from his opportunities, and found the arena atmosphere electric and the rival game intense, making it a memorable night. | When: Last Friday | Involving: John, John's teammates",
+        "John and his teammates won a tough game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates | It was a challenging game that resulted in a victory."
+      ]
+    },
+    {
+      "q_idx": 155,
+      "question": "How did John feel after being able to jog without pain?",
+      "expected_answer": "It was a huge success.",
+      "relevant_facts": [
+        "John views jogging without pain as a huge success, especially after being unable to jog for a long time. | Involving: John | He had been out for a long time.",
+        "John achieved a milestone at the gym by jogging a bit with no pain, which was a great relief. | When: Last Friday | Involving: John | It was a result of his hard work paying off."
+      ]
+    },
+    {
+      "q_idx": 156,
+      "question": "What kind of deal did John get in December?",
+      "expected_answer": "Deal with a renowned outdoor gear company",
+      "relevant_facts": [
+        "As part of his endorsement deal, John received top-notch hiking and outdoor gear and had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | When: Last week | Involving: John, photographer | Part of the endorsement deal",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 157,
+      "question": "Where was the photoshoot done for John's gear deal?",
+      "expected_answer": "In a gorgeous forest",
+      "relevant_facts": [
+        "As part of his endorsement deal, John received top-notch hiking and outdoor gear and had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | When: Last week | Involving: John, photographer | Part of the endorsement deal"
+      ]
+    },
+    {
+      "q_idx": 158,
+      "question": "In which area has John's team seen the most growth during training?",
+      "expected_answer": "Communication and bonding",
+      "relevant_facts": [
+        "John's team has experienced significant growth in communication and bonding, which has improved their performance by allowing them to understand each other's strengths and weaknesses. | Involving: John, John's team | The growth in communication and bonding has helped their performances."
+      ]
+    },
+    {
+      "q_idx": 159,
+      "question": "What type of seminars is John conducting?",
+      "expected_answer": "Sports and marketing seminars",
+      "relevant_facts": [
+        "John started conducting seminars to assist individuals with sports and marketing. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 160,
+      "question": "What activity did Tim do after reading the stories about the Himalayan trek?",
+      "expected_answer": "visited a travel agency",
+      "relevant_facts": [
+        "Tim read a story detailing a trek through the Himalayas by two hikers. | Involving: Tim, two hikers",
+        "The book described the Himalayan trek as tough, involving challenging terrain, altitude sickness, and bad weather, but ultimately rewarding with amazing sights, which motivated Tim. | Involving: Tim, hikers (from the story) | The challenging nature and rewarding outcome of the trek motivated Tim.",
+        "Tim visited a travel agency to determine the requirements for his upcoming dream trip. | When: Recently | Involving: Tim | To plan his dream trip."
+      ]
+    },
+    {
+      "q_idx": 161,
+      "question": "What is one cause that John supports with his influence and resources?",
+      "expected_answer": "youth sports and fair chances in sports",
+      "relevant_facts": [
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John is teaming up with a local organization that assists disadvantaged kids with sports and school, aiming to use his platform for positive community impact and inspiration. | Involving: John | To have a positive impact on the community and inspire others.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome and inspiring experience for him, seeing the kids' potential and growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 162,
+      "question": "What new fantasy TV series is Tim excited about?",
+      "expected_answer": "\"The Wheel of Time\"",
+      "relevant_facts": [
+        "Tim is excited to watch \"The Wheel of Time\" TV series. | Involving: Tim",
+        "A new fantasy TV series called \"The Wheel of Time\" is coming out next month. | When: next month (January 2024)"
+      ]
+    },
+    {
+      "q_idx": 163,
+      "question": "Which language is Tim learning?",
+      "expected_answer": "German",
+      "relevant_facts": [
+        "Tim is currently learning German, which he finds tough but fun. | Involving: Tim",
+        "Tim finds learning German tough but worth it, appreciating its structure, and notes it's easier than French, which he studied in high school. | Involving: Tim",
+        "Tim plans to continue his German lessons. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 164,
+      "question": "What language does Tim know besides German?",
+      "expected_answer": "Spanish",
+      "relevant_facts": [
+        "Tim finds learning German tough but worth it, appreciating its structure, and notes it's easier than French, which he studied in high school. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 165,
+      "question": "What book did Tim get in Italy that inspired him to cook?",
+      "expected_answer": "a cooking book",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 166,
+      "question": "What is John's favorite book series?",
+      "expected_answer": "Harry Potter",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd",
+        "John loves the first Harry Potter movie and owns the entire collection. | Involving: John",
+        "John has not been to any real Harry Potter places but has added visiting them to his to-do list. | Involving: John",
+        "John is a fan of Harry Potter movies. | Involving: John",
+        "John previously attended a charity event that featured Harry Potter trivia in August and enjoys being with people who are passionate about Harry Potter. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 167,
+      "question": "According to John, who is his favorite character from Lord of the Rings?",
+      "expected_answer": "Aragorn",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership qualities, bravery, selflessness, down-to-earth attitude, perseverance, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 168,
+      "question": "Why does John like Aragorn from Lord of the Rings?",
+      "expected_answer": "brave, selfless, down-to-earth attitude",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership qualities, bravery, selflessness, down-to-earth attitude, perseverance, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 169,
+      "question": "What kind of painting does John have in his room as a reminder?",
+      "expected_answer": "a painting of Aragorn",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room that serves as a reminder for him to stay true and be a leader. | Involving: John | To inspire him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 170,
+      "question": "What is the painting of Aragorn a reminder for John to be in everything he does?",
+      "expected_answer": "be a leader",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room that serves as a reminder for him to stay true and be a leader. | Involving: John | To inspire him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 171,
+      "question": "What map does Tim show to his friend John?",
+      "expected_answer": "a map of Middle-earth from LOTR",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 172,
+      "question": "Where will Tim be going for a semester abroad?",
+      "expected_answer": "Ireland",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | When: During his semester abroad (February 2024 onwards) | Involving: Tim",
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) - during his semester abroad | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 173,
+      "question": "Which city in Ireland will Tim be staying in during his semester abroad?",
+      "expected_answer": "Galway",
+      "relevant_facts": [
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) - during his semester abroad | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 174,
+      "question": "What charity event did John organize recently in 2024?",
+      "expected_answer": "benefit basketball game",
+      "relevant_facts": [
+        "John held a benefit basketball game to raise money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 175,
+      "question": "What achievement did John share with Tim in January 2024?",
+      "expected_answer": "endorsement with a popular beverage company",
+      "relevant_facts": [
+        "Tim advised John to choose endorsements that align with his values and brand, are from companies sharing his desire to make a change and help others, and feel authentic to his followers. | Involving: Tim, John",
+        "John is trying to figure out how to pick the right endorsements and asked Tim for advice. | Involving: John, Tim",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and a significant achievement."
+      ]
+    },
+    {
+      "q_idx": 176,
+      "question": "What was Johns's reaction to sealing the deal with the beverage company?",
+      "expected_answer": "crazy feeling, sense of accomplishment",
+      "relevant_facts": [
+        "John felt crazy and accomplished, believing his hard work and training hours paid off, after securing the endorsement deal. | Involving: John | The endorsement deal validated his efforts.",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and a significant achievement."
+      ]
+    },
+    {
+      "q_idx": 177,
+      "question": "Which city did John recommend to Tim in January 2024?",
+      "expected_answer": "Barcelona",
+      "relevant_facts": [
+        "Tim is adding Barcelona to his travel list. | Involving: Tim | Based on John's recommendation.",
+        "John recommends Barcelona as a must-visit city, highlighting its culture, architecture, food, and nearby beaches. | Involving: John"
+      ]
+    }
+  ],
+  "embedding_id": "bge-base-en-v1.5",
+  "bank_id": "emb_bge-base-en-v1-5_1772613813"
+}

--- a/benchmark-runner/datasets/locomo_embeddings_gt_bge-large-en-v1-5.json
+++ b/benchmark-runner/datasets/locomo_embeddings_gt_bge-large-en-v1-5.json
@@ -1,0 +1,1903 @@
+{
+  "annotations": [
+    {
+      "q_idx": 0,
+      "question": "what are John's goals with regards to his basketball career?",
+      "expected_answer": "improve shooting percentage, win a championship",
+      "relevant_facts": [
+        "John's main goal for his basketball career is to win a championship. | Involving: John",
+        "John's current goals include improving his shooting, making more of an impact on the court, being a consistent performer, helping his team, seeking more endorsements, and building his brand, as he is thinking about life after basketball. | Involving: John",
+        "John's goal is to improve his shooting percentage, and he is practicing hard to achieve it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 1,
+      "question": "What are John's goals for his career that are not related to his basketball skills?",
+      "expected_answer": "get endorsements, build his brand, do charity work",
+      "relevant_facts": [
+        "John's current goals include improving his shooting, making more of an impact on the court, being a consistent performer, helping his team, seeking more endorsements, and building his brand, as he is thinking about life after basketball. | Involving: John",
+        "John organized and held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John's benefit basketball game was a total success, attracting many people and raising money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John utilizes his contacts in the basketball industry and his marketing skills for networking to secure endorsements. | Involving: John",
+        "John intends to make a positive impact off the court through charity work or by inspiring others, motivated by his gratitude for basketball. | Involving: John",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John",
+        "John is making progress with exploring endorsements and has talked to some promising \"big names.\" | Involving: John",
+        "John is exploring endorsement opportunities with brands, feeling excited about the possibilities and rewarded by his hard work paying off. | Involving: John | He is excited about the possibilities and feels rewarded by his hard work paying off.",
+        "John is currently considering sports brands like Nike and Under Armour for collaboration, but is also open to exploring other brands that align with his values and interests. | Involving: John | He wants to collaborate with brands related to sports and those that align with his values.",
+        "John plans to keep Tim updated on which brands he chooses for endorsement. | Involving: John, Tim",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and wants to help young athletes succeed.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential.",
+        "John is collaborating with a local organization that assists disadvantaged children with sports and school, intending to leverage his platform for positive community impact and inspiration. | Involving: John",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John",
+        "John is learning how to market himself and boost his brand. | Involving: John",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. | Involving: John",
+        "John is currently in talks with Gatorade regarding a potential sponsorship. | Involving: John",
+        "John has secured endorsement deals. | Involving: John",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony",
+        "John likes Under Armour and expresses a desire to work with them in the future. | Involving: John",
+        "John is trying to figure out how to pick the right endorsements and asked Tim for advice. | Involving: John, Tim",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John spoke at a charity event. | Involving: John",
+        "John felt crazy and accomplished after signing the endorsement deal, believing his hard work and training hours were validated. | Involving: John | The endorsement deal was a significant achievement that validated his efforts.",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "Tim advised John to pick endorsements that align with his values and brand, suggesting he look for companies that share his desire to make a change and help others, ensuring authenticity to his followers. | Involving: Tim, John",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It was a dream come true and felt like all his hard work paid off.",
+        "John attended a charity event that featured Harry Potter trivia. | When: Last August | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 2,
+      "question": "What items does John collect?",
+      "expected_answer": "sneakers, fantasy movie DVDs, jerseys",
+      "relevant_facts": [
+        "John loves the first Harry Potter movie and owns the entire collection. | Involving: John",
+        "John likes to collect jerseys. | Involving: John",
+        "John loves talking to people about his sneaker collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 3,
+      "question": "Would Tim enjoy reading books by C. S. Lewis or John Greene?",
+      "expected_answer": "C. S.Lewis",
+      "relevant_facts": [
+        "John complimented Tim's Harry Potter themed Christmas tree, stating it looked amazing and that Tim knows how to create the right festive atmosphere. | Involving: John, Tim",
+        "Tim finds peace and captivation in reading fantasy books, which transport him to other worlds and stimulate his imagination. | Involving: Tim | Books provide an escape and stimulate his imagination.",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John for his trip, describing it as a book that will take him to a different world. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves for their ability to transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement for personal betterment. | Involving: Tim",
+        "Tim has been focusing on school, reading fantasy books to relieve stress, and learning to play the piano, finding satisfaction in his progress. | Involving: Tim",
+        "Tim finds fantasy books, such as Lord of the Rings, appealing because they offer an immersive experience into another world with intricate details, allowing him to explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim plans to visit more Harry Potter spots in the future, as it feels like stepping into the books. | When: In the future | Involving: Tim | It feels like stepping into the books.",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim and John are both interested in fantasy books and movies. | Involving: Tim, John",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising the author's world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "Tim and John both love fantasy books because they offer a break from reality, transport them to different worlds, and provide fun adventures. | Involving: Tim, John",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim has never been part of a sports team. He is passionate about reading, especially fantasy novels, and loves traveling to new places to experience different kinds of magic. | Involving: Tim",
+        "Tim is currently busy and overwhelmed with assignments and exams, and he is trying to find a way to balance studying with his hobby of reading fantasy novels. | When: The week of August 20-26, 2023 | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, analyzing characters and themes, and providing book recommendations. | Involving: Tim",
+        "Tim loves to read books in his free time, and the Harry Potter series is one of his favorites. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is progressing well. He finds the process nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim has heard great things about \"Dune\" but has not read it yet, and he wants to add it to his reading list. | Involving: Tim",
+        "Tim found the opportunity to write articles for an online magazine on a fantasy literature forum. | Involving: Tim",
+        "Tim loves fantasy. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim does not surf, but finds escape, freedom, and bliss in reading great fantasy books in a comfy spot, describing it as being in another world. | Involving: Tim",
+        "Tim decorated his Christmas tree himself with a Harry Potter theme and found it to be a blast. | Involving: Tim",
+        "Tim's favorite novels are fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim uses J.K. Rowling's quote \"Turn on the light - happiness hides in the darkest of times\" to maintain hope during difficult periods. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine. | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones. | Involving: Tim",
+        "Tim is visiting Universal Studios for the first time and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)",
+        "Tim visited a Harry Potter-themed place in London and took a tour a few years ago, finding the experience amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim was happy with how his Harry Potter themed Christmas tree project turned out. | Involving: Tim",
+        "Tim is working on a Harry Potter fan project and discussing collaborations for it. | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves, and is scheduled to be released in January 2024. | When: January 2024 | Involving: Tim",
+        "Tim had a nice chat with a Harry Potter fan. | When: Last week | Involving: Tim, a Harry Potter fan | It was a magical experience.",
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, highlighting its magical vibe, history, architecture, beauty, and its status as the birthplace of Harry Potter. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John | As a suggestion for John's team trip, which John and his teammates are still deciding on.",
+        "Tim is currently reading an inspiring fantasy series that focuses on the themes of friendship and loyalty. | Involving: Tim",
+        "Last week, Tim talked to a friend who is a Harry Potter fan to brainstorm ideas for his fan project. | When: last week | Involving: Tim, Tim's friend",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim's favorite movie theme to play on the piano is from \"Harry Potter and the Philosopher's Stone\", which is special to him as the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family",
+        "Tim uses reminders of the wizarding world as a way to escape reality and the daily grind. | Involving: Tim | It helps him escape.",
+        "Tim enjoys getting lost in fantasy realms as an escape, and 'That' is one of his favorite fantasy shows. | Involving: Tim",
+        "Tim's Harry Potter fan project is progressing well. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling, and takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim also likes Lord of the Rings. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, finding the experience enriching. | When: Last night | Involving: Tim | He found the talk enriching.",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, which he loves because it feels like having a piece of the wizarding world at home. | Involving: Tim | He loves their work and it provides a connection to the wizarding world.",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, which gave him a new lease of life. He values how his passion for fantasy connects him with people globally. | When: Last week (October 2-8, 2023) | Involving: Tim",
+        "Tim attended a Harry Potter party, met many people who shared his interests, and had a lot of fun. | When: Recently | Involving: Tim",
+        "Tim wore his Gryffindor scarf to the Harry Potter party and received a chocolate frog as a treat. | When: Recently | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 4,
+      "question": "What books has Tim read?",
+      "expected_answer": "Harry Potter, Game of Thrones, the Name of the Wind, The Alchemist, The Hobbit, A Dance with Dragons, and the Wheel of Time.",
+      "relevant_facts": [
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back (before November 21, 2023) | Involving: Tim | The book changed his perspective on his goals.",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John for his trip, describing it as a book that will take him to a different world. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves for their ability to transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement for personal betterment. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "Tim loves to read books in his free time, and the Harry Potter series is one of his favorites. | Involving: Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves, and is scheduled to be released in January 2024. | When: January 2024 | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising the author's world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "Tim uses J.K. Rowling's quote \"Turn on the light - happiness hides in the darkest of times\" to maintain hope during difficult periods. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling, and takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 5,
+      "question": "Based on Tim's collections, what is a shop that he would enjoy visiting in New York city?",
+      "expected_answer": "House of MinaLima",
+      "relevant_facts": [
+        "Tim is visiting Universal Studios for the first time and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)",
+        "John complimented Tim's Harry Potter themed Christmas tree, stating it looked amazing and that Tim knows how to create the right festive atmosphere. | Involving: John, Tim",
+        "Tim has added New York City to his travel list and is excited to visit, anticipating adventure, culture, and food. | Involving: Tim | John's positive description and strong recommendation of New York City.",
+        "Tim loves reading and enjoys escaping to the worlds created by books. He also has a collection of books. | Involving: Tim",
+        "Tim visited a Harry Potter-themed place in London and took a tour a few years ago, finding the experience amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim plans to visit more Harry Potter spots in the future, as it feels like stepping into the books. | When: In the future | Involving: Tim | It feels like stepping into the books.",
+        "Tim would love to explore more real Harry Potter places someday. | When: Someday | Involving: Tim",
+        "Tim decorated his Christmas tree himself with a Harry Potter theme and found it to be a blast. | Involving: Tim",
+        "Tim was happy with how his Harry Potter themed Christmas tree project turned out. | Involving: Tim",
+        "Tim showed John his book collection, which included books and a picture on a bookshelf. | Involving: Tim, John",
+        "Tim loves to read books in his free time, and the Harry Potter series is one of his favorites. | Involving: Tim",
+        "Tim uses reminders of the wizarding world as a way to escape reality and the daily grind. | Involving: Tim | It helps him escape.",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, which he loves because it feels like having a piece of the wizarding world at home. | Involving: Tim | He loves their work and it provides a connection to the wizarding world.",
+        "Tim wore his Gryffindor scarf to the Harry Potter party and received a chocolate frog as a treat. | When: Recently | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 6,
+      "question": "In which month's game did John achieve a career-high score in points?",
+      "expected_answer": "June 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 7,
+      "question": "Which geographical locations has Tim been to?",
+      "expected_answer": "California, London, the Smoky Mountains",
+      "relevant_facts": [
+        "Tim recently skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. He enjoyed connecting with someone who understood his interest. | When: Recently, around August 8, 2023 | Involving: Tim, Harry Potter fan (Tim met in CA) | Tim enjoyed connecting with someone who shared his interest in Harry Potter.",
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go well. | When: Last week | Involving: Tim",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim",
+        "Tim visited a Harry Potter-themed place in London and took a tour a few years ago, finding the experience amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, which gave him a new lease of life. He values how his passion for fantasy connects him with people globally. | When: Last week (October 2-8, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 8,
+      "question": "Which outdoor gear company likely signed up John for an endorsement deal?",
+      "expected_answer": "Under Armour",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John is currently considering sports brands like Nike and Under Armour for collaboration, but is also open to exploring other brands that align with his values and interests. | Involving: John | He wants to collaborate with brands related to sports and those that align with his values.",
+        "John likes Under Armour and expresses a desire to work with them in the future. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 9,
+      "question": "Which endorsement deals has John been offered?",
+      "expected_answer": "basketball shoes and gear deal with Nike, potential sponsorship with Gatorade, Moxie a popular beverage company, outdoor gear company",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It was a dream come true and felt like all his hard work paid off.",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is currently in talks with Gatorade regarding a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 10,
+      "question": "When was John in Seattle for a game?",
+      "expected_answer": "early August, 2023",
+      "relevant_facts": [
+        "John has a basketball game scheduled to play in Seattle next month. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 11,
+      "question": "What sports does John like besides basketball?",
+      "expected_answer": "surfing",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling as unreal. He started surfing five years ago and loves the connection to nature it provides, finding being in the water amazing, exciting, and free-feeling. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 12,
+      "question": "What year did John start surfing?",
+      "expected_answer": "2018",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling as unreal. He started surfing five years ago and loves the connection to nature it provides, finding being in the water amazing, exciting, and free-feeling. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 13,
+      "question": "What does Tim do to escape reality?",
+      "expected_answer": "Read fantasy books.",
+      "relevant_facts": [
+        "Tim loves going on road trips, exploring, hiking, and playing board games with friends and family. In his free time, he enjoys curling up with a good book to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim's favorite novels are fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim loves reading and enjoys escaping to the worlds created by books. He also has a collection of books. | Involving: Tim",
+        "Tim finds peace and captivation in reading fantasy books, which transport him to other worlds and stimulate his imagination. | Involving: Tim | Books provide an escape and stimulate his imagination.",
+        "Tim does not surf, but finds escape, freedom, and bliss in reading great fantasy books in a comfy spot, describing it as being in another world. | Involving: Tim",
+        "Tim and John both love fantasy books because they offer a break from reality, transport them to different worlds, and provide fun adventures. | Involving: Tim, John",
+        "Tim finds fantasy books, such as Lord of the Rings, appealing because they offer an immersive experience into another world with intricate details, allowing him to explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves for their ability to transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement for personal betterment. | Involving: Tim",
+        "Tim has been focusing on school, reading fantasy books to relieve stress, and learning to play the piano, finding satisfaction in his progress. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 14,
+      "question": "What kind of writing does Tim do?",
+      "expected_answer": "comments on favorite books in a fantasy literature forum, articles on fantasy novels, studying characters, themes, and making book recommendations, writing a fantasy novel",
+      "relevant_facts": [
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing great stories. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, finding the experience enriching. | When: Last night | Involving: Tim | He found the talk enriching.",
+        "John advises Tim to reflect on what went wrong and find ways to improve with his storytelling, similar to how he handles challenges on the court. | Involving: John, Tim | To help Tim overcome his storytelling setback.",
+        "Tim is writing articles about fantasy novels for an online magazine. | Involving: Tim",
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go well. | When: Last week | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is progressing well. He finds the process nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim found the opportunity to write articles for an online magazine on a fantasy literature forum. | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising the author's world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "Tim had a tough time with his English lit class but thinks his analysis on a series went ok. | Involving: Tim",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John for his trip, describing it as a book that will take him to a different world. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "John plans to add \"The Name of the Wind\" to his reading list after Tim's recommendation. | Involving: John | Tim recommended the book.",
+        "Tim experienced a significant writing issue last week, getting stuck on a plot twist, which he found frustrating but eventually overcame. | When: Last week (approx. October 30 - November 5, 2023) | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, analyzing characters and themes, and providing book recommendations. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "John asked Tim for book recommendations for his trip. | Involving: John, Tim",
+        "John plans to check out the book recommended by Tim. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 15,
+      "question": "Who is Anthony?",
+      "expected_answer": "likely John's friend, colleague or family",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony",
+        "A \"super-nerd\" won a signed Harry Potter book as a prize at the Harry Potter trivia contest John and Anthony attended. | Involving: super-nerd, John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 16,
+      "question": "After how many weeks did Tim reconnect with the fellow Harry Potter fan from California?",
+      "expected_answer": "three weeks",
+      "relevant_facts": [
+        "Tim recently skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. He enjoyed connecting with someone who understood his interest. | When: Recently, around August 8, 2023 | Involving: Tim, Harry Potter fan (Tim met in CA) | Tim enjoyed connecting with someone who shared his interest in Harry Potter."
+      ]
+    },
+    {
+      "q_idx": 17,
+      "question": "How many games has John mentioned winning?",
+      "expected_answer": "6",
+      "relevant_facts": [
+        "John's favorite game in his career was one where his team was down by 10 points in the 4th quarter, and he hit a buzzer-beater shot to win, which was a thrilling experience with an incredible atmosphere. These moments make him love basketball so much. | Involving: John, John's team | This experience contributes to John's love for basketball.",
+        "The best part of the recent basketball win for John was the camaraderie built with his team, both on and off the court. | Involving: John",
+        "John was elated about winning the trophy and appreciates Tim's support, and he plans to keep working hard. | Involving: John, Tim",
+        "John played an intense basketball game last week, which his team won by a tight score. He scored the last basket, which was an awesome and exhilarating experience with the crowd cheering. | When: Last week, around August 5, 2023 | Involving: John, John's team, crowd | It was an exhilarating experience for John to win and score the last basket.",
+        "John has a basketball trophy, indicating an achievement in the sport. | Involving: John",
+        "John's basketball team won a very close game against another team last week, with the win secured at the final buzzer. | When: Last week | Involving: John, John's team",
+        "John and his teammates celebrated their tough win at a restaurant. | When: After the game last week | Involving: John, John's teammates | To celebrate their win.",
+        "John's team won a trophy. | Involving: John's team",
+        "John and his teammates won a tough basketball game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates",
+        "John's basketball team was trailing significantly in the 4th quarter of a game last year but managed to overturn the deficit, leading to an unforgettable feeling of victory. | When: Last year (2022) | Involving: John, John's team",
+        "John's basketball team recently played a tough top team and secured a win. | When: Lately | Involving: John (member of the basketball team)"
+      ]
+    },
+    {
+      "q_idx": 18,
+      "question": "What authors has Tim read books from?",
+      "expected_answer": "J.K. Rowling, R.R. Martin, Patrick Rothfuss, Paulo Coelho, and J. R. R. Tolkien.",
+      "relevant_facts": [
+        "Tim loves to read books in his free time, and the Harry Potter series is one of his favorites. | Involving: Tim",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John for his trip, describing it as a book that will take him to a different world. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back (before November 21, 2023) | Involving: Tim | The book changed his perspective on his goals.",
+        "Tim recommended a book by Patrick Rothfuss, praising the author's world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "Tim finds fantasy books, such as Lord of the Rings, appealing because they offer an immersive experience into another world with intricate details, allowing him to explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves for their ability to transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement for personal betterment. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim also likes Lord of the Rings. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling, and takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 19,
+      "question": "What is a prominent charity organization that John might want to work with and why?",
+      "expected_answer": "Good Sports, because they work with Nike, Gatorade, and Under Armour and they aim toprovide youth sports opportunities for kids ages 3-18 in high-need communities.",
+      "relevant_facts": [
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and wants to help young athletes succeed.",
+        "John intends to make a positive impact off the court through charity work or by inspiring others, motivated by his gratitude for basketball. | Involving: John",
+        "John is collaborating with a local organization that assists disadvantaged children with sports and school, intending to leverage his platform for positive community impact and inspiration. | Involving: John",
+        "John feels great having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and believing his experiences can help shape their future and inspire them to go after their dreams. | Involving: John, young athletes",
+        "John is currently considering sports brands like Nike and Under Armour for collaboration, but is also open to exploring other brands that align with his values and interests. | Involving: John | He wants to collaborate with brands related to sports and those that align with his values.",
+        "John spoke at a charity event. | Involving: John",
+        "John likes Under Armour and expresses a desire to work with them in the future. | Involving: John",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony",
+        "John's benefit basketball game was a total success, attracting many people and raising money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "Tim advised John to pick endorsements that align with his values and brand, suggesting he look for companies that share his desire to make a change and help others, ensuring authenticity to his followers. | Involving: Tim, John",
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad to make a positive impact on their lives. He shared a picture of himself with some younger players at a recent practice. | Involving: John, younger players",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John attended a charity event that featured Harry Potter trivia. | When: Last August | Involving: John",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. | Involving: John",
+        "Some younger players see John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model. | Involving: John, younger players",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John",
+        "John finds mentoring challenging due to individual differences, but he enjoys gaining experience, adapting, motivating, and encouraging the players, and watching them develop and reach their goals. | Involving: John, players",
+        "John believes that basketball can unite people and create a positive impact. | Involving: John",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, as well as stay involved in the game during the off-season. | Involving: John, younger players",
+        "John is currently in talks with Gatorade regarding a potential sponsorship. | Involving: John",
+        "John organized and held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 20,
+      "question": "Which city was John in before traveling to Chicago?",
+      "expected_answer": "Seattle",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 21,
+      "question": "Which US cities does John mention visiting to Tim?",
+      "expected_answer": "Seattle, Chicago, New York",
+      "relevant_facts": [
+        "Tim has added New York City to his travel list and is excited to visit, anticipating adventure, culture, and food. | Involving: Tim | John's positive description and strong recommendation of New York City.",
+        "John loves discovering new cities and found his trip to New York City amazing and exciting, particularly enjoying exploring the city and trying various restaurants. He highly recommends visiting NYC. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore, describing it as super vibrant. | Involving: John",
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food, specifically recommending local seafood, and appreciates the incredible support from fans at games. | Involving: John",
+        "John initially struggled with the subway system during his NYC trip but found it easy after receiving help. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 22,
+      "question": "When did John meet with his teammates after returning from Chicago?",
+      "expected_answer": "August 15, 2023",
+      "relevant_facts": [
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John",
+        "John reunited with his teammates after his trip, feeling very welcome and happy due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates | He felt lucky to be part of the team and the atmosphere was electric."
+      ]
+    },
+    {
+      "q_idx": 23,
+      "question": "When is Tim attending a book conference?",
+      "expected_answer": "September 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month. | When: Next month (September 2023) | Involving: Tim | He hopes it will help him learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 24,
+      "question": "Where was John between August 11 and August 15 2023?",
+      "expected_answer": "Chicago",
+      "relevant_facts": [
+        "John reunited with his teammates after his trip, feeling very welcome and happy due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates | He felt lucky to be part of the team and the atmosphere was electric.",
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 25,
+      "question": "What similar sports collectible do Tim and John own?",
+      "expected_answer": "signed basketball",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, serving as a reminder of hard work. | Involving: Tim, Tim's favorite player | It reminds him of hard work.",
+        "John's teammates gave him a signed basketball as a symbol of their friendship and appreciation. | Involving: John, John's teammates | It serves as a reminder of their bond and the love they have for each other."
+      ]
+    },
+    {
+      "q_idx": 26,
+      "question": "Which TV series does Tim mention watching?",
+      "expected_answer": "That, Wheel of Time",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves, and is scheduled to be released in January 2024. | When: January 2024 | Involving: Tim",
+        "Tim enjoys getting lost in fantasy realms as an escape, and 'That' is one of his favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 27,
+      "question": "Which popular time management technique does Tim use to prepare for exams?",
+      "expected_answer": "Pomodoro technique",
+      "relevant_facts": [
+        "Tim's study trick is breaking studying into 25-minute sessions followed by 5-minute breaks for fun, which he finds less overwhelming and effective for staying on track. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 28,
+      "question": "Which popular music composer's tunes does Tim enjoy playing on the piano?",
+      "expected_answer": "John Williams",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 29,
+      "question": "What schools did John play basketball in and how many years was he with his team during high school?",
+      "expected_answer": "Middle school, high school, and college and he was with his high school team for 4 years.",
+      "relevant_facts": [
+        "John played basketball through middle and high school, earned a college scholarship, and was drafted by a team after college, achieving his childhood dream. | When: through middle and high school, after college | Involving: John",
+        "John and his friends were teammates for four years in high school. | Involving: John, John's friends (teammates)"
+      ]
+    },
+    {
+      "q_idx": 30,
+      "question": "Which cities has John been to?",
+      "expected_answer": "Seattle, Chicago, New York, and Paris.",
+      "relevant_facts": [
+        "John loves discovering new cities and found his trip to New York City amazing and exciting, particularly enjoying exploring the city and trying various restaurants. He highly recommends visiting NYC. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore, describing it as super vibrant. | Involving: John",
+        "John initially struggled with the subway system during his NYC trip but found it easy after receiving help. | Involving: John",
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food, specifically recommending local seafood, and appreciates the incredible support from fans at games. | Involving: John",
+        "John has been to Paris and loved it, finding the view from there incredible. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 31,
+      "question": "What month did Tim plan on going to Universal Studios?",
+      "expected_answer": "September, 2023",
+      "relevant_facts": [
+        "Tim is planning a trip to Universal Studios next month. | When: Next month | Involving: Tim (user)",
+        "Tim is visiting Universal Studios for the first time and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)",
+        "Tim plans to attend a book conference next month. | When: Next month (September 2023) | Involving: Tim | He hopes it will help him learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 32,
+      "question": "Which US states might Tim be in during September 2023 based on his plans of visiting Universal Studios?",
+      "expected_answer": "California or Florida",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month. | When: Next month (September 2023) | Involving: Tim | He hopes it will help him learn more about literature and create a stronger bond to it.",
+        "Tim is planning a trip to Universal Studios next month. | When: Next month | Involving: Tim (user)",
+        "Tim is visiting Universal Studios for the first time and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 33,
+      "question": "When does John plan on traveling with his team on a team trip?",
+      "expected_answer": "October, 2023",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip for next month (October 2023) to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To explore a new city and have some fun."
+      ]
+    },
+    {
+      "q_idx": 34,
+      "question": "What could John do after his basketball career?",
+      "expected_answer": "become a basketball coach since he likes giving back and leadership",
+      "relevant_facts": [
+        "John believes that basketball can unite people and create a positive impact. | Involving: John",
+        "John intends to make a positive impact off the court through charity work or by inspiring others, motivated by his gratitude for basketball. | Involving: John",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, as well as stay involved in the game during the off-season. | Involving: John, younger players",
+        "John organized and held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John feels great having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and believing his experiences can help shape their future and inspire them to go after their dreams. | Involving: John, young athletes",
+        "John's benefit basketball game was a total success, attracting many people and raising money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "John finds mentoring challenging due to individual differences, but he enjoys gaining experience, adapting, motivating, and encouraging the players, and watching them develop and reach their goals. | Involving: John, players",
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad to make a positive impact on their lives. He shared a picture of himself with some younger players at a recent practice. | Involving: John, younger players",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John",
+        "Some younger players see John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential.",
+        "John's strategies for motivating teammates involve showing care, celebrating achievements, providing constructive feedback, reminding them of the bigger goal, creating a positive environment, and giving pep talks before games. | Involving: John | In response to Tim's request for advice on motivation.",
+        "John is collaborating with a local organization that assists disadvantaged children with sports and school, intending to leverage his platform for positive community impact and inspiration. | Involving: John",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and wants to help young athletes succeed.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in. | Involving: John",
+        "John spoke at a charity event. | Involving: John",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, brave and down-to-earth attitude, perseverance, and commitment to justice. | Involving: John",
+        "John has a painting of Aragorn in his room. | Involving: John | It serves as a reminder for him to stay true and be a leader in everything he does."
+      ]
+    },
+    {
+      "q_idx": 35,
+      "question": "What outdoor activities does John enjoy?",
+      "expected_answer": "Hiking, surfing",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling as unreal. He started surfing five years ago and loves the connection to nature it provides, finding being in the water amazing, exciting, and free-feeling. | Involving: John, John's friends",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John felt immense love and happiness at his wedding, which was attended by some friends from his hiking club, despite him having only recently joined the club. | When: Last week | Involving: John, John's hiking club friends",
+        "John stumbled upon a peaceful spot while hiking, where the sound of the river was soothing and he felt at peace surrounded by rocks. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 36,
+      "question": "Who is Tim and John's favorite basketball player?",
+      "expected_answer": "LeBron James",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills and leadership he admires. | Involving: John",
+        "Tim's favorite basketball player is LeBron. | Involving: Tim, LeBron"
+      ]
+    },
+    {
+      "q_idx": 37,
+      "question": "Which week did Tim visit the UK for the Harry Potter Conference?",
+      "expected_answer": "The week before October 13th, 2023.",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, which gave him a new lease of life. He values how his passion for fantasy connects him with people globally. | When: Last week (October 2-8, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 38,
+      "question": "which country has Tim visited most frequently in his travels?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, which gave him a new lease of life. He values how his passion for fantasy connects him with people globally. | When: Last week (October 2-8, 2023) | Involving: Tim",
+        "Tim visited a Harry Potter-themed place in London and took a tour a few years ago, finding the experience amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim",
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go well. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 39,
+      "question": "What year did Tim go to the Smoky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 40,
+      "question": "Has Tim been to North Carolina and/or Tennesee states in the US?",
+      "expected_answer": "Yes",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 41,
+      "question": "What kind of fiction stories does Tim write?",
+      "expected_answer": "Fantasy stories with plot twists",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which is progressing well. He finds the process nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim experienced a significant writing issue last week, getting stuck on a plot twist, which he found frustrating but eventually overcame. | When: Last week (approx. October 30 - November 5, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 42,
+      "question": "What has John cooked?",
+      "expected_answer": "Soup, a slow cooker meal, and honey garlic chicken with roasted veg.",
+      "relevant_facts": [
+        "John will write down and mail the honey garlic chicken with roasted vegetables recipe to Tim, who is looking forward to trying it and will let John know how it turns out. | Involving: John, Tim | Tim requested the recipe after John mentioned it was a favorite.",
+        "John has been trying out cooking recipes and recently made a tasty soup. | Involving: John",
+        "John improvised the soup he made and does not have a specific recipe for it. | Involving: John",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes, and he enjoys trying new recipes. | Involving: John",
+        "John used sage as a spice in the soup he made. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 43,
+      "question": "What does John like about Lebron James?",
+      "expected_answer": "His heart, determination, skills, and leadership.",
+      "relevant_facts": [
+        "John loves basketball, particularly appreciating the determination and heart shown in moments like LeBron's epic block in the 2016 Finals. | Involving: John, LeBron | He appreciates the determination and heart shown by players.",
+        "John admires LeBron's work ethic and dedication to the game, finding him an inspiration. | Involving: John, LeBron",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John",
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills and leadership he admires. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 44,
+      "question": "When did John and his wife go on a European vacation?",
+      "expected_answer": "November, 2023.",
+      "relevant_facts": [
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 45,
+      "question": "Which country was Tim visiting in the second week of November?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 46,
+      "question": "Where was Tim in the week before 16 November 2023?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go well. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 47,
+      "question": "When did John get married at a greenhouse?",
+      "expected_answer": "last week of September 2023",
+      "relevant_facts": [
+        "John and his wife held their wedding ceremony at a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 48,
+      "question": "When did John get an ankle injury in 2023?",
+      "expected_answer": "around November 16, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 49,
+      "question": "How many times has John injured his ankle?",
+      "expected_answer": "two times",
+      "relevant_facts": [
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. | When: Last season | Involving: John",
+        "John injured himself not too long ago, which caused him to miss some basketball games and prevented him from helping his team. | When: Not too long ago | Involving: John, John's team"
+      ]
+    },
+    {
+      "q_idx": 50,
+      "question": "Which book was John reading during his recovery from an ankle injury?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John read and loved the book \"The Alchemist\". | Involving: John",
+        "John enjoys watching movies and having dinner out with friends and family. He also finds cuddling up with a book to be his chill time and considers cooking therapeutic, using it as a creative outlet away from the court. | Involving: John, John's friends, John's family",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. | When: Last season | Involving: John",
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow his dreams and search for his personal legend, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John | The book inspired him to follow his dreams and search for his personal legend, making him feel motivated and hopeful."
+      ]
+    },
+    {
+      "q_idx": 51,
+      "question": "What kind of yoga for building core strength might John benefit from?",
+      "expected_answer": "Hatha Yoga",
+      "relevant_facts": [
+        "John shared a photo of himself in the Warrior II pose and described it as beneficial for working out legs and core. | Involving: John | To demonstrate the pose and its benefits to Tim."
+      ]
+    },
+    {
+      "q_idx": 52,
+      "question": "What does John do to supplement his basketball training?",
+      "expected_answer": "Yoga, strength training",
+      "relevant_facts": [
+        "John includes strength training in his basketball routine to build muscle, increase power, prevent injuries, enhance explosiveness, and boost overall athleticism. | Involving: John | These are the benefits he seeks for his basketball performance.",
+        "John developed a workout schedule that balances basketball activities and strength training, emphasizing listening to his body and ensuring enough rest. | Involving: John | To find the right balance in his training and stay on track.",
+        "Incorporating strength training has significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, which has also boosted his confidence. | Involving: John | These improvements give him an upper hand over opponents and help him up his game.",
+        "John shared a photo of himself in the Warrior II pose and described it as beneficial for working out legs and core. | Involving: John | To demonstrate the pose and its benefits to Tim.",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it effective for building strength and stability. | Involving: John | To build strength and stability.",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John | To gain strength and flexibility.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose for balance and stability, appreciating how they challenge his body and mind. | Involving: John | He enjoys the challenge and the feeling of strength, balance, and stability.",
+        "John has experienced significant improvements from yoga, including increased strength, flexibility, focus, and balance during his workouts. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 53,
+      "question": "What other exercises can help John with his basketball performance?",
+      "expected_answer": "Sprinting, long-distance running, and boxing.",
+      "relevant_facts": [
+        "John includes strength training in his basketball routine to build muscle, increase power, prevent injuries, enhance explosiveness, and boost overall athleticism. | Involving: John | These are the benefits he seeks for his basketball performance.",
+        "Incorporating strength training has significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, which has also boosted his confidence. | Involving: John | These improvements give him an upper hand over opponents and help him up his game.",
+        "John has experienced significant improvements from yoga, including increased strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John developed a workout schedule that balances basketball activities and strength training, emphasizing listening to his body and ensuring enough rest. | Involving: John | To find the right balance in his training and stay on track.",
+        "John and his wife hosted a small get-together with friends and family to celebrate John's jogging milestone. Everyone had a ton of fun and it was good to see them again. | When: Last Friday or weekend | Involving: John, John's wife, friends, family | To celebrate John's milestone of jogging without pain.",
+        "John shared a photo of himself in the Warrior II pose and described it as beneficial for working out legs and core. | Involving: John | To demonstrate the pose and its benefits to Tim.",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it effective for building strength and stability. | Involving: John | To build strength and stability.",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John | To gain strength and flexibility.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose for balance and stability, appreciating how they challenge his body and mind. | Involving: John | He enjoys the challenge and the feeling of strength, balance, and stability.",
+        "John achieved a milestone at the gym, jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 54,
+      "question": "When did John take a trip to the Rocky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "John took a trip to the Rocky Mountains last year, finding the experience stunning and appreciating the fresh air and the world's incredibleness. | When: 2022 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 55,
+      "question": "When did John start playing professionally?",
+      "expected_answer": "May, 2023",
+      "relevant_facts": [
+        "John has been playing professional basketball for just under a year. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 56,
+      "question": "When did Tim start playing the violin?",
+      "expected_answer": "August 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 57,
+      "question": "What instruments does Tim play?",
+      "expected_answer": "piano, violin",
+      "relevant_facts": [
+        "Tim has been focusing on school, reading fantasy books to relieve stress, and learning to play the piano, finding satisfaction in his progress. | Involving: Tim",
+        "Tim is learning to play the violin. | Involving: Tim",
+        "Tim's favorite movie theme to play on the piano is from \"Harry Potter and the Philosopher's Stone\", which is special to him as the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family",
+        "Tim's favorite song to play on the piano is a theme from a movie he enjoys, which brings back great memories. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 58,
+      "question": "When did John attend the Harry Potter trivia?",
+      "expected_answer": "August 2023.",
+      "relevant_facts": [
+        "John attended a charity event that featured Harry Potter trivia. | When: Last August | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 59,
+      "question": "Which career-high performances did John achieve in 2023?",
+      "expected_answer": "highest point score, highest assist",
+      "relevant_facts": [
+        "John achieved a career-high in assists last Friday in a big basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John",
+        "John scored 40 points in a basketball game, which is his personal highest score. | When: Last week | Involving: John | It signifies his hard work paying off."
+      ]
+    },
+    {
+      "q_idx": 60,
+      "question": "When did John achieve a career-high assist performance?",
+      "expected_answer": "December 11, 2023",
+      "relevant_facts": [
+        "John achieved a career-high in assists last Friday in a big basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John",
+        "John felt great making plays for his team, enjoying seeing his teammates succeed from the opportunities he created. The electric atmosphere in the arena and the intensity of playing rivals made it a memorable night. | When: Last Friday (December 8, 2023) | Involving: John, John's teammates, John's rivals | Describes John's experience and feelings about his career-high game."
+      ]
+    },
+    {
+      "q_idx": 61,
+      "question": "What books has John read?",
+      "expected_answer": "inpsiring book on dreaming big, The Alchemist, fantasy series, non-fiction books on personal development, Dune",
+      "relevant_facts": [
+        "John finds fantasy books fuel his creativity. He also loves non-fiction books about personal development and mindset, which help him understand himself better. | Involving: John",
+        "John is currently reading an inspiring book that reminds him to keep dreaming. | Involving: John",
+        "John is currently reading \"Dune\" by Frank Herbert, which he enjoys and describes as a great story about religion and human control over ecology. He highly recommends it. | Involving: John",
+        "John read and loved the book \"The Alchemist\". | Involving: John",
+        "John is a huge fan of Lord of the Rings, appreciating its adventure, world, and characters. | Involving: John",
+        "John thinks Tim's bookshelf is awesome and considers The Hobbit one of his favorite books, along with another popular fantasy series. | Involving: John, Tim",
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow his dreams and search for his personal legend, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John | The book inspired him to follow his dreams and search for his personal legend, making him feel motivated and hopeful.",
+        "\"The Alchemist\" made John reflect on life and the importance of following one's dreams. | Involving: John",
+        "John highly recommends \"The Alchemist\". | Involving: John",
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, brave and down-to-earth attitude, perseverance, and commitment to justice. | Involving: John",
+        "John recently finished an amazing fantasy series, appreciating its twists and the author's skill in creating storylines and characters. He enjoys getting lost in fantasy worlds. | Involving: John",
+        "John has a painting of Aragorn in his room. | Involving: John | It serves as a reminder for him to stay true and be a leader in everything he does.",
+        "John appreciates maps in fantasy stories, such as the map of Middle-earth from Lord of the Rings, for helping him get lost in another world and making the exploration of different lands enjoyable. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 62,
+      "question": "What does John do to share his knowledge?",
+      "expected_answer": "gives seminars, mentors younger players.",
+      "relevant_facts": [
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, as well as stay involved in the game during the off-season. | Involving: John, younger players",
+        "John feels great having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and believing his experiences can help shape their future and inspire them to go after their dreams. | Involving: John, young athletes",
+        "John finds mentoring challenging due to individual differences, but he enjoys gaining experience, adapting, motivating, and encouraging the players, and watching them develop and reach their goals. | Involving: John, players",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John",
+        "Some younger players see John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 63,
+      "question": "When did John organize a basketball camp for kids?",
+      "expected_answer": "summer 2023",
+      "relevant_facts": [
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 64,
+      "question": "Which month was John in Italy?",
+      "expected_answer": "December, 2023",
+      "relevant_facts": [
+        "John visited Italy. | When: Last month (December 2023). | Involving: John",
+        "John found Italy's food, history, and architecture amazing, and bought a book there that gives him cooking inspiration. | When: Last month (December 2023, during his trip). | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 65,
+      "question": "What fantasy movies does Tim like?",
+      "expected_answer": "Lord of the Rings, Harry Potter, and Star Wars.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim's favorite movie theme to play on the piano is from \"Harry Potter and the Philosopher's Stone\", which is special to him as the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family",
+        "Tim also likes Lord of the Rings. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 66,
+      "question": "What is a Star Wars book that Tim might enjoy?",
+      "expected_answer": "Star Wars: Jedi Apprentice by Judy Blundell and David Farland. It is a highly rated and immersive series about his favorite movies.",
+      "relevant_facts": [
+        "Tim and John both love fantasy books because they offer a break from reality, transport them to different worlds, and provide fun adventures. | Involving: Tim, John",
+        "Tim and John are both interested in fantasy books and movies. | Involving: Tim, John",
+        "Tim loves going on road trips, exploring, hiking, and playing board games with friends and family. In his free time, he enjoys curling up with a good book to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim has been focusing on school, reading fantasy books to relieve stress, and learning to play the piano, finding satisfaction in his progress. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves for their ability to transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement for personal betterment. | Involving: Tim",
+        "Tim has never been part of a sports team. He is passionate about reading, especially fantasy novels, and loves traveling to new places to experience different kinds of magic. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim loves reading and enjoys escaping to the worlds created by books. He also has a collection of books. | Involving: Tim",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John for his trip, describing it as a book that will take him to a different world. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim's articles for the online magazine cover different fantasy novels, analyzing characters and themes, and providing book recommendations. | Involving: Tim",
+        "Tim loves fantasy. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim",
+        "Tim finds peace and captivation in reading fantasy books, which transport him to other worlds and stimulate his imagination. | Involving: Tim | Books provide an escape and stimulate his imagination.",
+        "Tim is currently writing a fantasy novel, which is progressing well. He finds the process nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim is always on the lookout for new book recommendations. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "Tim enjoys getting lost in fantasy realms as an escape, and 'That' is one of his favorite fantasy shows. | Involving: Tim",
+        "Tim's favorite novels are fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves, and is scheduled to be released in January 2024. | When: January 2024 | Involving: Tim",
+        "Tim is currently busy and overwhelmed with assignments and exams, and he is trying to find a way to balance studying with his hobby of reading fantasy novels. | When: The week of August 20-26, 2023 | Involving: Tim",
+        "Tim does not surf, but finds escape, freedom, and bliss in reading great fantasy books in a comfy spot, describing it as being in another world. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine. | Involving: Tim",
+        "Tim finds fantasy books, such as Lord of the Rings, appealing because they offer an immersive experience into another world with intricate details, allowing him to explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim found the opportunity to write articles for an online magazine on a fantasy literature forum. | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones. | Involving: Tim",
+        "Tim has heard great things about \"Dune\" but has not read it yet, and he wants to add it to his reading list. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim also likes Lord of the Rings. | Involving: Tim",
+        "Tim is currently reading an inspiring fantasy series that focuses on the themes of friendship and loyalty. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, finding the experience enriching. | When: Last night | Involving: Tim | He found the talk enriching."
+      ]
+    },
+    {
+      "q_idx": 67,
+      "question": "What would be a good hobby related to his travel dreams for Tim to pick up?",
+      "expected_answer": "Writing a travel blog.",
+      "relevant_facts": [
+        "Tim is proud of researching visa requirements, viewing it as taking initiative towards making his travel dreams a reality. | Involving: Tim | It feels like a step towards achieving his travel goals.",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones. | Involving: Tim",
+        "Tim loves going on road trips, exploring, hiking, and playing board games with friends and family. In his free time, he enjoys curling up with a good book to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim has added New York City to his travel list and is excited to visit, anticipating adventure, culture, and food. | Involving: Tim | John's positive description and strong recommendation of New York City.",
+        "Tim wants to visit Paris and see the Eiffel Tower for himself, believing that traveling is eye-opening. | Involving: Tim | Tim believes traveling is eye-opening.",
+        "Tim is excited to explore nature in Ireland during his study abroad. | When: February 2024 | Involving: Tim",
+        "Tim loves traveling. | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing great stories. | Involving: Tim",
+        "Tim has traveled to Europe before. | Involving: Tim",
+        "Tim is researching visa requirements for places he wants to visit, finding the process overwhelming but exciting. | Involving: Tim | He is taking initiative to make his travel dreams a reality.",
+        "Tim decided to add Barcelona to his travel list based on John's recommendation. | Involving: Tim | He heard great things about Barcelona and liked John's suggestion.",
+        "Tim's creativity for writing is inspired by books, movies, real-life experiences (such as reading about UK castles), and specific authors. | Involving: Tim",
+        "Tim read a story about two hikers who trekked through the Himalayas, which was described as tough but worth it due to challenging terrain, altitude sickness, and bad weather, but they saw amazing sights, motivating Tim. | Involving: Tim, two hikers | The story motivated Tim for his own travel plans.",
+        "Tim wants to visit The Cliffs of Moher in Ireland, describing them as having amazing ocean views and awesome cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim recommends visiting castles in Europe, describing them as magical. | Involving: Tim",
+        "Tim read an interesting book about castles in the UK and dreams of visiting them one day. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine. | Involving: Tim",
+        "Tim has never been part of a sports team. He is passionate about reading, especially fantasy novels, and loves traveling to new places to experience different kinds of magic. | Involving: Tim",
+        "Tim is reading stories from travelers around the world to plan his next adventure, having found a book with many such stories. | Involving: Tim | To plan his next adventure",
+        "Tim is currently writing a fantasy novel, which is progressing well. He finds the process nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim joined a group of globetrotters who share his interests. | When: Since Tim and John last talked (before January 2, 2024). | Involving: Tim, globetrotters",
+        "Tim is planning a trip to Universal Studios next month. | When: Next month | Involving: Tim (user)",
+        "Tim joined a travel club. | Involving: Tim | He is interested in different cultures and countries and is excited to meet new people and learn about what makes them unique.",
+        "Tim plans to visit more Harry Potter spots in the future, as it feels like stepping into the books. | When: In the future | Involving: Tim | It feels like stepping into the books.",
+        "Tim's articles for the online magazine cover different fantasy novels, analyzing characters and themes, and providing book recommendations. | Involving: Tim",
+        "Tim visited a Harry Potter-themed place in London and took a tour a few years ago, finding the experience amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim is visiting Universal Studios for the first time and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)",
+        "Tim would love to explore more real Harry Potter places someday. | When: Someday | Involving: Tim",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | When: Tuesday, December 26, 2023 | Involving: Tim | To learn requirements for his dream trip",
+        "Tim's passions are writing and reading, which help him stay motivated and improve. | Involving: Tim",
+        "Italy is on Tim's list of places to visit. | Involving: Tim",
+        "John advises Tim to reflect on what went wrong and find ways to improve with his storytelling, similar to how he handles challenges on the court. | Involving: John, Tim | To help Tim overcome his storytelling setback.",
+        "Tim plans to stay in Galway, Ireland, during his study abroad semester, noting its vibrant atmosphere, arts, and Irish music scene. | When: February 2024 | Involving: Tim",
+        "Tim found the opportunity to write articles for an online magazine on a fantasy literature forum. | Involving: Tim",
+        "Tim had a tough time with his English lit class but thinks his analysis on a series went ok. | Involving: Tim",
+        "Tim has always been interested in different cultures and countries. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling, and takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim offered to provide tips for visiting Harry Potter places to John. | Involving: Tim (to John)",
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go well. | When: Last week | Involving: Tim",
+        "Tim believes that creating a constructive atmosphere, setting an example through hard work, and using personal stories are effective ways to inspire others. | Involving: Tim (user) | Reflecting on John's advice on motivation.",
+        "Tim plans to update John about his Universal Studios trip. | Involving: Tim (user), John",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim",
+        "Tim took a trip last summer. | When: Summer 2023 | Involving: Tim",
+        "Tim was accepted into a study abroad program and plans to go to Ireland for a semester next month. | When: Acceptance on Friday, January 5, 2024; trip in February 2024 | Involving: Tim",
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, highlighting its magical vibe, history, architecture, beauty, and its status as the birthplace of Harry Potter. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John | As a suggestion for John's team trip, which John and his teammates are still deciding on.",
+        "Tim experienced a significant writing issue last week, getting stuck on a plot twist, which he found frustrating but eventually overcame. | When: Last week (approx. October 30 - November 5, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 68,
+      "question": "What day did Tim get into his study abroad program?",
+      "expected_answer": "Januarty 5, 2024",
+      "relevant_facts": [
+        "Tim was accepted into a study abroad program and plans to go to Ireland for a semester next month. | When: Acceptance on Friday, January 5, 2024; trip in February 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 69,
+      "question": "When will Tim leave for Ireland?",
+      "expected_answer": "February, 2024",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland during his study abroad. | When: February 2024 | Involving: Tim",
+        "Tim plans to stay in Galway, Ireland, during his study abroad semester, noting its vibrant atmosphere, arts, and Irish music scene. | When: February 2024 | Involving: Tim",
+        "Tim wants to visit The Cliffs of Moher in Ireland, describing them as having amazing ocean views and awesome cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim was accepted into a study abroad program and plans to go to Ireland for a semester next month. | When: Acceptance on Friday, January 5, 2024; trip in February 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 70,
+      "question": "Which Star Wars-related locations would Tim enjoy during his visit to Ireland?",
+      "expected_answer": "Skellig Michael, Malin Head, Loop Head, Ceann Sib\u00e9al, and Brow Head because they are Star Wars filming locations.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim was accepted into a study abroad program and plans to go to Ireland for a semester next month. | When: Acceptance on Friday, January 5, 2024; trip in February 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 71,
+      "question": "Which team did John sign with on 21 May, 2023?",
+      "expected_answer": "The Minnesota Wolves",
+      "relevant_facts": [
+        "John signed with the Minnesota Wolves team. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 72,
+      "question": "What is John's position on the team he signed with?",
+      "expected_answer": "shooting guard",
+      "relevant_facts": [
+        "John is a shooting guard for the Minnesota Wolves. | Involving: John",
+        "John signed with the Minnesota Wolves team. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 73,
+      "question": "What challenge did John encounter during pre-season training?",
+      "expected_answer": "fitting into the new team's style of play",
+      "relevant_facts": [
+        "John found fitting into the Minnesota Wolves' style of play challenging during pre-season training. | When: pre-season | Involving: John, Minnesota Wolves"
+      ]
+    },
+    {
+      "q_idx": 74,
+      "question": "What aspects of the Harry Potter universe will be discussed in John's fan project collaborations?",
+      "expected_answer": "characters, spells, magical creatures",
+      "relevant_facts": [
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 75,
+      "question": "What forum did Tim join recently?",
+      "expected_answer": "fantasy literature forum",
+      "relevant_facts": [
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books, finding the experience enriching. | When: Last night | Involving: Tim | He found the talk enriching."
+      ]
+    },
+    {
+      "q_idx": 76,
+      "question": "What kind of picture did Tim share as part of their Harry Potter book collection?",
+      "expected_answer": "MinaLima's creation from the Harry Potter films",
+      "relevant_facts": [
+        "Tim showed John his book collection, which included books and a picture on a bookshelf. | Involving: Tim, John",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, which he loves because it feels like having a piece of the wizarding world at home. | Involving: Tim | He loves their work and it provides a connection to the wizarding world."
+      ]
+    },
+    {
+      "q_idx": 77,
+      "question": "What was the highest number of points John scored in a game recently?",
+      "expected_answer": "40 points",
+      "relevant_facts": [
+        "John scored 40 points in a basketball game, which is his personal highest score. | When: Last week | Involving: John | It signifies his hard work paying off."
+      ]
+    },
+    {
+      "q_idx": 78,
+      "question": "What did John celebrate at a restaurant with teammates?",
+      "expected_answer": "a tough win",
+      "relevant_facts": [
+        "John and his teammates celebrated their tough win at a restaurant. | When: After the game last week | Involving: John, John's teammates | To celebrate their win."
+      ]
+    },
+    {
+      "q_idx": 79,
+      "question": "What kind of deals did John sign with Nike and Gatorade?",
+      "expected_answer": "basketball shoe and gear deal with Nike, potential sponsorship deal with Gatorade",
+      "relevant_facts": [
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is currently in talks with Gatorade regarding a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 80,
+      "question": "Which city is John excited to have a game at?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "John loves Seattle for its energy, diversity, awesome food, specifically recommending local seafood, and appreciates the incredible support from fans at games. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore, describing it as super vibrant. | Involving: John",
+        "John has a basketball game scheduled to play in Seattle next month. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 81,
+      "question": "How long has John been surfing?",
+      "expected_answer": "five years",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling as unreal. He started surfing five years ago and loves the connection to nature it provides, finding being in the water amazing, exciting, and free-feeling. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 82,
+      "question": "How does John feel while surfing?",
+      "expected_answer": "super exciting and free-feeling",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling as unreal. He started surfing five years ago and loves the connection to nature it provides, finding being in the water amazing, exciting, and free-feeling. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 83,
+      "question": "What kind of articles has Tim been writing about for the online magazine?",
+      "expected_answer": "different fantasy novels, characters, themes, and book recommendations",
+      "relevant_facts": [
+        "Tim's articles for the online magazine cover different fantasy novels, analyzing characters and themes, and providing book recommendations. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine. | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 84,
+      "question": "Which two fantasy novels does Tim particularly enjoy writing about?",
+      "expected_answer": "Harry Potter and Game of Thrones",
+      "relevant_facts": [
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 85,
+      "question": "What did Anthony and John end up playing during the charity event?",
+      "expected_answer": "an intense Harry Potter trivia contest",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony",
+        "A \"super-nerd\" won a signed Harry Potter book as a prize at the Harry Potter trivia contest John and Anthony attended. | Involving: super-nerd, John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 86,
+      "question": "What did John share with the person he skyped about?",
+      "expected_answer": "Characters from Harry Potter",
+      "relevant_facts": [
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 87,
+      "question": "How did John describe the team bond?",
+      "expected_answer": "Awesome",
+      "relevant_facts": [
+        "John finds it awesome to have his team to push them all. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 88,
+      "question": "How did John get introduced to basketball?",
+      "expected_answer": "Dad signed him up for a local league",
+      "relevant_facts": [
+        "John's dad signed him up for a local basketball league when John was ten years old. | When: when John was ten years old | Involving: John, John's dad"
+      ]
+    },
+    {
+      "q_idx": 89,
+      "question": "What is John's number one goal in his basketball career?",
+      "expected_answer": "Winning a championship",
+      "relevant_facts": [
+        "John's main goal for his basketball career is to win a championship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 90,
+      "question": "What organization is John teaming up with for his charity work?",
+      "expected_answer": "A local organization helping disadvantaged kids with sports and school",
+      "relevant_facts": [
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and wants to help young athletes succeed.",
+        "John is collaborating with a local organization that assists disadvantaged children with sports and school, intending to leverage his platform for positive community impact and inspiration. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 91,
+      "question": "When did John meet back up with his teammates after his trip in August 2023?",
+      "expected_answer": "Aug 15th",
+      "relevant_facts": [
+        "John reunited with his teammates after his trip, feeling very welcome and happy due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates | He felt lucky to be part of the team and the atmosphere was electric."
+      ]
+    },
+    {
+      "q_idx": 92,
+      "question": "What did John's teammates give him when they met on Aug 15th?",
+      "expected_answer": "a basketball with autographs on it",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a symbol of their friendship and appreciation. | Involving: John, John's teammates | It serves as a reminder of their bond and the love they have for each other.",
+        "John reunited with his teammates after his trip, feeling very welcome and happy due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates | He felt lucky to be part of the team and the atmosphere was electric."
+      ]
+    },
+    {
+      "q_idx": 93,
+      "question": "Why did John's teammates sign the basketball they gave him?",
+      "expected_answer": "to show their friendship and appreciation",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a symbol of their friendship and appreciation. | Involving: John, John's teammates | It serves as a reminder of their bond and the love they have for each other."
+      ]
+    },
+    {
+      "q_idx": 94,
+      "question": "What is the main intention behind Tim wanting to attend the book conference?",
+      "expected_answer": "to learn more about literature and create a stronger bond to it",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month. | When: Next month (September 2023) | Involving: Tim | He hopes it will help him learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 95,
+      "question": "What new activity has Tim started learning in August 2023?",
+      "expected_answer": "play the piano",
+      "relevant_facts": [
+        "Tim has been focusing on school, reading fantasy books to relieve stress, and learning to play the piano, finding satisfaction in his progress. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 96,
+      "question": "Which movie's theme is Tim's favorite to play on the piano?",
+      "expected_answer": "\"Harry Potter and the Philosopher's Stone\"",
+      "relevant_facts": [
+        "Tim's favorite movie theme to play on the piano is from \"Harry Potter and the Philosopher's Stone\", which is special to him as the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family"
+      ]
+    },
+    {
+      "q_idx": 97,
+      "question": "What special memory does \"Harry Potter and the Philosopher's Stone\" bring to Tim?",
+      "expected_answer": "Watching it with his family",
+      "relevant_facts": [
+        "Tim's favorite movie theme to play on the piano is from \"Harry Potter and the Philosopher's Stone\", which is special to him as the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family"
+      ]
+    },
+    {
+      "q_idx": 98,
+      "question": "Which movie does Tim mention they enjoy watching during Thanksgiving?",
+      "expected_answer": "\"Home Alone\"",
+      "relevant_facts": [
+        "Tim and his family consider Thanksgiving special, enjoying preparing the feast, discussing gratitude, and watching movies. | Involving: Tim (and his family)",
+        "Tim and his family enjoy watching \"Home Alone\" during Thanksgiving, as it brings lots of laughs. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 99,
+      "question": "What tradition does Tim mention they love during Thanksgiving?",
+      "expected_answer": "Prepping the feast and talking about what they're thankful for",
+      "relevant_facts": [
+        "Tim and his family consider Thanksgiving special, enjoying preparing the feast, discussing gratitude, and watching movies. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 100,
+      "question": "How long did John and his high school basketball teammates play together?",
+      "expected_answer": "Four years",
+      "relevant_facts": [
+        "John and his friends were teammates for four years in high school. | Involving: John, John's friends (teammates)"
+      ]
+    },
+    {
+      "q_idx": 101,
+      "question": "How was John's experience in New York City?",
+      "expected_answer": "Amazing",
+      "relevant_facts": [
+        "John loves discovering new cities and found his trip to New York City amazing and exciting, particularly enjoying exploring the city and trying various restaurants. He highly recommends visiting NYC. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 102,
+      "question": "What did John say about NYC, enticing Tim to visit?",
+      "expected_answer": "It's got so much to check out - the culture, food - you won't regret it.",
+      "relevant_facts": [
+        "Tim has added New York City to his travel list and is excited to visit, anticipating adventure, culture, and food. | Involving: Tim | John's positive description and strong recommendation of New York City.",
+        "John loves discovering new cities and found his trip to New York City amazing and exciting, particularly enjoying exploring the city and trying various restaurants. He highly recommends visiting NYC. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 103,
+      "question": "What kind of soup did John make recently?",
+      "expected_answer": "tasty soup with sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty soup. | Involving: John",
+        "John used sage as a spice in the soup he made. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 104,
+      "question": "What spice did John add to the soup for flavor?",
+      "expected_answer": "sage",
+      "relevant_facts": [
+        "John used sage as a spice in the soup he made. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 105,
+      "question": "What is Tim excited to see at Universal Studios?",
+      "expected_answer": "The Harry Potter stuff",
+      "relevant_facts": [
+        "Tim is visiting Universal Studios for the first time and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 106,
+      "question": "Where are John and his teammates planning to explore on a team trip?",
+      "expected_answer": "a new city",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip for next month (October 2023) to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To explore a new city and have some fun."
+      ]
+    },
+    {
+      "q_idx": 107,
+      "question": "What city did Tim suggest to John for the team trip next month?",
+      "expected_answer": "Edinburgh, Scotland",
+      "relevant_facts": [
+        "John found Tim's suggestion of Edinburgh, Scotland, a great idea and will consider it for his team trip. | When: Thursday, September 21, 2023 | Involving: John, Tim (assistant)",
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, highlighting its magical vibe, history, architecture, beauty, and its status as the birthplace of Harry Potter. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John | As a suggestion for John's team trip, which John and his teammates are still deciding on."
+      ]
+    },
+    {
+      "q_idx": 108,
+      "question": "What does John want to do after his basketball career?",
+      "expected_answer": "positively influence and inspire others, potentially start a foundation and engage in charity work",
+      "relevant_facts": [
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John",
+        "John intends to make a positive impact off the court through charity work or by inspiring others, motivated by his gratitude for basketball. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 109,
+      "question": "What advice did Tim give John about picking endorsements?",
+      "expected_answer": "Ensure they align with values and brand, look for companies that share the desire to make a change and help others, make sure the endorsement feels authentic",
+      "relevant_facts": [
+        "Tim advised John to pick endorsements that align with his values and brand, suggesting he look for companies that share his desire to make a change and help others, ensuring authenticity to his followers. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 110,
+      "question": "What book recommendation did Tim give to John for the trip?",
+      "expected_answer": "A fantasy novel by Patrick Rothfuss",
+      "relevant_facts": [
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John for his trip, describing it as a book that will take him to a different world. | Involving: Tim, John, Patrick Rothfuss",
+        "John asked Tim for book recommendations for his trip. | Involving: John, Tim",
+        "John plans to add \"The Name of the Wind\" to his reading list after Tim's recommendation. | Involving: John | Tim recommended the book.",
+        "John plans to check out the recommended book for his trip and shared a photo of his bookshelf, which contains books he has read and enjoyed. | Involving: John",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, as well as its strong world-building and character development. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising the author's world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "John likes fantasy novels with strong characters and good world-building, and plans to add \"The Name of the Wind\" to his reading list. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 111,
+      "question": "What type of venue did John and his girlfriend choose for their wedding ceremony?",
+      "expected_answer": "Greenhouse",
+      "relevant_facts": [
+        "John and his wife held their wedding ceremony at a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 112,
+      "question": "What was the setting for John and his wife's first dance?",
+      "expected_answer": "Cozy restaurant",
+      "relevant_facts": [
+        "John and his wife had their first dance at a cozy restaurant, which was described as dreamy with music and candlelight. | When: Last week | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 113,
+      "question": "Which basketball team does Tim support?",
+      "expected_answer": "The Wolves",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 114,
+      "question": "What passion does Tim mention connects him with people from all over the world?",
+      "expected_answer": "passion for fantasy stuff",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, which gave him a new lease of life. He values how his passion for fantasy connects him with people globally. | When: Last week (October 2-8, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 115,
+      "question": "How does John describe the game season for his team?",
+      "expected_answer": "intense with tough losses and great wins",
+      "relevant_facts": [
+        "John's team had an intense season with both tough losses and great wins, performing pretty well overall. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 116,
+      "question": "How does John say his team handles tough opponents?",
+      "expected_answer": "by backing each other up and not quitting",
+      "relevant_facts": [
+        "John's team is driven to improve by facing tough opponents, and they support each other and don't quit. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 117,
+      "question": "What motivates John's team to get better, according to John?",
+      "expected_answer": "facing tough opponents",
+      "relevant_facts": [
+        "John's team is driven to improve by facing tough opponents, and they support each other and don't quit. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 118,
+      "question": "What did John's team win at the end of the season?",
+      "expected_answer": "a trophy",
+      "relevant_facts": [
+        "John's team won a trophy. | Involving: John's team",
+        "John was elated about winning the trophy and appreciates Tim's support, and he plans to keep working hard. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 119,
+      "question": "Where did Tim capture the photography of the sunset over the mountain range?",
+      "expected_answer": "Smoky Mountains",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 120,
+      "question": "How does John feel about being seen as a mentor by some of the younger players?",
+      "expected_answer": "It feels great",
+      "relevant_facts": [
+        "Some younger players see John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model. | Involving: John, younger players",
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad to make a positive impact on their lives. He shared a picture of himself with some younger players at a recent practice. | Involving: John, younger players",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, as well as stay involved in the game during the off-season. | Involving: John, younger players",
+        "John finds mentoring challenging due to individual differences, but he enjoys gaining experience, adapting, motivating, and encouraging the players, and watching them develop and reach their goals. | Involving: John, players",
+        "John feels great having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and believing his experiences can help shape their future and inspire them to go after their dreams. | Involving: John, young athletes",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 121,
+      "question": "What does John find rewarding about mentoring the younger players?",
+      "expected_answer": "Seeing their growth, improvement, and confidence",
+      "relevant_facts": [
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad to make a positive impact on their lives. He shared a picture of himself with some younger players at a recent practice. | Involving: John, younger players",
+        "John finds mentoring challenging due to individual differences, but he enjoys gaining experience, adapting, motivating, and encouraging the players, and watching them develop and reach their goals. | Involving: John, players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 122,
+      "question": "What has John been able to help the younger players achieve?",
+      "expected_answer": "reach their goals",
+      "relevant_facts": [
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad to make a positive impact on their lives. He shared a picture of himself with some younger players at a recent practice. | Involving: John, younger players",
+        "Some younger players see John as a mentor, which he finds rewarding. He provides them with advice and support both on and off the court and enjoys being a positive role model. | Involving: John, younger players",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, as well as stay involved in the game during the off-season. | Involving: John, younger players",
+        "John finds mentoring challenging due to individual differences, but he enjoys gaining experience, adapting, motivating, and encouraging the players, and watching them develop and reach their goals. | Involving: John, players",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and wants to help young athletes succeed.",
+        "John feels great having the trust and admiration of the young athletes he mentors, finding it fulfilling to be a role model and believing his experiences can help shape their future and inspire them to go after their dreams. | Involving: John, young athletes",
+        "John is collaborating with a local organization that assists disadvantaged children with sports and school, intending to leverage his platform for positive community impact and inspiration. | Involving: John",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 123,
+      "question": "What genre is the novel that Tim is writing?",
+      "expected_answer": "Fantasy",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which is progressing well. He finds the process nerve-wracking but exciting and joyful. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 124,
+      "question": "Who is one of Tim's sources of inspiration for writing?",
+      "expected_answer": "J.K. Rowling",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling, and takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 125,
+      "question": "What J.K. Rowling quote does Tim resonate with?",
+      "expected_answer": "\"Turn on the light - happiness hides in the darkest of times.\"",
+      "relevant_facts": [
+        "Tim uses J.K. Rowling's quote \"Turn on the light - happiness hides in the darkest of times\" to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 126,
+      "question": "What does John write on the whiteboard to help him stay motivated?",
+      "expected_answer": "motivational quotes and strategies",
+      "relevant_facts": [
+        "John uses a whiteboard with motivational quotes and strategies to stay focused and motivated during tough workouts, aiding his improvement. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 127,
+      "question": "What hobby is a therapy for John when away from the court?",
+      "expected_answer": "Cooking",
+      "relevant_facts": [
+        "John enjoys watching movies and having dinner out with friends and family. He also finds cuddling up with a book to be his chill time and considers cooking therapeutic, using it as a creative outlet away from the court. | Involving: John, John's friends, John's family"
+      ]
+    },
+    {
+      "q_idx": 128,
+      "question": "What type of meal does John often cook using a slow cooker?",
+      "expected_answer": "honey garlic chicken with roasted veg",
+      "relevant_facts": [
+        "John will write down and mail the honey garlic chicken with roasted vegetables recipe to Tim, who is looking forward to trying it and will let John know how it turns out. | Involving: John, Tim | Tim requested the recipe after John mentioned it was a favorite.",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes, and he enjoys trying new recipes. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 129,
+      "question": "How will John share the honey garlic chicken recipe with the other person?",
+      "expected_answer": "write it down and mail it",
+      "relevant_facts": [
+        "John will write down and mail the honey garlic chicken with roasted vegetables recipe to Tim, who is looking forward to trying it and will let John know how it turns out. | Involving: John, Tim | Tim requested the recipe after John mentioned it was a favorite."
+      ]
+    },
+    {
+      "q_idx": 130,
+      "question": "What was Tim's huge writing issue last week,as mentioned on November 6, 2023?",
+      "expected_answer": "He got stuck on a plot twist",
+      "relevant_facts": [
+        "Tim experienced a significant writing issue last week, getting stuck on a plot twist, which he found frustrating but eventually overcame. | When: Last week (approx. October 30 - November 5, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 131,
+      "question": "What does Tim have that serves as a reminder of hard work and is his prized possession?",
+      "expected_answer": "a basketball signed by his favorite player",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, serving as a reminder of hard work. | Involving: Tim, Tim's favorite player | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 132,
+      "question": "Why do Tim and John find LeBron inspiring?",
+      "expected_answer": "LeBron's determination and the epic block in Game 7 of the '16 Finals",
+      "relevant_facts": [
+        "John admires LeBron's work ethic and dedication to the game, finding him an inspiration. | Involving: John, LeBron",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John",
+        "John loves basketball, particularly appreciating the determination and heart shown in moments like LeBron's epic block in the 2016 Finals. | Involving: John, LeBron | He appreciates the determination and heart shown by players.",
+        "Tim was inspired by LeBron's epic block in Game 7 of the 2016 Finals, where LeBron chased down Iguodala and pinned the ball, which was a game-changing moment leading to a win. | When: June 19, 2016 (Game 7 of the 2016 NBA Finals) | Involving: Tim, LeBron, Iguodala | It was an inspiration to never give up.",
+        "Tim loves sports and admires the determination and heart of players, particularly in moments like LeBron's epic block. | Involving: Tim, players, LeBron"
+      ]
+    },
+    {
+      "q_idx": 133,
+      "question": "How did John describe the views during their road trip out on the European coastline?",
+      "expected_answer": "Spectacular",
+      "relevant_facts": [
+        "John and his wife took a road trip along the European coastline, enjoying spectacular views, bonding, creating memories, and appreciating the change from their regular life. | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 134,
+      "question": "What is one of Tim's favorite fantasy TV shows, as mentioned on November 11, 2023?",
+      "expected_answer": "\"That\"",
+      "relevant_facts": [
+        "Tim enjoys getting lost in fantasy realms as an escape, and 'That' is one of his favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 135,
+      "question": "How does Tim stay motivated during difficult study sessions?",
+      "expected_answer": "Visualizing goals and success",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 136,
+      "question": "What did Tim say about his injury on 16 November, 2023?",
+      "expected_answer": "The doctor said it's not too serious",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 137,
+      "question": "What was the setback Tim faced in his writing project on 21 November, 2023?",
+      "expected_answer": "Story based on experiences in the UK didn't go as planned",
+      "relevant_facts": [
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go well. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 138,
+      "question": "How did John overcome his ankle injury from last season?",
+      "expected_answer": "stayed focused on recovery and worked hard to strengthen his body",
+      "relevant_facts": [
+        "John overcame his ankle injury by staying focused on recovery and strengthening his body, which taught him the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John is actively trying to stay active and performs daily physical therapy exercises as part of his rehabilitation from his injury. | When: Every day | Involving: John | To recover from his injury",
+        "John plans to keep pushing and staying positive in his recovery and fitness journey. | Involving: John",
+        "John achieved a milestone at the gym, jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John",
+        "John uses a whiteboard with motivational quotes and strategies to stay focused and motivated during tough workouts, aiding his improvement. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 139,
+      "question": "What motivated Tim to keep pushing himself to get better in writing and reading?",
+      "expected_answer": "Love for writing and reading",
+      "relevant_facts": [
+        "Tim's passions are writing and reading, which help him stay motivated and improve. | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing great stories. | Involving: Tim",
+        "Tim has never been part of a sports team. He is passionate about reading, especially fantasy novels, and loves traveling to new places to experience different kinds of magic. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 140,
+      "question": "How did John overcome a mistake he made during a big game in basketball?",
+      "expected_answer": "Worked hard to get better and focused on growth",
+      "relevant_facts": [
+        "John is comforted and motivated by a basketball that reminds him of his teammates' bond and support, and his journey in basketball. This encourages him to stay strong, give his all, and never give up, viewing supportive people as a \"cheer team.\" | Involving: John, John's teammates | The ball and support serve as a powerful reminder and motivator for his basketball journey and personal strength.",
+        "John learned that resilience and owning up to mistakes are important from his experience of messing up in a big basketball game. | Involving: John",
+        "John is passionate about basketball, and this passion keeps him motivated during tough times. | Involving: John",
+        "John messed up during a big basketball game, which was hard for him to accept. | Involving: John",
+        "John loves playing professional basketball because it provides a constant challenge, fosters personal growth, allows him to achieve goals, and gives him a great sense of satisfaction and purpose through teamwork and fan support. | Involving: John",
+        "John's teammates offer him consistent support and encouragement, even when he makes errors. | Involving: John's teammates, John",
+        "John gives his all every time he is on the basketball court. | Involving: John",
+        "Basketball is very important to John; he practices and trains daily to stay in shape and improve, considering it his passion. | Involving: John",
+        "John advises Tim to reflect on what went wrong and find ways to improve with his storytelling, similar to how he handles challenges on the court. | Involving: John, Tim | To help Tim overcome his storytelling setback.",
+        "John finds his journey as a professional basketball player to be great, involving challenges and growth. | Involving: John",
+        "John is motivated by his teammates' belief in him and his passion for improving his skills, driven by a desire not to disappoint his teammates. | Involving: John, John's teammates",
+        "John uses a whiteboard with motivational quotes and strategies to stay focused and motivated during tough workouts, aiding his improvement. | Involving: John",
+        "John keeps a plaque on his desk as a physical reminder to believe in himself, which helps him trust his abilities, face obstacles, and stay motivated. | Involving: John",
+        "John plans to keep pushing and staying positive in his recovery and fitness journey. | Involving: John",
+        "John plans to keep pushing forward. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 141,
+      "question": "What book did John recently finish rereading that left him feeling inspired and hopeful about following dreams?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow his dreams and search for his personal legend, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John | The book inspired him to follow his dreams and search for his personal legend, making him feel motivated and hopeful."
+      ]
+    },
+    {
+      "q_idx": 142,
+      "question": "How did \"The Alchemist\" impact John's perspective on following dreams?",
+      "expected_answer": "made him think again about following dreams and searching for personal legends",
+      "relevant_facts": [
+        "\"The Alchemist\" made John reflect on life and the importance of following one's dreams. | Involving: John",
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow his dreams and search for his personal legend, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John | The book inspired him to follow his dreams and search for his personal legend, making him feel motivated and hopeful."
+      ]
+    },
+    {
+      "q_idx": 143,
+      "question": "What is John trying out to improve his strength and flexibility after recovery from ankle injury?",
+      "expected_answer": "yoga",
+      "relevant_facts": [
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it effective for building strength and stability. | Involving: John | To build strength and stability.",
+        "John is actively trying to stay active and performs daily physical therapy exercises as part of his rehabilitation from his injury. | When: Every day | Involving: John | To recover from his injury",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John | To gain strength and flexibility.",
+        "John overcame his ankle injury by staying focused on recovery and strengthening his body, which taught him the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John has experienced significant improvements from yoga, including increased strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose for balance and stability, appreciating how they challenge his body and mind. | Involving: John | He enjoys the challenge and the feeling of strength, balance, and stability.",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. | When: Last season | Involving: John",
+        "John achieved a milestone at the gym, jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John",
+        "John shared a photo of himself in the Warrior II pose and described it as beneficial for working out legs and core. | Involving: John | To demonstrate the pose and its benefits to Tim."
+      ]
+    },
+    {
+      "q_idx": 144,
+      "question": "How long does John usually hold the yoga pose he shared with Tim?",
+      "expected_answer": "30-60 seconds",
+      "relevant_facts": [
+        "John shared a photo of himself in the Warrior II pose and described it as beneficial for working out legs and core. | Involving: John | To demonstrate the pose and its benefits to Tim.",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it effective for building strength and stability. | Involving: John | To build strength and stability."
+      ]
+    },
+    {
+      "q_idx": 145,
+      "question": "Where was the forest picture shared by John on December 1,2023 taken?",
+      "expected_answer": "near his hometown",
+      "relevant_facts": [
+        "John shared a photo of a tranquil forest near his hometown, which Tim described as magical. | When: Friday, December 01, 2023 | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 146,
+      "question": "What did Tim recently start learning in addition to being part of a travel club and working on studies?",
+      "expected_answer": "an instrument",
+      "relevant_facts": [
+        "Tim joined a travel club. | Involving: Tim | He is interested in different cultures and countries and is excited to meet new people and learn about what makes them unique.",
+        "Tim is currently working on his studies. | Involving: Tim",
+        "Tim recently started learning an instrument. | Involving: Tim | He always admired musicians and is finally trying it."
+      ]
+    },
+    {
+      "q_idx": 147,
+      "question": "What instrument is Tim learning to play in December 2023?",
+      "expected_answer": "violin",
+      "relevant_facts": [
+        "Tim is learning to play the violin. | Involving: Tim",
+        "Tim recently started learning an instrument. | Involving: Tim | He always admired musicians and is finally trying it."
+      ]
+    },
+    {
+      "q_idx": 148,
+      "question": "How long has Tim been playing the piano for, as of December 2023?",
+      "expected_answer": "about four months",
+      "relevant_facts": [
+        "Tim's favorite movie theme to play on the piano is from \"Harry Potter and the Philosopher's Stone\", which is special to him as the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family",
+        "Tim has been focusing on school, reading fantasy books to relieve stress, and learning to play the piano, finding satisfaction in his progress. | Involving: Tim",
+        "Tim has been playing a game or sport for about four months and is enjoying the progress he's making. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 149,
+      "question": "What book did Tim just finish reading on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 150,
+      "question": "Which book did Tim recommend to John as a good story on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim and John both love fantasy books because they offer a break from reality, transport them to different worlds, and provide fun adventures. | Involving: Tim, John",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "John asked Tim for book recommendations for his trip. | Involving: John, Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim",
+        "John plans to check out the book recommended by Tim. | Involving: John, Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves for their ability to transport him to other places. He also enjoys non-fiction books on growth, psychology, and self-improvement for personal betterment. | Involving: Tim",
+        "John felt great making plays for his team, enjoying seeing his teammates succeed from the opportunities he created. The electric atmosphere in the arena and the intensity of playing rivals made it a memorable night. | When: Last Friday (December 8, 2023) | Involving: John, John's teammates, John's rivals | Describes John's experience and feelings about his career-high game.",
+        "John achieved a career-high in assists last Friday in a big basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 151,
+      "question": "What is the topic of discussion between John and Tim on 11 December, 2023?",
+      "expected_answer": "Academic achievements and sports successes",
+      "relevant_facts": [
+        "John showed Tim a photo from the intense basketball game he played. | When: During the conversation | Involving: John, Tim",
+        "John felt great making plays for his team, enjoying seeing his teammates succeed from the opportunities he created. The electric atmosphere in the arena and the intensity of playing rivals made it a memorable night. | When: Last Friday (December 8, 2023) | Involving: John, John's teammates, John's rivals | Describes John's experience and feelings about his career-high game.",
+        "Tim has been swamped with exams this week and is plowing through them. | When: This week | Involving: Tim",
+        "John achieved a career-high in assists last Friday in a big basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John",
+        "Tim gave a presentation in class, feeling nervous but successfully completing it, which he views as progress. | When: Yesterday | Involving: Tim (user)",
+        "John achieved a milestone at the gym, jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John",
+        "Tim had a tough exam last week that initially made him doubt himself, but he turned it into a learning experience, studied hard, and realized his resilience and determination. | When: Last week | Involving: Tim",
+        "John scored 40 points in a basketball game, which is his personal highest score. | When: Last week | Involving: John | It signifies his hard work paying off."
+      ]
+    },
+    {
+      "q_idx": 152,
+      "question": "What kind of game did John have a career-high in assists in?",
+      "expected_answer": "basketball",
+      "relevant_facts": [
+        "John achieved a career-high in assists last Friday in a big basketball game against their rival. | When: Last Friday (December 8, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 153,
+      "question": "What was John's way of dealing with doubts and stress when he was younger?",
+      "expected_answer": "practicing basketball outside for hours",
+      "relevant_facts": [
+        "A picture reminds John of his youth when he practiced basketball outside for hours, dreaming of playing in big games, and using it as a way to deal with doubts and stress. He finds it amazing how powerful a ball and hoop can be. | When: When John was younger (past, ongoing memory) | Involving: John | Explains John's deep connection to basketball and its role in his life."
+      ]
+    },
+    {
+      "q_idx": 154,
+      "question": "How did John feel about the atmosphere during the big game against the rival team?",
+      "expected_answer": "electric and intense",
+      "relevant_facts": [
+        "John felt great making plays for his team, enjoying seeing his teammates succeed from the opportunities he created. The electric atmosphere in the arena and the intensity of playing rivals made it a memorable night. | When: Last Friday (December 8, 2023) | Involving: John, John's teammates, John's rivals | Describes John's experience and feelings about his career-high game.",
+        "John played an intense basketball game last week, which his team won by a tight score. He scored the last basket, which was an awesome and exhilarating experience with the crowd cheering. | When: Last week, around August 5, 2023 | Involving: John, John's team, crowd | It was an exhilarating experience for John to win and score the last basket.",
+        "John and his teammates won a tough basketball game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 155,
+      "question": "How did John feel after being able to jog without pain?",
+      "expected_answer": "It was a huge success.",
+      "relevant_facts": [
+        "John and his wife hosted a small get-together with friends and family to celebrate John's jogging milestone. Everyone had a ton of fun and it was good to see them again. | When: Last Friday or weekend | Involving: John, John's wife, friends, family | To celebrate John's milestone of jogging without pain.",
+        "John achieved a milestone at the gym, jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 156,
+      "question": "What kind of deal did John get in December?",
+      "expected_answer": "Deal with a renowned outdoor gear company",
+      "relevant_facts": [
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 157,
+      "question": "Where was the photoshoot done for John's gear deal?",
+      "expected_answer": "In a gorgeous forest",
+      "relevant_facts": [
+        "John had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | Involving: John, photographer"
+      ]
+    },
+    {
+      "q_idx": 158,
+      "question": "In which area has John's team seen the most growth during training?",
+      "expected_answer": "Communication and bonding",
+      "relevant_facts": [
+        "John's team has experienced significant growth in communication and bonding, which has improved their performances by allowing them to understand each other's strengths and weaknesses. | Involving: John's team | The growth in communication and bonding helped improve team performances."
+      ]
+    },
+    {
+      "q_idx": 159,
+      "question": "What type of seminars is John conducting?",
+      "expected_answer": "Sports and marketing seminars",
+      "relevant_facts": [
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 160,
+      "question": "What activity did Tim do after reading the stories about the Himalayan trek?",
+      "expected_answer": "visited a travel agency",
+      "relevant_facts": [
+        "Tim read a story about two hikers who trekked through the Himalayas, which was described as tough but worth it due to challenging terrain, altitude sickness, and bad weather, but they saw amazing sights, motivating Tim. | Involving: Tim, two hikers | The story motivated Tim for his own travel plans.",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | When: Tuesday, December 26, 2023 | Involving: Tim | To learn requirements for his dream trip"
+      ]
+    },
+    {
+      "q_idx": 161,
+      "question": "What is one cause that John supports with his influence and resources?",
+      "expected_answer": "youth sports and fair chances in sports",
+      "relevant_facts": [
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and wants to help young athletes succeed.",
+        "John is collaborating with a local organization that assists disadvantaged children with sports and school, intending to leverage his platform for positive community impact and inspiration. | Involving: John",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 162,
+      "question": "What new fantasy TV series is Tim excited about?",
+      "expected_answer": "\"The Wheel of Time\"",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves, and is scheduled to be released in January 2024. | When: January 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 163,
+      "question": "Which language is Tim learning?",
+      "expected_answer": "German",
+      "relevant_facts": [
+        "Tim is learning German, finding it tough but fun, and likes its structure, noting it's easier than French, which he took in high school. | Involving: Tim",
+        "Tim plans to continue with his German lessons. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 164,
+      "question": "What language does Tim know besides German?",
+      "expected_answer": "Spanish",
+      "relevant_facts": [
+        "Tim is learning German, finding it tough but fun, and likes its structure, noting it's easier than French, which he took in high school. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 165,
+      "question": "What book did Tim get in Italy that inspired him to cook?",
+      "expected_answer": "a cooking book",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 166,
+      "question": "What is John's favorite book series?",
+      "expected_answer": "Harry Potter",
+      "relevant_facts": [
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "John loves the first Harry Potter movie and owns the entire collection. | Involving: John",
+        "A \"super-nerd\" won a signed Harry Potter book as a prize at the Harry Potter trivia contest John and Anthony attended. | Involving: super-nerd, John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 167,
+      "question": "According to John, who is his favorite character from Lord of the Rings?",
+      "expected_answer": "Aragorn",
+      "relevant_facts": [
+        "John is a huge fan of Lord of the Rings, appreciating its adventure, world, and characters. | Involving: John",
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, brave and down-to-earth attitude, perseverance, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 168,
+      "question": "Why does John like Aragorn from Lord of the Rings?",
+      "expected_answer": "brave, selfless, down-to-earth attitude",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, brave and down-to-earth attitude, perseverance, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 169,
+      "question": "What kind of painting does John have in his room as a reminder?",
+      "expected_answer": "a painting of Aragorn",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room. | Involving: John | It serves as a reminder for him to stay true and be a leader in everything he does."
+      ]
+    },
+    {
+      "q_idx": 170,
+      "question": "What is the painting of Aragorn a reminder for John to be in everything he does?",
+      "expected_answer": "be a leader",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room. | Involving: John | It serves as a reminder for him to stay true and be a leader in everything he does.",
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, brave and down-to-earth attitude, perseverance, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 171,
+      "question": "What map does Tim show to his friend John?",
+      "expected_answer": "a map of Middle-earth from LOTR",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 172,
+      "question": "Where will Tim be going for a semester abroad?",
+      "expected_answer": "Ireland",
+      "relevant_facts": [
+        "Tim plans to stay in Galway, Ireland, during his study abroad semester, noting its vibrant atmosphere, arts, and Irish music scene. | When: February 2024 | Involving: Tim",
+        "Tim wants to visit The Cliffs of Moher in Ireland, describing them as having amazing ocean views and awesome cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim is excited to explore nature in Ireland during his study abroad. | When: February 2024 | Involving: Tim",
+        "Tim was accepted into a study abroad program and plans to go to Ireland for a semester next month. | When: Acceptance on Friday, January 5, 2024; trip in February 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 173,
+      "question": "Which city in Ireland will Tim be staying in during his semester abroad?",
+      "expected_answer": "Galway",
+      "relevant_facts": [
+        "Tim plans to stay in Galway, Ireland, during his study abroad semester, noting its vibrant atmosphere, arts, and Irish music scene. | When: February 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 174,
+      "question": "What charity event did John organize recently in 2024?",
+      "expected_answer": "benefit basketball game",
+      "relevant_facts": [
+        "John's benefit basketball game was a total success, attracting many people and raising money for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity",
+        "John organized and held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 175,
+      "question": "What achievement did John share with Tim in January 2024?",
+      "expected_answer": "endorsement with a popular beverage company",
+      "relevant_facts": [
+        "John plans to keep Tim updated on which brands he chooses for endorsement. | Involving: John, Tim",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It was a dream come true and felt like all his hard work paid off."
+      ]
+    },
+    {
+      "q_idx": 176,
+      "question": "What was Johns's reaction to sealing the deal with the beverage company?",
+      "expected_answer": "crazy feeling, sense of accomplishment",
+      "relevant_facts": [
+        "John felt crazy and accomplished after signing the endorsement deal, believing his hard work and training hours were validated. | Involving: John | The endorsement deal was a significant achievement that validated his efforts.",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It was a dream come true and felt like all his hard work paid off."
+      ]
+    },
+    {
+      "q_idx": 177,
+      "question": "Which city did John recommend to Tim in January 2024?",
+      "expected_answer": "Barcelona",
+      "relevant_facts": [
+        "John recommended Barcelona to Tim as a must-visit city, highlighting its culture, architecture, food, and nearby beaches. | Involving: John (recommender), Tim (recipient)",
+        "Tim decided to add Barcelona to his travel list based on John's recommendation. | Involving: Tim | He heard great things about Barcelona and liked John's suggestion."
+      ]
+    }
+  ],
+  "embedding_id": "bge-large-en-v1.5",
+  "bank_id": "emb_bge-large-en-v1-5_1772619394"
+}

--- a/benchmark-runner/datasets/locomo_embeddings_gt_bge-small-en-v1-5.json
+++ b/benchmark-runner/datasets/locomo_embeddings_gt_bge-small-en-v1-5.json
@@ -1,0 +1,1880 @@
+{
+  "annotations": [
+    {
+      "q_idx": 0,
+      "question": "what are John's goals with regards to his basketball career?",
+      "expected_answer": "improve shooting percentage, win a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John | This is his main professional aspiration.",
+        "John's goal is to improve his shooting percentage. | Involving: John",
+        "John's on-court goals include improving his shooting, making more impact, being a consistent performer, and helping his team. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 1,
+      "question": "What are John's goals for his career that are not related to his basketball skills?",
+      "expected_answer": "get endorsements, build his brand, do charity work",
+      "relevant_facts": [
+        "John's off-court goals include securing more endorsements and building his brand, as he considers life after basketball. | Involving: John | John wants to think about life after basketball.",
+        "John is making progress with endorsements and has talked to some promising 'big names'. | Involving: John | This is an exciting development for his career.",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | This is his concrete plan to achieve his goal of making a difference off the court.",
+        "John uses his contacts in the basketball industry and his marketing skills for networking to secure endorsements. | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John | John wants to make the most of his chances and leave a meaningful legacy.",
+        "John held a successful benefit basketball game last week, which raised money for charity and had a great turnout. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity.",
+        "John also wants to make a difference away from the court through charity work or inspiring people, as he feels basketball has been good to him and he wants to give back. | Involving: John | He wants to use his platform for positive community impact.",
+        "John is learning how to market himself and boost his brand. | Involving: John",
+        "John is exploring endorsement opportunities with brands, which he finds exciting and rewarding as his hard work is paying off. | Involving: John",
+        "John hopes to use his platform to have a positive impact on the community and inspire others. | Involving: John | This is the desired outcome of his charity work.",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to other brands that align with his values and interests. | Involving: John",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create more opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John has always liked Under Armour and would find it cool to work with them. | Involving: John",
+        "John participated in a photoshoot in a gorgeous forest where the photographer captured epic shots for his endorsement deal. | Involving: John, photographer | For the endorsement deal.",
+        "John felt crazy and accomplished after sealing the endorsement deal, believing his hard work and training hours paid off. | Involving: John | The endorsement made him feel that all his hard work was worth it.",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a 'super-nerd' won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John | Part of the endorsement deal.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire the kids and show them their potential.",
+        "John has secured endorsement deals. | Involving: John",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in, including speaking at a charity event. | Involving: John",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John",
+        "John secured an endorsement with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It is a dream come true for him.",
+        "John previously attended a Harry Potter charity event that included trivia. | When: Last August | Involving: John",
+        "John secured an amazing endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 2,
+      "question": "What items does John collect?",
+      "expected_answer": "sneakers, fantasy movie DVDs, jerseys",
+      "relevant_facts": [
+        "John likes to collect jerseys. | Involving: John",
+        "John loves talking about his sneaker collection. | Involving: John",
+        "John loves \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter movie collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 3,
+      "question": "Would Tim enjoy reading books by C. S. Lewis or John Greene?",
+      "expected_answer": "C. S.Lewis",
+      "relevant_facts": [
+        "Tim loves reading because it allows him to escape to another world, and he has a collection of books for this purpose. | Involving: Tim | Reading allows him to escape to another world.",
+        "J.K. Rowling is an inspiring writer for Tim, whose books he finds captivating due to their detail and creative storytelling. He takes notes on her style for his own writing and has been reading her works for a long time. | Involving: Tim, J.K. Rowling",
+        "Tim and John share a mutual interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim has been focusing on school, reading fantasy books to de-stress, and learning to play the piano, finding the progress satisfying. | When: Since he last talked to John | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | When: Currently | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books, appreciating how the story comes alive on screen. | Involving: Tim",
+        "John knows that Tim finds peace in reading fantasy books. | Involving: John, Tim",
+        "Tim and John both love fantasy books because they offer an escape from reality into different worlds for adventure. | Involving: Tim, John",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves because they transport him to other places. | Involving: Tim",
+        "Tim does not surf, but finds escape, happiness, and freedom (bliss) by reading great fantasy books in a comfy spot, comparing it to being in another world. | Involving: Tim",
+        "Tim loves going on road trips with friends and family, exploring, hiking, and playing board games. He also enjoys curling up with a good book in his free time to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim enjoys both fantasy stories and non-fiction books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes from different fantasy novels, and making book recommendations. | Involving: Tim",
+        "Tim recently reorganized his bookshelf and shared a photo of it, noting it contains some of his favorite fantasy books. | Involving: Tim",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John, suggesting it would be great for his trip. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine, an opportunity he found on a fantasy lit forum. He shared his ideas with the magazine, and they liked them, which he finds very rewarding. | Involving: Tim | Tim loves fantasy and finds it awesome to spread his love for the genre through his writing.",
+        "Tim loves to read books in his downtime, and the Harry Potter series is one of his favorites. | Involving: Tim",
+        "Tim likes 'The Hobbit' and another popular fantasy series. | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim plans to visit more Harry Potter related spots in the future because it makes him feel like he is stepping into the books. | When: In the future | Involving: Tim | It makes him feel like he is stepping into the books.",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, with Lord of the Rings being his favorite. | Involving: Tim",
+        "Tim just finished reading 'A Dance with Dragons' and highly recommends it. | Involving: Tim",
+        "Tim has a fantasy reading hobby and loves sinking into different magical worlds; he is trying to juggle this hobby with studying. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss to John, describing it as \"awesome\" and praising the author's world-building and character development. | When: Wednesday, August 09, 2023 | Involving: Tim, John, Patrick Rothfuss",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim",
+        "Tim's fantasy writing is going well; he is in the middle of writing a fantasy novel, which he finds nerve-wracking but exciting, and feels his hard work is paying off. Writing brings him joy. | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones, and he is very enthusiastic about them. | Involving: Tim",
+        "Tim uses his Harry Potter related items as reminders, which help him escape reality. | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim enjoys getting lost in fantasy realms as a form of escape. | Involving: Tim (user)",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, excellent world-building, and character development. | Involving: Tim",
+        "Tim is working on a Harry Potter fan project and is discussing collaborations for it. | Involving: Tim",
+        "\"That\" is one of Tim's favorite fantasy shows. | Involving: Tim (user)",
+        "\"Harry Potter and the Philosopher's Stone\" is a special movie for Tim because it was the first in the series and brings back magical memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family | The movie evokes special family memories.",
+        "Tim suggested Edinburgh, Scotland, as a destination for John's team trip, highlighting its magical vibe, Harry Potter connection, history, architecture, and beauty. | Involving: Tim, John",
+        "Tim decorated his Christmas tree himself with a Harry Potter theme, finding it a fun project and being happy with the outcome. | When: last year | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to be released next month. | When: Next month | Involving: Tim",
+        "Tim talked to a friend, who is a Harry Potter fan, last week to figure out ideas for his fan project. | When: Last week | Involving: Tim, Tim's friend | To figure out ideas for the Harry Potter fan project.",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim had a nice and magical chat with a Harry Potter fan. | When: Last week | Involving: Tim, a Harry Potter fan | It was a magical experience due to shared passion."
+      ]
+    },
+    {
+      "q_idx": 4,
+      "question": "What books has Tim read?",
+      "expected_answer": "Harry Potter, Game of Thrones, the Name of the Wind, The Alchemist, The Hobbit, A Dance with Dragons, and the Wheel of Time.",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, whose books he finds captivating due to their detail and creative storytelling. He takes notes on her style for his own writing and has been reading her works for a long time. | Involving: Tim, J.K. Rowling",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books, appreciating how the story comes alive on screen. | Involving: Tim",
+        "Tim plans to visit more Harry Potter related spots in the future because it makes him feel like he is stepping into the books. | When: In the future | Involving: Tim | It makes him feel like he is stepping into the books.",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back | Involving: Tim | The book impacted his perspective on goals.",
+        "Tim loves to read books in his downtime, and the Harry Potter series is one of his favorites. | Involving: Tim",
+        "John plans to add \"The Name of the Wind\" to his reading list based on Tim's recommendation. | Involving: John, Tim",
+        "Tim considers \"The Alchemist\" one of his favorite books. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss to John, describing it as \"awesome\" and praising the author's world-building and character development. | When: Wednesday, August 09, 2023 | Involving: Tim, John, Patrick Rothfuss",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim just finished reading 'A Dance with Dragons' and highly recommends it. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves because they transport him to other places. | Involving: Tim",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim likes 'The Hobbit' and another popular fantasy series. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, excellent world-building, and character development. | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to be released next month. | When: Next month | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones, and he is very enthusiastic about them. | Involving: Tim",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John, suggesting it would be great for his trip. | Involving: Tim, John, Patrick Rothfuss"
+      ]
+    },
+    {
+      "q_idx": 5,
+      "question": "Based on Tim's collections, what is a shop that he would enjoy visiting in New York city?",
+      "expected_answer": "House of MinaLima",
+      "relevant_facts": [
+        "Tim wants to visit New York City and has added it to his travel list, excited to explore and try things out. | Involving: Tim | John's positive description of New York City.",
+        "Tim uses his Harry Potter related items as reminders, which help him escape reality. | Involving: Tim",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, and he loves their work, viewing it as a piece of the wizarding world at home. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 6,
+      "question": "In which month's game did John achieve a career-high score in points?",
+      "expected_answer": "June 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 7,
+      "question": "Which geographical locations has Tim been to?",
+      "expected_answer": "California, London, the Smoky Mountains",
+      "relevant_facts": [
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | Involving: Tim, Harry Potter fan | Tim enjoyed talking to someone who understands his interest.",
+        "Tim experienced a setback last week when his attempt to write a story based on his experiences in the UK did not go as he wanted. | When: Last week (around 2023-11-14) | Involving: Tim",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "Tim has visited Europe before. | Involving: Tim",
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 8,
+      "question": "Which outdoor gear company likely signed up John for an endorsement deal?",
+      "expected_answer": "Under Armour",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John | Part of the endorsement deal.",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to other brands that align with his values and interests. | Involving: John",
+        "John secured an amazing endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John has always liked Under Armour and would find it cool to work with them. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 9,
+      "question": "Which endorsement deals has John been offered?",
+      "expected_answer": "basketball shoes and gear deal with Nike, potential sponsorship with Gatorade, Moxie a popular beverage company, outdoor gear company",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John | Part of the endorsement deal.",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to other brands that align with his values and interests. | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John secured an amazing endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John secured an endorsement with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It is a dream come true for him."
+      ]
+    },
+    {
+      "q_idx": 10,
+      "question": "When was John in Seattle for a game?",
+      "expected_answer": "early August, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 11,
+      "question": "What sports does John like besides basketball?",
+      "expected_answer": "surfing",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with friends, describing the experience as unreal, exciting, and free-feeling due to the connection to nature. | When: Started five years ago; had an awesome summer in the past | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 12,
+      "question": "What year did John start surfing?",
+      "expected_answer": "2018",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with friends, describing the experience as unreal, exciting, and free-feeling due to the connection to nature. | When: Started five years ago; had an awesome summer in the past | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 13,
+      "question": "What does Tim do to escape reality?",
+      "expected_answer": "Read fantasy books.",
+      "relevant_facts": [
+        "Tim and John both love fantasy books because they offer an escape from reality into different worlds for adventure. | Involving: Tim, John",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves because they transport him to other places. | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim loves going on road trips with friends and family, exploring, hiking, and playing board games. He also enjoys curling up with a good book in his free time to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim loves reading because it allows him to escape to another world, and he has a collection of books for this purpose. | Involving: Tim | Reading allows him to escape to another world.",
+        "Tim enjoys getting lost in fantasy realms as a form of escape. | Involving: Tim (user)",
+        "Tim does not surf, but finds escape, happiness, and freedom (bliss) by reading great fantasy books in a comfy spot, comparing it to being in another world. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | When: Currently | Involving: Tim",
+        "Tim has a fantasy reading hobby and loves sinking into different magical worlds; he is trying to juggle this hobby with studying. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 14,
+      "question": "What kind of writing does Tim do?",
+      "expected_answer": "comments on favorite books in a fantasy literature forum, articles on fantasy novels, studying characters, themes, and making book recommendations, writing a fantasy novel",
+      "relevant_facts": [
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, excellent world-building, and character development. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine, an opportunity he found on a fantasy lit forum. He shared his ideas with the magazine, and they liked them, which he finds very rewarding. | Involving: Tim | Tim loves fantasy and finds it awesome to spread his love for the genre through his writing.",
+        "Tim's fantasy writing is going well; he is in the middle of writing a fantasy novel, which he finds nerve-wracking but exciting, and feels his hard work is paying off. Writing brings him joy. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it allows him to combine his love for reading and sharing great stories. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes from different fantasy novels, and making book recommendations. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 15,
+      "question": "Who is Anthony?",
+      "expected_answer": "likely John's friend, colleague or family",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a 'super-nerd' won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd"
+      ]
+    },
+    {
+      "q_idx": 16,
+      "question": "After how many weeks did Tim reconnect with the fellow Harry Potter fan from California?",
+      "expected_answer": "three weeks",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 17,
+      "question": "How many games has John mentioned winning?",
+      "expected_answer": "6",
+      "relevant_facts": [
+        "John's basketball team won a close game against another team. | When: Last week (relative to December 16, 2023) | Involving: John (and his team)",
+        "John's favorite game was one where his team was down by 10 points in the 4th quarter, and he hit a buzzer-beater shot to win. The atmosphere was incredible, and it was a thrilling experience that made him love basketball. | Involving: John, John's team | Highlights a significant personal achievement and passion for basketball.",
+        "John felt that winning the basketball game was amazing and worth all the hard work they put in. | Involving: John (and his basketball team)",
+        "John's team won a trophy, making him feel great and validating their hard work and effort. | Involving: John (and his team)",
+        "John and his teammates pulled off a tough win in a game, creating an incredible and electric atmosphere. | When: Last week | Involving: John, John's teammates | It was a significant victory and an incredible experience for the team.",
+        "John's basketball team recently played a tough game against a top team and won. | When: Recently | Involving: John (and his basketball team)",
+        "John's basketball team overcame a large deficit in the 4th quarter of a game last year, resulting in an unforgettable win. | When: Last year | Involving: John | The experience was amazing and unforgettable, demonstrating the value of perseverance.",
+        "John's team won an intense basketball game by a tight score last week, with John scoring the last basket. | When: Last week | Involving: John, John's team, crowd"
+      ]
+    },
+    {
+      "q_idx": 18,
+      "question": "What authors has Tim read books from?",
+      "expected_answer": "J.K. Rowling, R.R. Martin, Patrick Rothfuss, Paulo Coelho, and J. R. R. Tolkien.",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, whose books he finds captivating due to their detail and creative storytelling. He takes notes on her style for his own writing and has been reading her works for a long time. | Involving: Tim, J.K. Rowling",
+        "Tim recommended a book by Patrick Rothfuss to John, describing it as \"awesome\" and praising the author's world-building and character development. | When: Wednesday, August 09, 2023 | Involving: Tim, John, Patrick Rothfuss",
+        "Tim loves to read books in his downtime, and the Harry Potter series is one of his favorites. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back | Involving: Tim | The book impacted his perspective on goals.",
+        "Tim considers \"The Alchemist\" one of his favorite books. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, with Lord of the Rings being his favorite. | Involving: Tim",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim just finished reading 'A Dance with Dragons' and highly recommends it. | Involving: Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he loves because they transport him to other places. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim likes 'The Hobbit' and another popular fantasy series. | Involving: Tim",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, excellent world-building, and character development. | Involving: Tim",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones, and he is very enthusiastic about them. | Involving: Tim",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John, suggesting it would be great for his trip. | Involving: Tim, John, Patrick Rothfuss"
+      ]
+    },
+    {
+      "q_idx": 19,
+      "question": "What is a prominent charity organization that John might want to work with and why?",
+      "expected_answer": "Good Sports, because they work with Nike, Gatorade, and Under Armour and they aim toprovide youth sports opportunities for kids ages 3-18 in high-need communities.",
+      "relevant_facts": [
+        "John's off-court goals include securing more endorsements and building his brand, as he considers life after basketball. | Involving: John | John wants to think about life after basketball.",
+        "John has always liked Under Armour and would find it cool to work with them. | Involving: John",
+        "John hopes to use his platform to have a positive impact on the community and inspire others. | Involving: John | This is the desired outcome of his charity work.",
+        "John also wants to make a difference away from the court through charity work or inspiring people, as he feels basketball has been good to him and he wants to give back. | Involving: John | He wants to use his platform for positive community impact.",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John | John wants to make the most of his chances and leave a meaningful legacy.",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create more opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | This is his concrete plan to achieve his goal of making a difference off the court.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in, including speaking at a charity event. | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John held a successful benefit basketball game last week, which raised money for charity and had a great turnout. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity.",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to other brands that align with his values and interests. | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 20,
+      "question": "Which city was John in before traveling to Chicago?",
+      "expected_answer": "Seattle",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 21,
+      "question": "Which US cities does John mention visiting to Tim?",
+      "expected_answer": "Seattle, Chicago, New York",
+      "relevant_facts": [
+        "Tim wants to visit New York City and has added it to his travel list, excited to explore and try things out. | Involving: Tim | John's positive description of New York City.",
+        "John loves discovering new cities and found New York City amazing, enjoying exploring the city and trying all the restaurants, culture, and food. He recommends it as a must-visit adventure. | Involving: John",
+        "John offered to help Tim with his travel plans and encouraged him to reach out anytime he needs assistance. | Involving: John, Tim",
+        "John considers Seattle one of his favorite cities to explore due to its vibrancy. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (recommending local seafood), and the incredible support from fans at games. | Involving: John",
+        "John recently took a trip to Chicago, where he found the energy amazing and the locals friendly. | When: Recently (within the last few days before August 11, 2023) | Involving: John",
+        "John had a trip to NYC where he initially struggled with figuring out the subway system but found it easy after someone helped explain it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 22,
+      "question": "When did John meet with his teammates after returning from Chicago?",
+      "expected_answer": "August 15, 2023",
+      "relevant_facts": [
+        "John recently took a trip to Chicago, where he found the energy amazing and the locals friendly. | When: Recently (within the last few days before August 11, 2023) | Involving: John",
+        "John reunited with his teammates on the 15th after his trip, feeling very welcome and lucky to be part of the team, experiencing an electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball as a sign of their friendship and love when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 23,
+      "question": "When is Tim attending a book conference?",
+      "expected_answer": "September 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 24,
+      "question": "Where was John between August 11 and August 15 2023?",
+      "expected_answer": "Chicago",
+      "relevant_facts": [
+        "John recently took a trip to Chicago, where he found the energy amazing and the locals friendly. | When: Recently (within the last few days before August 11, 2023) | Involving: John",
+        "John reunited with his teammates on the 15th after his trip, feeling very welcome and lucky to be part of the team, experiencing an electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 25,
+      "question": "What similar sports collectible do Tim and John own?",
+      "expected_answer": "signed basketball",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a sign of their friendship and love when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love.",
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 26,
+      "question": "Which TV series does Tim mention watching?",
+      "expected_answer": "That, Wheel of Time",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to be released next month. | When: Next month | Involving: Tim",
+        "\"That\" is one of Tim's favorite fantasy shows. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 27,
+      "question": "Which popular time management technique does Tim use to prepare for exams?",
+      "expected_answer": "Pomodoro technique",
+      "relevant_facts": [
+        "Tim breaks up his studying into smaller parts, specifically 25 minutes on and 5 minutes off for something fun, to make it less overwhelming and stay on track. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 28,
+      "question": "Which popular music composer's tunes does Tim enjoy playing on the piano?",
+      "expected_answer": "John Williams",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim",
+        "John believes Tim plays the piano and asked about it. | Involving: John, Tim",
+        "Tim has been focusing on school, reading fantasy books to de-stress, and learning to play the piano, finding the progress satisfying. | When: Since he last talked to John | Involving: Tim",
+        "Tim is mostly interested in classical music but is also keen to try jazz and film scores. | Involving: Tim",
+        "\"Harry Potter and the Philosopher's Stone\" is a special movie for Tim because it was the first in the series and brings back magical memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family | The movie evokes special family memories.",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 29,
+      "question": "What schools did John play basketball in and how many years was he with his team during high school?",
+      "expected_answer": "Middle school, high school, and college and he was with his high school team for 4 years.",
+      "relevant_facts": [
+        "John continued playing basketball through middle and high school, which led to him earning a college scholarship. | When: During middle and high school | Involving: John | This shows his dedication and progression in the sport.",
+        "John and his friends were teammates for four years in high school. | When: High school | Involving: John, John's friends",
+        "After college, John was drafted by a team, which he considers his childhood dream come true. | When: After college | Involving: John | This was the culmination of his long-standing dream and hard work."
+      ]
+    },
+    {
+      "q_idx": 30,
+      "question": "Which cities has John been to?",
+      "expected_answer": "Seattle, Chicago, New York, and Paris.",
+      "relevant_facts": [
+        "John loves discovering new cities and found New York City amazing, enjoying exploring the city and trying all the restaurants, culture, and food. He recommends it as a must-visit adventure. | Involving: John",
+        "John had a trip to NYC where he initially struggled with figuring out the subway system but found it easy after someone helped explain it. | Involving: John",
+        "John considers Seattle one of his favorite cities to explore due to its vibrancy. | Involving: John",
+        "John has been to Paris, loved it, and found the view from the Eiffel Tower incredible. He believes traveling helps you see new things and is educational. | Involving: John",
+        "John recently took a trip to Chicago, where he found the energy amazing and the locals friendly. | When: Recently (within the last few days before August 11, 2023) | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (recommending local seafood), and the incredible support from fans at games. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 31,
+      "question": "What month did Tim plan on going to Universal Studios?",
+      "expected_answer": "September, 2023",
+      "relevant_facts": [
+        "The upcoming trip will be Tim's first time visiting Universal Studios, and he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim (user)",
+        "Tim is planning a trip to Universal Studios next month. | When: Next month (September 2023) | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 32,
+      "question": "Which US states might Tim be in during September 2023 based on his plans of visiting Universal Studios?",
+      "expected_answer": "California or Florida",
+      "relevant_facts": [
+        "The upcoming trip will be Tim's first time visiting Universal Studios, and he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim (user)",
+        "Tim is planning a trip to Universal Studios next month. | When: Next month (September 2023) | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 33,
+      "question": "When does John plan on traveling with his team on a team trip?",
+      "expected_answer": "October, 2023",
+      "relevant_facts": [
+        "John and his new teammates are planning a team trip next month to explore a new city and have some fun. | When: Next month (October 2023) | Involving: John, John's new teammates | To have some fun."
+      ]
+    },
+    {
+      "q_idx": 34,
+      "question": "What could John do after his basketball career?",
+      "expected_answer": "become a basketball coach since he likes giving back and leadership",
+      "relevant_facts": [
+        "John is mentoring younger players on his team, which he finds super rewarding and loves as it allows him to share his skills and knowledge. It also helps him stay involved in the game during the off-season. | Involving: John, younger players (on John's team)",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John | John wants to make the most of his chances and leave a meaningful legacy.",
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad he could make a positive impact on their lives. | Involving: John, younger players",
+        "John also wants to make a difference away from the court through charity work or inspiring people, as he feels basketball has been good to him and he wants to give back. | Involving: John | He wants to use his platform for positive community impact.",
+        "Some of the younger players see John as a mentor, which he finds rewarding. He tries to provide them with advice and support on and off the court and enjoys being a positive role model for them. | Involving: John, younger players",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | This is his concrete plan to achieve his goal of making a difference off the court.",
+        "John faces challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it rewarding to watch them develop and reach their goals. | Involving: John, younger players",
+        "Tim asked John for tips on motivating others on his team. | Involving: Tim (user), John",
+        "John hopes to use his platform to have a positive impact on the community and inspire others. | Involving: John | This is the desired outcome of his charity work.",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create more opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John feels great having the younger players' trust and admiration. He finds being a role model for these young athletes fulfilling and is glad his experiences can help shape their future and inspire them to go after their dreams. | Involving: John, younger players",
+        "John advises that motivating others involves showing care, celebrating achievements, providing constructive feedback, reminding of bigger goals, creating a positive environment, and giving pep talks before games. | Involving: John | In response to Tim's request for advice on motivating others.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 35,
+      "question": "What outdoor activities does John enjoy?",
+      "expected_answer": "Hiking, surfing",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with friends, describing the experience as unreal, exciting, and free-feeling due to the connection to nature. | When: Started five years ago; had an awesome summer in the past | Involving: John, John's friends",
+        "John went camping in the mountains with others, where he enjoyed disconnecting, chilling, and taking in the peaceful and refreshing beauty of nature. | Involving: John and others",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John | Part of the endorsement deal.",
+        "John mentioned he might visit The Cliffs of Moher after his season. | When: After his season (future plan) | Involving: John",
+        "John loves the ocean and is looking forward to eating seafood. | Involving: John",
+        "John stumbled across the spot shown in the shared photo while hiking. | Involving: John",
+        "John secured an amazing endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John took a stunning trip to the Rocky Mountains. | When: Last year | Involving: John",
+        "Some of John's hiking club friends attended his wedding, even though he had just joined the club. | When: Last week | Involving: John, John's hiking club friends"
+      ]
+    },
+    {
+      "q_idx": 36,
+      "question": "Who is Tim and John's favorite basketball player?",
+      "expected_answer": "LeBron James",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whom he admires for his skills, leadership, work ethic, and dedication. | Involving: John, LeBron",
+        "Tim's favorite basketball player is LeBron James. Tim was inspired by LeBron James' epic block in Game 7 of the 2016 Finals against Iguodala, which was a game-changing moment that led to a win and taught Tim the value of never giving up. John also recalls this specific block as an example of determination and heart that makes him love basketball. | When: Game 7 of the 2016 Finals (June 19, 2016) | Involving: Tim, John, LeBron James, Iguodala | It taught Tim the value of never giving up and exemplifies the determination and heart that makes John love basketball."
+      ]
+    },
+    {
+      "q_idx": 37,
+      "question": "Which week did Tim visit the UK for the Harry Potter Conference?",
+      "expected_answer": "The week before October 13th, 2023.",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 38,
+      "question": "which country has Tim visited most frequently in his travels?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim experienced a setback last week when his attempt to write a story based on his experiences in the UK did not go as he wanted. | When: Last week (around 2023-11-14) | Involving: Tim",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 39,
+      "question": "What year did Tim go to the Smoky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 40,
+      "question": "Has Tim been to North Carolina and/or Tennesee states in the US?",
+      "expected_answer": "Yes",
+      "relevant_facts": [
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 41,
+      "question": "What kind of fiction stories does Tim write?",
+      "expected_answer": "Fantasy stories with plot twists",
+      "relevant_facts": [
+        "Tim's fantasy writing is going well; he is in the middle of writing a fantasy novel, which he finds nerve-wracking but exciting, and feels his hard work is paying off. Writing brings him joy. | Involving: Tim",
+        "Tim experienced a significant and frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually resolved it by getting his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 42,
+      "question": "What has John cooked?",
+      "expected_answer": "Soup, a slow cooker meal, and honey garlic chicken with roasted veg.",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty soup. | When: Recently | Involving: John",
+        "John used sage as a spice in the soup he recently made. | Involving: John | For flavor",
+        "John improvised the soup recipe on the spot and does not have a written recipe for it. | Involving: John",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes, and he enjoys trying out new recipes. | Involving: John",
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables. | When: Saturday, October 21, 2023 | Involving: Tim, John | Tim wants to try the delicious-sounding meal.",
+        "John committed to writing down and mailing the honey garlic chicken with roasted vegetables recipe to Tim. | When: Saturday, October 21, 2023 | Involving: John, Tim | To fulfill Tim's request for the recipe."
+      ]
+    },
+    {
+      "q_idx": 43,
+      "question": "What does John like about Lebron James?",
+      "expected_answer": "His heart, determination, skills, and leadership.",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whom he admires for his skills, leadership, work ethic, and dedication. | Involving: John, LeBron",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John | He is inspired by LeBron's moments of determination and heart.",
+        "Tim's favorite basketball player is LeBron James. Tim was inspired by LeBron James' epic block in Game 7 of the 2016 Finals against Iguodala, which was a game-changing moment that led to a win and taught Tim the value of never giving up. John also recalls this specific block as an example of determination and heart that makes him love basketball. | When: Game 7 of the 2016 Finals (June 19, 2016) | Involving: Tim, John, LeBron James, Iguodala | It taught Tim the value of never giving up and exemplifies the determination and heart that makes John love basketball."
+      ]
+    },
+    {
+      "q_idx": 44,
+      "question": "When did John and his wife go on a European vacation?",
+      "expected_answer": "November, 2023.",
+      "relevant_facts": [
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 45,
+      "question": "Which country was Tim visiting in the second week of November?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim experienced a setback last week when his attempt to write a story based on his experiences in the UK did not go as he wanted. | When: Last week (around 2023-11-14) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 46,
+      "question": "Where was Tim in the week before 16 November 2023?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim experienced a setback last week when his attempt to write a story based on his experiences in the UK did not go as he wanted. | When: Last week (around 2023-11-14) | Involving: Tim",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 47,
+      "question": "When did John get married at a greenhouse?",
+      "expected_answer": "last week of September 2023",
+      "relevant_facts": [
+        "John and his wife found a lovely greenhouse venue for their wedding, which was a smaller, more intimate gathering, and they followed necessary safety protocols. | When: Last week | Involving: John, John's wife, loved ones | To ensure everyone felt safe and to celebrate with loved ones."
+      ]
+    },
+    {
+      "q_idx": 48,
+      "question": "When did John get an ankle injury in 2023?",
+      "expected_answer": "around November 16, 2023",
+      "relevant_facts": [
+        "John injured himself, causing him to miss basketball games and be unable to help his team. | When: Not too long ago (relative to December 16, 2023) | Involving: John (and his team)",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a relief after being out for so long. | When: Friday, December 15, 2023 | Involving: John | It was a significant milestone in his recovery/training."
+      ]
+    },
+    {
+      "q_idx": 49,
+      "question": "How many times has John injured his ankle?",
+      "expected_answer": "two times",
+      "relevant_facts": [
+        "Last season, John hurt his ankle, which required time off and physical therapy. This experience was a tough mental and physical challenge that taught him the importance of patience and perseverance. | When: Last season (prior to November 2023) | Involving: John | It was a major challenge that led to personal growth and learning.",
+        "John and his wife hosted a small get-together with friends and family. | When: After December 15, 2023 | Involving: John, John's wife, friends, family | To celebrate John's success of jogging without pain.",
+        "John injured himself, causing him to miss basketball games and be unable to help his team. | When: Not too long ago (relative to December 16, 2023) | Involving: John (and his team)",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a relief after being out for so long. | When: Friday, December 15, 2023 | Involving: John | It was a significant milestone in his recovery/training."
+      ]
+    },
+    {
+      "q_idx": 50,
+      "question": "Which book was John reading during his recovery from an ankle injury?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John is currently reading an inspiring book that reminds him to keep dreaming and motivates him to keep reaching for new goals. | Involving: John",
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and trust the process, leaving him feeling hopeful. | When: Recently | Involving: John | The book inspired and motivated him to pursue his dreams.",
+        "John is currently recovering from an injury, which he describes as tough but he is staying positive and taking it slow. | Involving: John",
+        "Last season, John hurt his ankle, which required time off and physical therapy. This experience was a tough mental and physical challenge that taught him the importance of patience and perseverance. | When: Last season (prior to November 2023) | Involving: John | It was a major challenge that led to personal growth and learning."
+      ]
+    },
+    {
+      "q_idx": 51,
+      "question": "What kind of yoga for building core strength might John benefit from?",
+      "expected_answer": "Hatha Yoga",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 52,
+      "question": "What does John do to supplement his basketball training?",
+      "expected_answer": "Yoga, strength training",
+      "relevant_facts": [
+        "John includes strength training in his basketball routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism. | Involving: John | These are the benefits for basketball performance.",
+        "John created a workout schedule that balances basketball and strength training, and he prioritizes listening to his body and getting enough rest. | Involving: John | To stay on track, push himself during practice, and look after himself.",
+        "Incorporating strength training significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, which also boosted his confidence. | Involving: John | It gave him an upper hand over opponents and helped him up his game.",
+        "John has noticed improvements in his strength, flexibility, focus, and balance during workouts as a result of practicing yoga. | Involving: John",
+        "John enjoys practicing specific yoga poses, including Warrior II, which makes him feel strong, and another pose that helps with balance and stability, as they challenge his body and mind. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John typically holds the Warrior II yoga pose for 30-60 seconds to build strength and stability. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 53,
+      "question": "What other exercises can help John with his basketball performance?",
+      "expected_answer": "Sprinting, long-distance running, and boxing.",
+      "relevant_facts": [
+        "John includes strength training in his basketball routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism. | Involving: John | These are the benefits for basketball performance.",
+        "Incorporating strength training significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, which also boosted his confidence. | Involving: John | It gave him an upper hand over opponents and helped him up his game.",
+        "John enjoys practicing specific yoga poses, including Warrior II, which makes him feel strong, and another pose that helps with balance and stability, as they challenge his body and mind. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John created a workout schedule that balances basketball and strength training, and he prioritizes listening to his body and getting enough rest. | Involving: John | To stay on track, push himself during practice, and look after himself.",
+        "John has noticed improvements in his strength, flexibility, focus, and balance during workouts as a result of practicing yoga. | Involving: John",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a relief after being out for so long. | When: Friday, December 15, 2023 | Involving: John | It was a significant milestone in his recovery/training.",
+        "John typically holds the Warrior II yoga pose for 30-60 seconds to build strength and stability. | Involving: John",
+        "John started surfing five years ago and had an awesome summer surfing with friends, describing the experience as unreal, exciting, and free-feeling due to the connection to nature. | When: Started five years ago; had an awesome summer in the past | Involving: John, John's friends",
+        "Some of John's hiking club friends attended his wedding, even though he had just joined the club. | When: Last week | Involving: John, John's hiking club friends",
+        "Tim plans to try the Warrior II yoga pose. | Involving: Tim (user) | John shared details and a photo of the pose, inspiring Tim to try it.",
+        "John took a stunning trip to the Rocky Mountains. | When: Last year | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 54,
+      "question": "When did John take a trip to the Rocky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "John took a stunning trip to the Rocky Mountains. | When: Last year | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 55,
+      "question": "When did John start playing professionally?",
+      "expected_answer": "May, 2023",
+      "relevant_facts": [
+        "John has been playing professional basketball for just under a year. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 56,
+      "question": "When did Tim start playing the violin?",
+      "expected_answer": "August 2023",
+      "relevant_facts": [
+        "Tim is learning to play the violin. | Involving: Tim | It's a great way to chill and get creative.",
+        "Tim recently started learning an instrument. | Involving: Tim | He has always admired musicians and is finally trying it.",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 57,
+      "question": "What instruments does Tim play?",
+      "expected_answer": "piano, violin",
+      "relevant_facts": [
+        "Tim is learning to play the violin. | Involving: Tim | It's a great way to chill and get creative.",
+        "John hopes to hear Tim play the violin someday. | Involving: John, Tim",
+        "Tim has been focusing on school, reading fantasy books to de-stress, and learning to play the piano, finding the progress satisfying. | When: Since he last talked to John | Involving: Tim",
+        "John believes Tim plays the piano and asked about it. | Involving: John, Tim",
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 58,
+      "question": "When did John attend the Harry Potter trivia?",
+      "expected_answer": "August 2023.",
+      "relevant_facts": [
+        "John previously attended a Harry Potter charity event that included trivia. | When: Last August | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 59,
+      "question": "Which career-high performances did John achieve in 2023?",
+      "expected_answer": "highest point score, highest assist",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a big basketball game against his team's rival. | When: Last Friday | Involving: John",
+        "John scored 40 points in a game, which was his highest score ever, indicating that his hard work is paying off. | When: Last week | Involving: John | It was his personal best score, showing the results of his hard work."
+      ]
+    },
+    {
+      "q_idx": 60,
+      "question": "When did John achieve a career-high assist performance?",
+      "expected_answer": "December 11, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 61,
+      "question": "What books has John read?",
+      "expected_answer": "inpsiring book on dreaming big, The Alchemist, fantasy series, non-fiction books on personal development, Dune",
+      "relevant_facts": [
+        "Tim and John both love fantasy books because they offer an escape from reality into different worlds for adventure. | Involving: Tim, John",
+        "Tim and John share a mutual interest in fantasy books and movies. | Involving: Tim, John",
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and trust the process, leaving him feeling hopeful. | When: Recently | Involving: John | The book inspired and motivated him to pursue his dreams.",
+        "John is currently reading an inspiring book that reminds him to keep dreaming and motivates him to keep reaching for new goals. | Involving: John",
+        "John highly recommends \"The Alchemist\". | Involving: John",
+        "John is currently reading 'Dune' by Frank Herbert, which he describes as a great story about religion and human control over ecology, and he highly recommends it. | Involving: John",
+        "John enjoys non-fiction books about personal development and mindset because they help him know himself better. | Involving: John",
+        "John finds that fantasy books fuel his creativity. | Involving: John",
+        "John likes Tim's bookshelf and considers 'The Hobbit' and another popular fantasy series among his favorite books. | Involving: John, Tim",
+        "John read and loved \"The Alchemist\", which made him think about life and the importance of following one's dreams. | Involving: John",
+        "John is a huge fan of Lord of the Rings, appreciating its adventure, world, and characters. | Involving: John | He enjoys the adventure, world, and characters.",
+        "John loves \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter movie collection. | Involving: John",
+        "John loves the map of Middle-earth from Lord of the Rings, finding it helps him get lost in another world and enjoys exploring different lands and regions in fantasy stories. | Involving: John",
+        "John recently finished an amazing fantasy series, enjoying its twists, awesome storylines, and characters, and loves getting lost in fantasy worlds. | Involving: John",
+        "John likes fantasy novels that feature strong characters and cool world-building. | Involving: John",
+        "John's favorite character is Aragorn from Lord of the Rings, finding him inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 62,
+      "question": "What does John do to share his knowledge?",
+      "expected_answer": "gives seminars, mentors younger players.",
+      "relevant_facts": [
+        "John is mentoring younger players on his team, which he finds super rewarding and loves as it allows him to share his skills and knowledge. It also helps him stay involved in the game during the off-season. | Involving: John, younger players (on John's team)",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John",
+        "John faces challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it rewarding to watch them develop and reach their goals. | Involving: John, younger players",
+        "Some of the younger players see John as a mentor, which he finds rewarding. He tries to provide them with advice and support on and off the court and enjoys being a positive role model for them. | Involving: John, younger players",
+        "John started doing seminars to help people with sports and marketing, which has been going well. | When: This week (prior to December 26, 2023) | Involving: John",
+        "John advises that motivating others involves showing care, celebrating achievements, providing constructive feedback, reminding of bigger goals, creating a positive environment, and giving pep talks before games. | Involving: John | In response to Tim's request for advice on motivating others.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 63,
+      "question": "When did John organize a basketball camp for kids?",
+      "expected_answer": "summer 2023",
+      "relevant_facts": [
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 64,
+      "question": "Which month was John in Italy?",
+      "expected_answer": "December, 2023",
+      "relevant_facts": [
+        "John visited Italy and had a blast. | When: Last month | Involving: John",
+        "John found the food, history, and architecture in Italy amazing. | When: Last month | Involving: John",
+        "John bought a book in Italy that has been giving him cooking inspiration. | When: Last month | Involving: John",
+        "John secured an endorsement with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It is a dream come true for him."
+      ]
+    },
+    {
+      "q_idx": 65,
+      "question": "What fantasy movies does Tim like?",
+      "expected_answer": "Lord of the Rings, Harry Potter, and Star Wars.",
+      "relevant_facts": [
+        "\"Harry Potter and the Philosopher's Stone\" is a special movie for Tim because it was the first in the series and brings back magical memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family | The movie evokes special family memories.",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, and he loves their work, viewing it as a piece of the wizarding world at home. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, with Lord of the Rings being his favorite. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books, appreciating how the story comes alive on screen. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 66,
+      "question": "What is a Star Wars book that Tim might enjoy?",
+      "expected_answer": "Star Wars: Jedi Apprentice by Judy Blundell and David Farland. It is a highly rated and immersive series about his favorite movies.",
+      "relevant_facts": [
+        "Tim loves reading because it allows him to escape to another world, and he has a collection of books for this purpose. | Involving: Tim | Reading allows him to escape to another world.",
+        "Tim is writing articles about fantasy novels for an online magazine, an opportunity he found on a fantasy lit forum. He shared his ideas with the magazine, and they liked them, which he finds very rewarding. | Involving: Tim | Tim loves fantasy and finds it awesome to spread his love for the genre through his writing.",
+        "Tim and John share a mutual interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim does not surf, but finds escape, happiness, and freedom (bliss) by reading great fantasy books in a comfy spot, comparing it to being in another world. | Involving: Tim",
+        "Tim and John both love fantasy books because they offer an escape from reality into different worlds for adventure. | Involving: Tim, John",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim enjoys getting lost in fantasy realms as a form of escape. | Involving: Tim (user)",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | When: Currently | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim has a fantasy reading hobby and loves sinking into different magical worlds; he is trying to juggle this hobby with studying. | Involving: Tim",
+        "Tim is always on the lookout for new books to read. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, excellent world-building, and character development. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, with Lord of the Rings being his favorite. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 67,
+      "question": "What would be a good hobby related to his travel dreams for Tim to pick up?",
+      "expected_answer": "Writing a travel blog.",
+      "relevant_facts": [
+        "Tim is proud of researching visa requirements, viewing it as taking initiative towards his travel dreams. | Involving: Tim (user) | It makes him feel like he's making progress towards his travel goals.",
+        "Tim finds nature refreshing and considers it a good break from school. | Involving: Tim",
+        "Tim loves going on road trips with friends and family, exploring, hiking, and playing board games. He also enjoys curling up with a good book in his free time to escape reality. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim read a story about two hikers who trekked through the Himalayas, which was described as tough but worth it, involving challenging terrain, altitude sickness, and bad weather, but leading to amazing sights. | Involving: Tim (reader), two hikers | The story motivated Tim for his own travel plans.",
+        "Tim is reading stories from travelers around the world to plan his next adventure. | Involving: Tim",
+        "Tim recommends visiting castles in Europe, describing them as magical. | Involving: Tim | He finds castles magical.",
+        "Tim is researching visa requirements for places he wants to visit, finding it overwhelming but exciting. | Involving: Tim (user) | He is excited about making his travel dreams a reality.",
+        "Tim read an awesome book about castles in the UK, found it very interesting, and dreams of visiting them one day. | Involving: Tim",
+        "Tim has always been interested in different cultures and countries. | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "Tim joined a travel club. | Involving: Tim | He is interested in different cultures and countries, and excited to meet new people and learn about what makes them unique.",
+        "Tim plans to add Barcelona to his travel list. | Involving: Tim (user) | He heard great things about it and liked John's suggestion.",
+        "Tim has been writing more articles, which he enjoys as it allows him to combine his love for reading and sharing great stories. | Involving: Tim",
+        "Tim plans to visit more Harry Potter related spots in the future because it makes him feel like he is stepping into the books. | When: In the future | Involving: Tim | It makes him feel like he is stepping into the books.",
+        "Tim loves traveling, believes it is eye-opening, and wants to visit Paris to see the Eiffel Tower for himself. | Involving: Tim",
+        "Tim loves traveling to new places to experience a different kind of magic. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, whose books he finds captivating due to their detail and creative storytelling. He takes notes on her style for his own writing and has been reading her works for a long time. | Involving: Tim, J.K. Rowling",
+        "Tim is writing articles about fantasy novels for an online magazine, an opportunity he found on a fantasy lit forum. He shared his ideas with the magazine, and they liked them, which he finds very rewarding. | Involving: Tim | Tim loves fantasy and finds it awesome to spread his love for the genre through his writing.",
+        "Tim's fantasy writing is going well; he is in the middle of writing a fantasy novel, which he finds nerve-wracking but exciting, and feels his hard work is paying off. Writing brings him joy. | Involving: Tim",
+        "Tim offered to provide John with tips for visiting Harry Potter places. | Involving: Tim, John",
+        "Tim visited a castle in the UK and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Italy is on Tim's list of places to visit. | Involving: Tim",
+        "Tim's creativity for writing is fired up by books, movies, real-life experiences, and certain authors. Reading about castles in the UK specifically gave him loads of ideas. | Involving: Tim",
+        "Tim plans to keep up with his German lessons. | Involving: Tim",
+        "Tim wants to visit New York City and has added it to his travel list, excited to explore and try things out. | Involving: Tim | John's positive description of New York City.",
+        "John offered to help Tim with his travel plans and encouraged him to reach out anytime he needs assistance. | Involving: John, Tim",
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | Involving: Tim | To explore nature and see the ocean views and cliffs.",
+        "Tim has visited Europe before. | Involving: Tim",
+        "Tim plans to stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim | Galway is known for its arts, Irish music, and vibrant atmosphere.",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | Involving: Tim | To gather information for planning his next adventure.",
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim | For a study abroad program",
+        "Tim is currently learning German and finds it tough but fun. | Involving: Tim",
+        "The upcoming trip will be Tim's first time visiting Universal Studios, and he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim (user)",
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it.",
+        "Tim finds learning German tough but worth it, and likes its structure, noting it's easier than French which he took in high school. | Involving: Tim",
+        "Tim joined a group of globetrotters who share his interests. | Involving: Tim, globetrotters",
+        "Tim is passionate about writing and reading, which helps him stay motivated and push himself to get better. | Involving: Tim",
+        "Tim uses an app for language learning. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes from different fantasy novels, and making book recommendations. | Involving: Tim",
+        "Tim experienced a setback last week when his attempt to write a story based on his experiences in the UK did not go as he wanted. | When: Last week (around 2023-11-14) | Involving: Tim",
+        "Tim wants to explore more real Harry Potter places someday. | When: Someday | Involving: Tim",
+        "Tim believes that creating a constructive atmosphere, setting an example through hard work, and using personal stories can inspire others. | Involving: Tim (user)",
+        "Tim plans to reflect on what went wrong with his storytelling and how to improve, based on John's advice. | Involving: Tim",
+        "Tim has always wanted to try the seafood in Seattle. | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim finds nature calming, a \"reset for the soul,\" and believes it makes people feel tiny but connected, reminding them they are part of something bigger. He also likes being in the mountains. | Involving: Tim (user)",
+        "Tim was accepted into a study abroad program he applied for. | When: Friday, January 5, 2024 | Involving: Tim",
+        "Tim took a trip last summer. | When: Last summer | Involving: Tim (user)",
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim",
+        "Tim suggested Edinburgh, Scotland, as a destination for John's team trip, highlighting its magical vibe, Harry Potter connection, history, architecture, and beauty. | Involving: Tim, John",
+        "Tim is planning a trip to Universal Studios next month. | When: Next month (September 2023) | Involving: Tim (user)",
+        "Tim experienced a significant and frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually resolved it by getting his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 68,
+      "question": "What day did Tim get into his study abroad program?",
+      "expected_answer": "Januarty 5, 2024",
+      "relevant_facts": [
+        "Tim was accepted into a study abroad program he applied for. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 69,
+      "question": "When will Tim leave for Ireland?",
+      "expected_answer": "February, 2024",
+      "relevant_facts": [
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim | For a study abroad program",
+        "Tim plans to stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim | Galway is known for its arts, Irish music, and vibrant atmosphere."
+      ]
+    },
+    {
+      "q_idx": 70,
+      "question": "Which Star Wars-related locations would Tim enjoy during his visit to Ireland?",
+      "expected_answer": "Skellig Michael, Malin Head, Loop Head, Ceann Sib\u00e9al, and Brow Head because they are Star Wars filming locations.",
+      "relevant_facts": [
+        "Tim plans to visit more Harry Potter related spots in the future because it makes him feel like he is stepping into the books. | When: In the future | Involving: Tim | It makes him feel like he is stepping into the books.",
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | Involving: Tim | To explore nature and see the ocean views and cliffs.",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "Tim enjoys getting lost in fantasy realms as a form of escape. | Involving: Tim (user)",
+        "Tim plans to stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim | Galway is known for its arts, Irish music, and vibrant atmosphere.",
+        "Tim loves reading because it allows him to escape to another world, and he has a collection of books for this purpose. | Involving: Tim | Reading allows him to escape to another world.",
+        "Tim finds nature refreshing and considers it a good break from school. | Involving: Tim",
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim | For a study abroad program",
+        "Tim does not surf, but finds escape, happiness, and freedom (bliss) by reading great fantasy books in a comfy spot, comparing it to being in another world. | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim enjoys fantasy books like Lord of the Rings because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim and John both love fantasy books because they offer an escape from reality into different worlds for adventure. | Involving: Tim, John",
+        "Tim wants to explore more real Harry Potter places someday. | When: Someday | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, enjoying epic adventures and magical worlds, with Lord of the Rings being his favorite. | Involving: Tim",
+        "Tim has a fantasy reading hobby and loves sinking into different magical worlds; he is trying to juggle this hobby with studying. | Involving: Tim",
+        "Tim loves traveling to new places to experience a different kind of magic. | Involving: Tim",
+        "Tim finds nature calming, a \"reset for the soul,\" and believes it makes people feel tiny but connected, reminding them they are part of something bigger. He also likes being in the mountains. | Involving: Tim (user)",
+        "Tim was accepted into a study abroad program he applied for. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 71,
+      "question": "Which team did John sign with on 21 May, 2023?",
+      "expected_answer": "The Minnesota Wolves",
+      "relevant_facts": [
+        "John signed with the Minnesota Wolves. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 72,
+      "question": "What is John's position on the team he signed with?",
+      "expected_answer": "shooting guard",
+      "relevant_facts": [
+        "John is a shooting guard for the Minnesota Wolves. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 73,
+      "question": "What challenge did John encounter during pre-season training?",
+      "expected_answer": "fitting into the new team's style of play",
+      "relevant_facts": [
+        "John found fitting into the new team's style of play challenging during pre-season training. | When: During pre-season | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 74,
+      "question": "What aspects of the Harry Potter universe will be discussed in John's fan project collaborations?",
+      "expected_answer": "characters, spells, magical creatures",
+      "relevant_facts": [
+        "Tim and John are discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "Tim is working on a Harry Potter fan project and is discussing collaborations for it. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 75,
+      "question": "What forum did Tim join recently?",
+      "expected_answer": "fantasy literature forum",
+      "relevant_facts": [
+        "Tim is writing articles about fantasy novels for an online magazine, an opportunity he found on a fantasy lit forum. He shared his ideas with the magazine, and they liked them, which he finds very rewarding. | Involving: Tim | Tim loves fantasy and finds it awesome to spread his love for the genre through his writing.",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 76,
+      "question": "What kind of picture did Tim share as part of their Harry Potter book collection?",
+      "expected_answer": "MinaLima's creation from the Harry Potter films",
+      "relevant_facts": [
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, and he loves their work, viewing it as a piece of the wizarding world at home. | Involving: Tim",
+        "Tim recently reorganized his bookshelf and shared a photo of it, noting it contains some of his favorite fantasy books. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 77,
+      "question": "What was the highest number of points John scored in a game recently?",
+      "expected_answer": "40 points",
+      "relevant_facts": [
+        "John scored 40 points in a game, which was his highest score ever, indicating that his hard work is paying off. | When: Last week | Involving: John | It was his personal best score, showing the results of his hard work."
+      ]
+    },
+    {
+      "q_idx": 78,
+      "question": "What did John celebrate at a restaurant with teammates?",
+      "expected_answer": "a tough win",
+      "relevant_facts": [
+        "John and his teammates celebrated their tough win at a restaurant, feeling exhausted but happy, laughing and reliving intense moments. | When: After the game last week | Involving: John, John's teammates | It was a joyful celebration of their victory and a bonding experience."
+      ]
+    },
+    {
+      "q_idx": 79,
+      "question": "What kind of deals did John sign with Nike and Gatorade?",
+      "expected_answer": "basketball shoe and gear deal with Nike, potential sponsorship deal with Gatorade",
+      "relevant_facts": [
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 80,
+      "question": "Which city is John excited to have a game at?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "John loves Seattle for its energy, diversity, awesome food (recommending local seafood), and the incredible support from fans at games. | Involving: John",
+        "John has a game scheduled in Seattle next month. | When: Next month | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 81,
+      "question": "How long has John been surfing?",
+      "expected_answer": "five years",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with friends, describing the experience as unreal, exciting, and free-feeling due to the connection to nature. | When: Started five years ago; had an awesome summer in the past | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 82,
+      "question": "How does John feel while surfing?",
+      "expected_answer": "super exciting and free-feeling",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with friends, describing the experience as unreal, exciting, and free-feeling due to the connection to nature. | When: Started five years ago; had an awesome summer in the past | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 83,
+      "question": "What kind of articles has Tim been writing about for the online magazine?",
+      "expected_answer": "different fantasy novels, characters, themes, and book recommendations",
+      "relevant_facts": [
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones, and he is very enthusiastic about them. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine, an opportunity he found on a fantasy lit forum. He shared his ideas with the magazine, and they liked them, which he finds very rewarding. | Involving: Tim | Tim loves fantasy and finds it awesome to spread his love for the genre through his writing.",
+        "Tim's articles for the online magazine involve studying characters and themes from different fantasy novels, and making book recommendations. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 84,
+      "question": "Which two fantasy novels does Tim particularly enjoy writing about?",
+      "expected_answer": "Harry Potter and Game of Thrones",
+      "relevant_facts": [
+        "Tim is writing articles about fantasy novels for an online magazine, an opportunity he found on a fantasy lit forum. He shared his ideas with the magazine, and they liked them, which he finds very rewarding. | Involving: Tim | Tim loves fantasy and finds it awesome to spread his love for the genre through his writing.",
+        "Tim's favorite fantasy novels to write about are Harry Potter and Game of Thrones, and he is very enthusiastic about them. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes from different fantasy novels, and making book recommendations. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 85,
+      "question": "What did Anthony and John end up playing during the charity event?",
+      "expected_answer": "an intense Harry Potter trivia contest",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a 'super-nerd' won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd"
+      ]
+    },
+    {
+      "q_idx": 86,
+      "question": "What did John share with the person he skyped about?",
+      "expected_answer": "Characters from Harry Potter",
+      "relevant_facts": [
+        "Tim and John are discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 87,
+      "question": "How did John describe the team bond?",
+      "expected_answer": "Awesome",
+      "relevant_facts": [
+        "John's team has an awesome bond that makes all the hard work worth it. | Involving: John, John's team"
+      ]
+    },
+    {
+      "q_idx": 88,
+      "question": "How did John get introduced to basketball?",
+      "expected_answer": "Dad signed him up for a local league",
+      "relevant_facts": [
+        "When John turned ten, his dad signed him up for a local basketball league, and he has been playing ever since. | When: When John was ten | Involving: John, John's dad | This was a significant step in his basketball journey."
+      ]
+    },
+    {
+      "q_idx": 89,
+      "question": "What is John's number one goal in his basketball career?",
+      "expected_answer": "Winning a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John | This is his main professional aspiration."
+      ]
+    },
+    {
+      "q_idx": 90,
+      "question": "What organization is John teaming up with for his charity work?",
+      "expected_answer": "A local organization helping disadvantaged kids with sports and school",
+      "relevant_facts": [
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | This is his concrete plan to achieve his goal of making a difference off the court.",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create more opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs."
+      ]
+    },
+    {
+      "q_idx": 91,
+      "question": "When did John meet back up with his teammates after his trip in August 2023?",
+      "expected_answer": "Aug 15th",
+      "relevant_facts": [
+        "John reunited with his teammates on the 15th after his trip, feeling very welcome and lucky to be part of the team, experiencing an electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball as a sign of their friendship and love when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 92,
+      "question": "What did John's teammates give him when they met on Aug 15th?",
+      "expected_answer": "a basketball with autographs on it",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a sign of their friendship and love when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 93,
+      "question": "Why did John's teammates sign the basketball they gave him?",
+      "expected_answer": "to show their friendship and appreciation",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a sign of their friendship and love when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | As a sign of their friendship and love."
+      ]
+    },
+    {
+      "q_idx": 94,
+      "question": "What is the main intention behind Tim wanting to attend the book conference?",
+      "expected_answer": "to learn more about literature and create a stronger bond to it",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 95,
+      "question": "What new activity has Tim started learning in August 2023?",
+      "expected_answer": "play the piano",
+      "relevant_facts": [
+        "Tim has been focusing on school, reading fantasy books to de-stress, and learning to play the piano, finding the progress satisfying. | When: Since he last talked to John | Involving: Tim",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 96,
+      "question": "Which movie's theme is Tim's favorite to play on the piano?",
+      "expected_answer": "\"Harry Potter and the Philosopher's Stone\"",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim",
+        "\"Harry Potter and the Philosopher's Stone\" is a special movie for Tim because it was the first in the series and brings back magical memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family | The movie evokes special family memories."
+      ]
+    },
+    {
+      "q_idx": 97,
+      "question": "What special memory does \"Harry Potter and the Philosopher's Stone\" bring to Tim?",
+      "expected_answer": "Watching it with his family",
+      "relevant_facts": [
+        "\"Harry Potter and the Philosopher's Stone\" is a special movie for Tim because it was the first in the series and brings back magical memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family | The movie evokes special family memories."
+      ]
+    },
+    {
+      "q_idx": 98,
+      "question": "Which movie does Tim mention they enjoy watching during Thanksgiving?",
+      "expected_answer": "\"Home Alone\"",
+      "relevant_facts": [
+        "Tim and his family find Thanksgiving special, enjoying prepping the feast, discussing gratitude, and watching movies afterward. | Involving: Tim (and his family)",
+        "Tim and his family enjoy watching \"Home Alone,\" \"Elf,\" and \"The Santa Clause\" during the holidays, finding them funny, heartwarming, and festive. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 99,
+      "question": "What tradition does Tim mention they love during Thanksgiving?",
+      "expected_answer": "Prepping the feast and talking about what they're thankful for",
+      "relevant_facts": [
+        "Tim and his family find Thanksgiving special, enjoying prepping the feast, discussing gratitude, and watching movies afterward. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 100,
+      "question": "How long did John and his high school basketball teammates play together?",
+      "expected_answer": "Four years",
+      "relevant_facts": [
+        "John and his friends were teammates for four years in high school. | When: High school | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 101,
+      "question": "How was John's experience in New York City?",
+      "expected_answer": "Amazing",
+      "relevant_facts": [
+        "John loves discovering new cities and found New York City amazing, enjoying exploring the city and trying all the restaurants, culture, and food. He recommends it as a must-visit adventure. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 102,
+      "question": "What did John say about NYC, enticing Tim to visit?",
+      "expected_answer": "It's got so much to check out - the culture, food - you won't regret it.",
+      "relevant_facts": [
+        "John loves discovering new cities and found New York City amazing, enjoying exploring the city and trying all the restaurants, culture, and food. He recommends it as a must-visit adventure. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 103,
+      "question": "What kind of soup did John make recently?",
+      "expected_answer": "tasty soup with sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty soup. | When: Recently | Involving: John",
+        "John used sage as a spice in the soup he recently made. | Involving: John | For flavor"
+      ]
+    },
+    {
+      "q_idx": 104,
+      "question": "What spice did John add to the soup for flavor?",
+      "expected_answer": "sage",
+      "relevant_facts": [
+        "John used sage as a spice in the soup he recently made. | Involving: John | For flavor"
+      ]
+    },
+    {
+      "q_idx": 105,
+      "question": "What is Tim excited to see at Universal Studios?",
+      "expected_answer": "The Harry Potter stuff",
+      "relevant_facts": [
+        "The upcoming trip will be Tim's first time visiting Universal Studios, and he is particularly excited about the Harry Potter attractions. | When: Next month (September 2023) | Involving: Tim (user)",
+        "Tim is planning a trip to Universal Studios next month. | When: Next month (September 2023) | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 106,
+      "question": "Where are John and his teammates planning to explore on a team trip?",
+      "expected_answer": "a new city",
+      "relevant_facts": [
+        "John and his new teammates are planning a team trip next month to explore a new city and have some fun. | When: Next month (October 2023) | Involving: John, John's new teammates | To have some fun."
+      ]
+    },
+    {
+      "q_idx": 107,
+      "question": "What city did Tim suggest to John for the team trip next month?",
+      "expected_answer": "Edinburgh, Scotland",
+      "relevant_facts": [
+        "John liked Tim's suggestion of Edinburgh, Scotland, and will consider it for the team trip. | Involving: John, Tim",
+        "Tim suggested Edinburgh, Scotland, as a destination for John's team trip, highlighting its magical vibe, Harry Potter connection, history, architecture, and beauty. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 108,
+      "question": "What does John want to do after his basketball career?",
+      "expected_answer": "positively influence and inspire others, potentially start a foundation and engage in charity work",
+      "relevant_facts": [
+        "John also wants to make a difference away from the court through charity work or inspiring people, as he feels basketball has been good to him and he wants to give back. | Involving: John | He wants to use his platform for positive community impact.",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work to leave a meaningful legacy. | Involving: John | John wants to make the most of his chances and leave a meaningful legacy.",
+        "John hopes to use his platform to have a positive impact on the community and inspire others. | Involving: John | This is the desired outcome of his charity work."
+      ]
+    },
+    {
+      "q_idx": 109,
+      "question": "What advice did Tim give John about picking endorsements?",
+      "expected_answer": "Ensure they align with values and brand, look for companies that share the desire to make a change and help others, make sure the endorsement feels authentic",
+      "relevant_facts": [
+        "Tim advised John to pick endorsements that align with his values and brand, are from companies that share his desire to make a change and help others, and feel authentic to his followers. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 110,
+      "question": "What book recommendation did Tim give to John for the trip?",
+      "expected_answer": "A fantasy novel by Patrick Rothfuss",
+      "relevant_facts": [
+        "John asked Tim for book recommendations for his trip. | Involving: John, Tim",
+        "Tim recommended the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss to John, suggesting it would be great for his trip. | Involving: Tim, John, Patrick Rothfuss",
+        "John plans to add \"The Name of the Wind\" to his reading list based on Tim's recommendation. | Involving: John, Tim",
+        "Tim recommended a book by Patrick Rothfuss to John, describing it as \"awesome\" and praising the author's world-building and character development. | When: Wednesday, August 09, 2023 | Involving: Tim, John, Patrick Rothfuss",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, excellent world-building, and character development. | Involving: Tim",
+        "John and his new teammates are planning a team trip next month to explore a new city and have some fun. | When: Next month (October 2023) | Involving: John, John's new teammates | To have some fun."
+      ]
+    },
+    {
+      "q_idx": 111,
+      "question": "What type of venue did John and his girlfriend choose for their wedding ceremony?",
+      "expected_answer": "Greenhouse",
+      "relevant_facts": [
+        "John and his wife found a lovely greenhouse venue for their wedding, which was a smaller, more intimate gathering, and they followed necessary safety protocols. | When: Last week | Involving: John, John's wife, loved ones | To ensure everyone felt safe and to celebrate with loved ones."
+      ]
+    },
+    {
+      "q_idx": 112,
+      "question": "What was the setting for John and his wife's first dance?",
+      "expected_answer": "Cozy restaurant",
+      "relevant_facts": [
+        "John and his wife had their first dance at a cozy restaurant, which was described as dreamy with music and candlelight. | When: Last week | Involving: John, John's wife, loved ones"
+      ]
+    },
+    {
+      "q_idx": 113,
+      "question": "Which basketball team does Tim support?",
+      "expected_answer": "The Wolves",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 114,
+      "question": "What passion does Tim mention connects him with people from all over the world?",
+      "expected_answer": "passion for fantasy stuff",
+      "relevant_facts": [
+        "John feels that his team connects him with others, similar to how Tim's passion for fantasy connects him with people. | Involving: John, Tim",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and inspiring, and feeling like he got a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 115,
+      "question": "How does John describe the game season for his team?",
+      "expected_answer": "intense with tough losses and great wins",
+      "relevant_facts": [
+        "John's team had an intense season, experiencing both tough losses and great wins, but overall performed well. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 116,
+      "question": "How does John say his team handles tough opponents?",
+      "expected_answer": "by backing each other up and not quitting",
+      "relevant_facts": [
+        "John's team is driven to improve by tough opponents, and they support each other, showing resilience. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 117,
+      "question": "What motivates John's team to get better, according to John?",
+      "expected_answer": "facing tough opponents",
+      "relevant_facts": [
+        "John's team is driven to improve by tough opponents, and they support each other, showing resilience. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 118,
+      "question": "What did John's team win at the end of the season?",
+      "expected_answer": "a trophy",
+      "relevant_facts": [
+        "John's team won a trophy, making him feel great and validating their hard work and effort. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 119,
+      "question": "Where did Tim capture the photography of the sunset over the mountain range?",
+      "expected_answer": "Smoky Mountains",
+      "relevant_facts": [
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 120,
+      "question": "How does John feel about being seen as a mentor by some of the younger players?",
+      "expected_answer": "It feels great",
+      "relevant_facts": [
+        "Some of the younger players see John as a mentor, which he finds rewarding. He tries to provide them with advice and support on and off the court and enjoys being a positive role model for them. | Involving: John, younger players",
+        "John is mentoring younger players on his team, which he finds super rewarding and loves as it allows him to share his skills and knowledge. It also helps him stay involved in the game during the off-season. | Involving: John, younger players (on John's team)",
+        "John feels great having the younger players' trust and admiration. He finds being a role model for these young athletes fulfilling and is glad his experiences can help shape their future and inspire them to go after their dreams. | Involving: John, younger players",
+        "John faces challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it rewarding to watch them develop and reach their goals. | Involving: John, younger players",
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad he could make a positive impact on their lives. | Involving: John, younger players",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 121,
+      "question": "What does John find rewarding about mentoring the younger players?",
+      "expected_answer": "Seeing their growth, improvement, and confidence",
+      "relevant_facts": [
+        "John faces challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it rewarding to watch them develop and reach their goals. | Involving: John, younger players",
+        "John finds seeing the younger players' growth, improvement, and confidence fulfilling, and is glad he could make a positive impact on their lives. | Involving: John, younger players"
+      ]
+    },
+    {
+      "q_idx": 122,
+      "question": "What has John been able to help the younger players achieve?",
+      "expected_answer": "reach their goals",
+      "relevant_facts": [
+        "John faces challenges mentoring due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it rewarding to watch them develop and reach their goals. | Involving: John, younger players"
+      ]
+    },
+    {
+      "q_idx": 123,
+      "question": "What genre is the novel that Tim is writing?",
+      "expected_answer": "Fantasy",
+      "relevant_facts": [
+        "Tim's fantasy writing is going well; he is in the middle of writing a fantasy novel, which he finds nerve-wracking but exciting, and feels his hard work is paying off. Writing brings him joy. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 124,
+      "question": "Who is one of Tim's sources of inspiration for writing?",
+      "expected_answer": "J.K. Rowling",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, whose books he finds captivating due to their detail and creative storytelling. He takes notes on her style for his own writing and has been reading her works for a long time. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 125,
+      "question": "What J.K. Rowling quote does Tim resonate with?",
+      "expected_answer": "\"Turn on the light - happiness hides in the darkest of times.\"",
+      "relevant_facts": [
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 126,
+      "question": "What does John write on the whiteboard to help him stay motivated?",
+      "expected_answer": "motivational quotes and strategies",
+      "relevant_facts": [
+        "John wrote motivational quotes and strategies on a whiteboard to help him stay focused and motivated during tough workouts and to keep improving. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 127,
+      "question": "What hobby is a therapy for John when away from the court?",
+      "expected_answer": "Cooking",
+      "relevant_facts": [
+        "John enjoys cuddling up with a book as his chill time and finds cooking therapeutic when he's away from the court, using it as a creative outlet and a break. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 128,
+      "question": "What type of meal does John often cook using a slow cooker?",
+      "expected_answer": "honey garlic chicken with roasted veg",
+      "relevant_facts": [
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes, and he enjoys trying out new recipes. | Involving: John",
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables. | When: Saturday, October 21, 2023 | Involving: Tim, John | Tim wants to try the delicious-sounding meal.",
+        "John committed to writing down and mailing the honey garlic chicken with roasted vegetables recipe to Tim. | When: Saturday, October 21, 2023 | Involving: John, Tim | To fulfill Tim's request for the recipe."
+      ]
+    },
+    {
+      "q_idx": 129,
+      "question": "How will John share the honey garlic chicken recipe with the other person?",
+      "expected_answer": "write it down and mail it",
+      "relevant_facts": [
+        "John committed to writing down and mailing the honey garlic chicken with roasted vegetables recipe to Tim. | When: Saturday, October 21, 2023 | Involving: John, Tim | To fulfill Tim's request for the recipe."
+      ]
+    },
+    {
+      "q_idx": 130,
+      "question": "What was Tim's huge writing issue last week,as mentioned on November 6, 2023?",
+      "expected_answer": "He got stuck on a plot twist",
+      "relevant_facts": [
+        "Tim experienced a significant and frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually resolved it by getting his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 131,
+      "question": "What does Tim have that serves as a reminder of hard work and is his prized possession?",
+      "expected_answer": "a basketball signed by his favorite player",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 132,
+      "question": "Why do Tim and John find LeBron inspiring?",
+      "expected_answer": "LeBron's determination and the epic block in Game 7 of the '16 Finals",
+      "relevant_facts": [
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John | He is inspired by LeBron's moments of determination and heart.",
+        "Tim's favorite basketball player is LeBron James. Tim was inspired by LeBron James' epic block in Game 7 of the 2016 Finals against Iguodala, which was a game-changing moment that led to a win and taught Tim the value of never giving up. John also recalls this specific block as an example of determination and heart that makes him love basketball. | When: Game 7 of the 2016 Finals (June 19, 2016) | Involving: Tim, John, LeBron James, Iguodala | It taught Tim the value of never giving up and exemplifies the determination and heart that makes John love basketball.",
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whom he admires for his skills, leadership, work ethic, and dedication. | Involving: John, LeBron"
+      ]
+    },
+    {
+      "q_idx": 133,
+      "question": "How did John describe the views during their road trip out on the European coastline?",
+      "expected_answer": "Spectacular",
+      "relevant_facts": [
+        "John and his wife took a road trip along the European coastline, enjoying spectacular views, bonding, and creating memories, which was a refreshing change from John's usual routine. | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 134,
+      "question": "What is one of Tim's favorite fantasy TV shows, as mentioned on November 11, 2023?",
+      "expected_answer": "\"That\"",
+      "relevant_facts": [
+        "\"That\" is one of Tim's favorite fantasy shows. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 135,
+      "question": "How does Tim stay motivated during difficult study sessions?",
+      "expected_answer": "Visualizing goals and success",
+      "relevant_facts": [
+        "Tim breaks up his studying into smaller parts, specifically 25 minutes on and 5 minutes off for something fun, to make it less overwhelming and stay on track. | Involving: Tim",
+        "Tim finds the idea of having a meaningful motivator inspiring and plans to keep it in mind for when he needs a push to reach his goals. | Involving: Tim",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 136,
+      "question": "What did Tim say about his injury on 16 November, 2023?",
+      "expected_answer": "The doctor said it's not too serious",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 137,
+      "question": "What was the setback Tim faced in his writing project on 21 November, 2023?",
+      "expected_answer": "Story based on experiences in the UK didn't go as planned",
+      "relevant_facts": [
+        "Tim experienced a setback last week when his attempt to write a story based on his experiences in the UK did not go as he wanted. | When: Last week (around 2023-11-14) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 138,
+      "question": "How did John overcome his ankle injury from last season?",
+      "expected_answer": "stayed focused on recovery and worked hard to strengthen his body",
+      "relevant_facts": [
+        "Last season, John hurt his ankle, which required time off and physical therapy. This experience was a tough mental and physical challenge that taught him the importance of patience and perseverance. | When: Last season (prior to November 2023) | Involving: John | It was a major challenge that led to personal growth and learning.",
+        "John is passionate about basketball and uses this love and enthusiasm to stay motivated during tough times. | Involving: John",
+        "John includes strength training in his basketball routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism. | Involving: John | These are the benefits for basketball performance.",
+        "John's motivation during challenging times comes from his teammates' belief in him and his love for improving his skills, driven by a desire not to let them down. | Involving: John, John's teammates",
+        "John believes that persevering through struggles, especially in sports, leads to greater satisfaction and personal development. | Involving: John",
+        "John is currently recovering from an injury, which he describes as tough but he is staying positive and taking it slow. | Involving: John",
+        "John created a workout schedule that balances basketball and strength training, and he prioritizes listening to his body and getting enough rest. | Involving: John | To stay on track, push himself during practice, and look after himself.",
+        "John and his wife hosted a small get-together with friends and family. | When: After December 15, 2023 | Involving: John, John's wife, friends, family | To celebrate John's success of jogging without pain.",
+        "John is doing daily physical therapy exercises as part of his rehabilitation to stay active. | When: Currently (ongoing) | Involving: John | To recover from his injury and stay active.",
+        "Basketball is very important to John; he practices and trains every day to stay in shape and improve, considering it his passion. | When: Every day | Involving: John | It is his passion and helps him stay in shape and improve.",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "When facing challenges on the basketball court, John tries to reflect on what went wrong and find ways to improve. | Involving: John",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a relief after being out for so long. | When: Friday, December 15, 2023 | Involving: John | It was a significant milestone in his recovery/training.",
+        "John is committed to growing and improving both on and off the court. | Involving: John",
+        "John injured himself, causing him to miss basketball games and be unable to help his team. | When: Not too long ago (relative to December 16, 2023) | Involving: John (and his team)",
+        "John stated he will keep pushing forward. | Involving: John",
+        "John keeps a plaque on his desk that serves as a constant reminder to believe in himself, helping him trust his abilities and stay motivated to face obstacles. | Involving: John",
+        "Incorporating strength training significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, which also boosted his confidence. | Involving: John | It gave him an upper hand over opponents and helped him up his game.",
+        "John plans to keep pushing and staying positive. | Involving: John",
+        "John wrote motivational quotes and strategies on a whiteboard to help him stay focused and motivated during tough workouts and to keep improving. | Involving: John",
+        "John enjoys practicing specific yoga poses, including Warrior II, which makes him feel strong, and another pose that helps with balance and stability, as they challenge his body and mind. | Involving: John",
+        "John believes that taking time for oneself is crucial for staying sharp, focused, gaining new perspectives, and tackling challenges with more energy. He intends to keep the importance of finding the right balance in mind as he continues his journey. | Involving: John",
+        "John took a picture during a morning workout, which serves as a reminder that the journey can be awesome. | Involving: John | To remind himself that the journey can be awesome.",
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and trust the process, leaving him feeling hopeful. | When: Recently | Involving: John | The book inspired and motivated him to pursue his dreams.",
+        "John is currently reading an inspiring book that reminds him to keep dreaming and motivates him to keep reaching for new goals. | Involving: John",
+        "John found a new gym to maintain his basketball skills, which is essential for his professional basketball career. | When: Sunday, August 20, 2023 | Involving: John | To stay fit and survive in pro ball."
+      ]
+    },
+    {
+      "q_idx": 139,
+      "question": "What motivated Tim to keep pushing himself to get better in writing and reading?",
+      "expected_answer": "Love for writing and reading",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, whose books he finds captivating due to their detail and creative storytelling. He takes notes on her style for his own writing and has been reading her works for a long time. | Involving: Tim, J.K. Rowling",
+        "Tim is passionate about writing and reading, which helps him stay motivated and push himself to get better. | Involving: Tim",
+        "Tim's fantasy writing is going well; he is in the middle of writing a fantasy novel, which he finds nerve-wracking but exciting, and feels his hard work is paying off. Writing brings him joy. | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it allows him to combine his love for reading and sharing great stories. | Involving: Tim",
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 140,
+      "question": "How did John overcome a mistake he made during a big game in basketball?",
+      "expected_answer": "Worked hard to get better and focused on growth",
+      "relevant_facts": [
+        "John made a mistake during a big basketball game, which was hard to accept, but he worked to improve and learned the importance of resilience and owning up to mistakes. | Involving: John | It was a significant learning experience that shaped his approach to challenges."
+      ]
+    },
+    {
+      "q_idx": 141,
+      "question": "What book did John recently finish rereading that left him feeling inspired and hopeful about following dreams?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and trust the process, leaving him feeling hopeful. | When: Recently | Involving: John | The book inspired and motivated him to pursue his dreams."
+      ]
+    },
+    {
+      "q_idx": 142,
+      "question": "How did \"The Alchemist\" impact John's perspective on following dreams?",
+      "expected_answer": "made him think again about following dreams and searching for personal legends",
+      "relevant_facts": [
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and trust the process, leaving him feeling hopeful. | When: Recently | Involving: John | The book inspired and motivated him to pursue his dreams.",
+        "John read and loved \"The Alchemist\", which made him think about life and the importance of following one's dreams. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 143,
+      "question": "What is John trying out to improve his strength and flexibility after recovery from ankle injury?",
+      "expected_answer": "yoga",
+      "relevant_facts": [
+        "John has noticed improvements in his strength, flexibility, focus, and balance during workouts as a result of practicing yoga. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John typically holds the Warrior II yoga pose for 30-60 seconds to build strength and stability. | Involving: John",
+        "Last season, John hurt his ankle, which required time off and physical therapy. This experience was a tough mental and physical challenge that taught him the importance of patience and perseverance. | When: Last season (prior to November 2023) | Involving: John | It was a major challenge that led to personal growth and learning.",
+        "John is currently recovering from an injury, which he describes as tough but he is staying positive and taking it slow. | Involving: John",
+        "John is doing daily physical therapy exercises as part of his rehabilitation to stay active. | When: Currently (ongoing) | Involving: John | To recover from his injury and stay active.",
+        "John enjoys practicing specific yoga poses, including Warrior II, which makes him feel strong, and another pose that helps with balance and stability, as they challenge his body and mind. | Involving: John",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a relief after being out for so long. | When: Friday, December 15, 2023 | Involving: John | It was a significant milestone in his recovery/training."
+      ]
+    },
+    {
+      "q_idx": 144,
+      "question": "How long does John usually hold the yoga pose he shared with Tim?",
+      "expected_answer": "30-60 seconds",
+      "relevant_facts": [
+        "Tim plans to try the Warrior II yoga pose. | Involving: Tim (user) | John shared details and a photo of the pose, inspiring Tim to try it.",
+        "John enjoys practicing specific yoga poses, including Warrior II, which makes him feel strong, and another pose that helps with balance and stability, as they challenge his body and mind. | Involving: John",
+        "John typically holds the Warrior II yoga pose for 30-60 seconds to build strength and stability. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 145,
+      "question": "Where was the forest picture shared by John on December 1,2023 taken?",
+      "expected_answer": "near his hometown",
+      "relevant_facts": [
+        "John shared a photo of a tranquil forest located near his hometown. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 146,
+      "question": "What did Tim recently start learning in addition to being part of a travel club and working on studies?",
+      "expected_answer": "an instrument",
+      "relevant_facts": [
+        "Tim has been swamped with studies and projects. | Involving: Tim",
+        "Tim joined a travel club. | Involving: Tim | He is interested in different cultures and countries, and excited to meet new people and learn about what makes them unique.",
+        "Tim recently started learning an instrument. | Involving: Tim | He has always admired musicians and is finally trying it.",
+        "Tim is working on his studies. | Involving: Tim",
+        "Tim has been focusing on school, reading fantasy books to de-stress, and learning to play the piano, finding the progress satisfying. | When: Since he last talked to John | Involving: Tim",
+        "Tim has been swamped with exams this week. | When: This week | Involving: Tim",
+        "Tim is learning to play the violin. | Involving: Tim | It's a great way to chill and get creative.",
+        "Tim joined a group of globetrotters who share his interests. | Involving: Tim, globetrotters",
+        "Tim is doing well in school, balancing his studies with relaxing by reading books, and is currently hooked on a book he is reading. | Involving: Tim",
+        "Tim is currently busy and overwhelmed with assignments and exams. | When: This week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 147,
+      "question": "What instrument is Tim learning to play in December 2023?",
+      "expected_answer": "violin",
+      "relevant_facts": [
+        "Tim is learning to play the violin. | Involving: Tim | It's a great way to chill and get creative.",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 148,
+      "question": "How long has Tim been playing the piano for, as of December 2023?",
+      "expected_answer": "about four months",
+      "relevant_facts": [
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)",
+        "Tim has been focusing on school, reading fantasy books to de-stress, and learning to play the piano, finding the progress satisfying. | When: Since he last talked to John | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 149,
+      "question": "What book did Tim just finish reading on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim just finished reading 'A Dance with Dragons' and highly recommends it. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 150,
+      "question": "Which book did Tim recommend to John as a good story on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 151,
+      "question": "What is the topic of discussion between John and Tim on 11 December, 2023?",
+      "expected_answer": "Academic achievements and sports successes",
+      "relevant_facts": [
+        "John felt great making plays for his team, enjoying seeing his teammates succeed from the opportunities he created. The arena atmosphere was electric, and playing against rivals added an extra level of intensity, making it a memorable night. | When: Last Friday | Involving: John, John's teammates, John's rivals | Describes John's positive experience and feelings about his career-high game.",
+        "Tim is currently busy and overwhelmed with assignments and exams. | When: This week | Involving: Tim",
+        "Tim has been swamped with exams this week. | When: This week | Involving: Tim",
+        "John's team won an intense basketball game by a tight score last week, with John scoring the last basket. | When: Last week | Involving: John, John's team, crowd",
+        "John achieved a career-high in assists during a big basketball game against his team's rival. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 152,
+      "question": "What kind of game did John have a career-high in assists in?",
+      "expected_answer": "basketball",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a big basketball game against his team's rival. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 153,
+      "question": "What was John's way of dealing with doubts and stress when he was younger?",
+      "expected_answer": "practicing basketball outside for hours",
+      "relevant_facts": [
+        "The picture reminds John of his younger days when he would practice basketball outside for hours, dreaming of playing in big games. Practicing basketball was his way of dealing with doubts and stress, and he finds it amazing how powerful a ball and hoop can be. | When: When John was younger | Involving: John | Explains John's deep connection to basketball and its role in his life."
+      ]
+    },
+    {
+      "q_idx": 154,
+      "question": "How did John feel about the atmosphere during the big game against the rival team?",
+      "expected_answer": "electric and intense",
+      "relevant_facts": [
+        "John felt great making plays for his team, enjoying seeing his teammates succeed from the opportunities he created. The arena atmosphere was electric, and playing against rivals added an extra level of intensity, making it a memorable night. | When: Last Friday | Involving: John, John's teammates, John's rivals | Describes John's positive experience and feelings about his career-high game."
+      ]
+    },
+    {
+      "q_idx": 155,
+      "question": "How did John feel after being able to jog without pain?",
+      "expected_answer": "It was a huge success.",
+      "relevant_facts": [
+        "John and his wife hosted a small get-together with friends and family. | When: After December 15, 2023 | Involving: John, John's wife, friends, family | To celebrate John's success of jogging without pain.",
+        "John achieved a milestone at the gym by being able to jog a bit with no pain, which was a relief after being out for so long. | When: Friday, December 15, 2023 | Involving: John | It was a significant milestone in his recovery/training."
+      ]
+    },
+    {
+      "q_idx": 156,
+      "question": "What kind of deal did John get in December?",
+      "expected_answer": "Deal with a renowned outdoor gear company",
+      "relevant_facts": [
+        "John participated in a photoshoot in a gorgeous forest where the photographer captured epic shots for his endorsement deal. | Involving: John, photographer | For the endorsement deal.",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John | Part of the endorsement deal.",
+        "John shared a picture from the photoshoot with Tim. | When: Tuesday, December 19, 2023 | Involving: John, Tim | Tim requested to see a picture from the photoshoot.",
+        "John secured an amazing endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 157,
+      "question": "Where was the photoshoot done for John's gear deal?",
+      "expected_answer": "In a gorgeous forest",
+      "relevant_facts": [
+        "John participated in a photoshoot in a gorgeous forest where the photographer captured epic shots for his endorsement deal. | Involving: John, photographer | For the endorsement deal."
+      ]
+    },
+    {
+      "q_idx": 158,
+      "question": "In which area has John's team seen the most growth during training?",
+      "expected_answer": "Communication and bonding",
+      "relevant_facts": [
+        "John's team has experienced significant growth in communication and bonding, which has improved their performances by allowing them to understand each other's strengths and weaknesses. | Involving: John, John's team | The growth in communication and bonding has helped their performances."
+      ]
+    },
+    {
+      "q_idx": 159,
+      "question": "What type of seminars is John conducting?",
+      "expected_answer": "Sports and marketing seminars",
+      "relevant_facts": [
+        "John started doing seminars to help people with sports and marketing, which has been going well. | When: This week (prior to December 26, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 160,
+      "question": "What activity did Tim do after reading the stories about the Himalayan trek?",
+      "expected_answer": "visited a travel agency",
+      "relevant_facts": [
+        "Tim read a story about two hikers who trekked through the Himalayas, which was described as tough but worth it, involving challenging terrain, altitude sickness, and bad weather, but leading to amazing sights. | Involving: Tim (reader), two hikers | The story motivated Tim for his own travel plans.",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | Involving: Tim | To gather information for planning his next adventure."
+      ]
+    },
+    {
+      "q_idx": 161,
+      "question": "What is one cause that John supports with his influence and resources?",
+      "expected_answer": "youth sports and fair chances in sports",
+      "relevant_facts": [
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create more opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | This is his concrete plan to achieve his goal of making a difference off the court.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience filled with laughs, high-fives, and personal growth for everyone involved. | When: Summer 2023 | Involving: John, kids | It was an opportunity to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 162,
+      "question": "What new fantasy TV series is Tim excited about?",
+      "expected_answer": "\"The Wheel of Time\"",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\", which is based on a book series he loves and is scheduled to be released next month. | When: Next month | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 163,
+      "question": "Which language is Tim learning?",
+      "expected_answer": "German",
+      "relevant_facts": [
+        "Tim is currently learning German and finds it tough but fun. | Involving: Tim",
+        "Tim finds learning German tough but worth it, and likes its structure, noting it's easier than French which he took in high school. | Involving: Tim",
+        "Tim plans to keep up with his German lessons. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 164,
+      "question": "What language does Tim know besides German?",
+      "expected_answer": "Spanish",
+      "relevant_facts": [
+        "Tim finds learning German tough but worth it, and likes its structure, noting it's easier than French which he took in high school. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 165,
+      "question": "What book did Tim get in Italy that inspired him to cook?",
+      "expected_answer": "a cooking book",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 166,
+      "question": "What is John's favorite book series?",
+      "expected_answer": "Harry Potter",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a 'super-nerd' won a signed Harry Potter book as a prize. | Involving: John, Anthony, super-nerd",
+        "Tim and John are discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "Tim offered to provide John with tips for visiting Harry Potter places. | Involving: Tim, John",
+        "John enjoys being with people who are passionate about Harry Potter. | Involving: John",
+        "John has not visited any real Harry Potter places but plans to add visiting them to his to-do list. | Involving: John",
+        "John loves \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter movie collection. | Involving: John",
+        "John is a fan of Harry Potter movies. | Involving: John",
+        "John previously attended a Harry Potter charity event that included trivia. | When: Last August | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 167,
+      "question": "According to John, who is his favorite character from Lord of the Rings?",
+      "expected_answer": "Aragorn",
+      "relevant_facts": [
+        "John's favorite character is Aragorn from Lord of the Rings, finding him inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 168,
+      "question": "Why does John like Aragorn from Lord of the Rings?",
+      "expected_answer": "brave, selfless, down-to-earth attitude",
+      "relevant_facts": [
+        "John's favorite character is Aragorn from Lord of the Rings, finding him inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, and commitment to justice. | Involving: John",
+        "John has a painting of Aragorn in his room, which serves as a reminder for him to stay true and be a leader. | Involving: John | To remind him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 169,
+      "question": "What kind of painting does John have in his room as a reminder?",
+      "expected_answer": "a painting of Aragorn",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room, which serves as a reminder for him to stay true and be a leader. | Involving: John | To remind him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 170,
+      "question": "What is the painting of Aragorn a reminder for John to be in everything he does?",
+      "expected_answer": "be a leader",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room, which serves as a reminder for him to stay true and be a leader. | Involving: John | To remind him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 171,
+      "question": "What map does Tim show to his friend John?",
+      "expected_answer": "a map of Middle-earth from LOTR",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 172,
+      "question": "Where will Tim be going for a semester abroad?",
+      "expected_answer": "Ireland",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | Involving: Tim | To explore nature and see the ocean views and cliffs.",
+        "Tim plans to go to Ireland for a semester next month as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim | For a study abroad program",
+        "Tim plans to stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim | Galway is known for its arts, Irish music, and vibrant atmosphere."
+      ]
+    },
+    {
+      "q_idx": 173,
+      "question": "Which city in Ireland will Tim be staying in during his semester abroad?",
+      "expected_answer": "Galway",
+      "relevant_facts": [
+        "Tim plans to stay in Galway, Ireland, which he notes is known for its arts, Irish music, and vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim | Galway is known for its arts, Irish music, and vibrant atmosphere."
+      ]
+    },
+    {
+      "q_idx": 174,
+      "question": "What charity event did John organize recently in 2024?",
+      "expected_answer": "benefit basketball game",
+      "relevant_facts": [
+        "John held a successful benefit basketball game last week, which raised money for charity and had a great turnout. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity."
+      ]
+    },
+    {
+      "q_idx": 175,
+      "question": "What achievement did John share with Tim in January 2024?",
+      "expected_answer": "endorsement with a popular beverage company",
+      "relevant_facts": [
+        "John secured an endorsement with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It is a dream come true for him.",
+        "Tim advised John to pick endorsements that align with his values and brand, are from companies that share his desire to make a change and help others, and feel authentic to his followers. | Involving: Tim, John",
+        "John asked Tim for advice on how to pick the right endorsements. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 176,
+      "question": "What was Johns's reaction to sealing the deal with the beverage company?",
+      "expected_answer": "crazy feeling, sense of accomplishment",
+      "relevant_facts": [
+        "John felt crazy and accomplished after sealing the endorsement deal, believing his hard work and training hours paid off. | Involving: John | The endorsement made him feel that all his hard work was worth it.",
+        "John secured an endorsement with a popular beverage company. | When: Last week (between January 1 and January 7, 2024) | Involving: John | It is a dream come true for him."
+      ]
+    },
+    {
+      "q_idx": 177,
+      "question": "Which city did John recommend to Tim in January 2024?",
+      "expected_answer": "Barcelona",
+      "relevant_facts": [
+        "John recommends Barcelona as a must-visit city, highlighting its culture, architecture, food, and beaches. | Involving: John",
+        "Tim plans to add Barcelona to his travel list. | Involving: Tim (user) | He heard great things about it and liked John's suggestion."
+      ]
+    }
+  ],
+  "embedding_id": "bge-small-en-v1.5",
+  "bank_id": "emb_bge-small-en-v1-5_1772557344"
+}

--- a/benchmark-runner/datasets/locomo_embeddings_gt_cohere-embed-english-light-v3-0.json
+++ b/benchmark-runner/datasets/locomo_embeddings_gt_cohere-embed-english-light-v3-0.json
@@ -1,0 +1,1854 @@
+{
+  "annotations": [
+    {
+      "q_idx": 0,
+      "question": "what are John's goals with regards to his basketball career?",
+      "expected_answer": "improve shooting percentage, win a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John",
+        "John is focusing on improving his shooting and making more impact on the court, aiming to be a consistent performer and help his team. Off-court, he is seeking more endorsements and building his brand, as he considers life after basketball. | Involving: John",
+        "John's goal is to improve his shooting percentage. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 1,
+      "question": "What are John's goals for his career that are not related to his basketball skills?",
+      "expected_answer": "get endorsements, build his brand, do charity work",
+      "relevant_facts": [
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy after his basketball career. | Involving: John",
+        "John uses his contacts in the basketball industry and his marketing skills for networking to secure endorsements. | Involving: John",
+        "John also wants to make a difference away from the court through charity work or by inspiring people. | Involving: John | He feels basketball has been great to him and he wants to give something back.",
+        "John's professional growth includes improving his overall basketball game, securing endorsement deals, and learning to market himself and boost his brand. | Involving: John",
+        "John is exploring endorsement opportunities with brands, which excites him and makes him feel rewarded by his hard work. | Involving: John | To work with brands and do something special, as a payoff for his hard work.",
+        "John is focusing on improving his shooting and making more impact on the court, aiming to be a consistent performer and help his team. Off-court, he is seeking more endorsements and building his brand, as he considers life after basketball. | Involving: John",
+        "John is making progress with exploring endorsements and has talked to some big companies, which looks promising. | Involving: John",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform for positive community impact and to inspire others.",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "John plans to keep Tim updated on which brands he chooses for endorsement opportunities. | Involving: John, Tim",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in, including speaking at charity events. | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John | To find suitable brands for collaboration.",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John",
+        "John started doing seminars to help people with their sports and marketing. | When: recently | Involving: John",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports.",
+        "John shared a picture from his photoshoot. | Involving: John",
+        "John had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | When: Last week | Involving: John, photographer",
+        "John asked Tim for advice on how to pick the right endorsements. | When: Thursday, September 21, 2023 | Involving: John (user), Tim (assistant) | John is looking into more endorsements and building his brand.",
+        "Tim advised John to pick endorsements that align with his values and brand, suggesting he look for companies that share his desire to make a change and help others, ensuring authenticity to his followers. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John (user) | In response to John's request for advice on picking endorsements."
+      ]
+    },
+    {
+      "q_idx": 2,
+      "question": "What items does John collect?",
+      "expected_answer": "sneakers, fantasy movie DVDs, jerseys",
+      "relevant_facts": [
+        "John loves talking to people about his sneaker collection. | Involving: John",
+        "John loves \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter collection. | Involving: John",
+        "John likes to collect jerseys. | Involving: John",
+        "John is a fan of Harry Potter movies. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 3,
+      "question": "Would Tim enjoy reading books by C. S. Lewis or John Greene?",
+      "expected_answer": "C. S.Lewis",
+      "relevant_facts": [
+        "Tim recommended a book by Patrick Rothfuss, praising its amazing world-building and character development. | Involving: Tim, John | Tim thinks the book is 'awesome'.",
+        "Tim reads fantasy books as a way to take a break from stress. | Involving: Tim | To relieve stress",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | When: Currently (as of Aug 9, 2023) | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim and John are friends and both share an interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim enjoys \"The Hobbit\" and another popular fantasy series, appreciating how these books transport readers to different worlds, offering a break from reality and an adventure. | Involving: Tim",
+        "Tim does not surf. He finds escape, freedom, and bliss by reading great fantasy books in a comfy spot, comparing it to John's experience with surfing. | Involving: Tim",
+        "Tim enjoys fantasy stories but also reads books on growth, psychology, and self-improvement to better himself. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he enjoys because they transport him to other places. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim (user's conversation partner)",
+        "Tim loves reading, finding it a way to escape to other worlds, and has a collection of books for this purpose. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes of different fantasy novels and making book recommendations. | Involving: Tim",
+        "Tim finds fantasy books like Lord of the Rings awesome because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim has only read the Game of Thrones series by George R. R. Martin. | Involving: Tim (user's conversation partner), George R. R. Martin",
+        "Tim finds peace in reading fantasy books. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting, and believes his hard work is paying off. | Involving: Tim",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim",
+        "Tim is interested in reading and fantasy novels, enjoying sinking into different magical worlds. | Involving: Tim",
+        "The TV series \"The Wheel of Time\" is based on a book series that Tim loves. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim | To discuss his favorite books and connect with others.",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim is currently reading an inspiring fantasy novel series about the power of friendship and loyalty. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" describing its protagonist as a magician and musician, and praising its world-building and character development. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds. | Involving: Tim",
+        "Tim is looking at a map of Middle-earth from Lord of the Rings and finds it cool to see all the different realms and regions. | Involving: Tim",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim's favorite movie is Lord of the Rings. | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim is trying to find a way to juggle studying with his fantasy reading hobby. | Involving: Tim | To manage his overwhelming academic workload and personal interests.",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum because he loves fantasy, and the magazine liked his ideas. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim enjoys getting lost in fantasy realms as an escape, and \"That\" is one of his favorite fantasy shows. | Involving: Tim",
+        "Tim uses reminders of the wizarding world as a way to escape reality. | Involving: Tim | To escape reality."
+      ]
+    },
+    {
+      "q_idx": 4,
+      "question": "What books has Tim read?",
+      "expected_answer": "Harry Potter, Game of Thrones, the Name of the Wind, The Alchemist, The Hobbit, A Dance with Dragons, and the Wheel of Time.",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim plans to visit more Harry Potter-related spots in the future, which makes him feel like he's stepping into the books. | When: In the future | Involving: Tim | To feel like he's stepping into the books.",
+        "Tim recommended a book by Patrick Rothfuss, praising its amazing world-building and character development. | Involving: Tim, John | Tim thinks the book is 'awesome'.",
+        "Tim enjoys \"The Hobbit\" and another popular fantasy series, appreciating how these books transport readers to different worlds, offering a break from reality and an adventure. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back | Involving: Tim",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim",
+        "Tim visited a Harry Potter-related place in London a few years ago and went on an amazing tour, describing it as like walking into a Harry Potter movie. | When: a few years ago | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim would love to explore real Harry Potter places someday. | When: someday | Involving: Tim",
+        "Tim is planning his first trip to Universal Studios next month and is excited for the Harry Potter attractions. | When: Next month | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he enjoys because they transport him to other places. | Involving: Tim",
+        "The TV series \"The Wheel of Time\" is based on a book series that Tim loves. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim (user's conversation partner)",
+        "Tim feels a strong connection and love when surrounded by people who share the same passion, as he experienced with the Harry Potter fan. | Involving: Tim",
+        "John remembers Tim previously mentioning Harry Potter. | Involving: John, Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" describing its protagonist as a magician and musician, and praising its world-building and character development. | Involving: Tim",
+        "Tim has only read the Game of Thrones series by George R. R. Martin. | Involving: Tim (user's conversation partner), George R. R. Martin",
+        "Tim is a huge fan of Emma Watson, the main actress in Harry Potter, and is inspired by her strong support for gender equality and women's rights advocacy. | Involving: Tim, Emma Watson (main actress in Harry Potter)",
+        "Tim uses reminders of the wizarding world as a way to escape reality. | Involving: Tim | To escape reality.",
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "Tim is working on a Harry Potter fan project and has been discussing collaborations for it. | Involving: Tim",
+        "Tim had a nice and magical chat with a Harry Potter fan. | When: Last week | Involving: Tim, a Harry Potter fan",
+        "Tim recently attended a Harry Potter party where he met many like-minded people and had a lot of fun. | When: Friday, December 08, 2023 | Involving: Tim",
+        "Tim felt inspired and gained a new lease of life after attending the Harry Potter conference. | When: Last week | Involving: Tim | The conference connected him with people who shared his passion.",
+        "Tim attended a Harry Potter conference in the UK. | When: Last week | Involving: Tim",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim",
+        "Tim has a picture from MinaLima, who created all the props for the Harry Potter films, and he loves their work because it feels like having a piece of the wizarding world at home. | Involving: Tim, MinaLima | He loves their work and it connects him to the wizarding world.",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: Recently | Involving: Tim, Harry Potter fan (met in CA)",
+        "Tim decorated his Christmas tree himself with a Harry Potter theme, which he found to be a fun project and was happy with the result. | When: Last year (likely December 2022) | Involving: Tim | He enjoyed the project and was pleased with the outcome.",
+        "Tim offered to provide tips for visiting Harry Potter places. | Involving: Tim",
+        "Last week, Tim talked to a friend, who is a Harry Potter fan, to figure out ideas for his Harry Potter fan project. | When: Last week (May 14-20, 2023) | Involving: Tim, Tim's friend | To figure out ideas for the project.",
+        "Tim suggested Edinburgh, Scotland, as a destination for John's team trip, highlighting its magical vibe, history, architecture, beauty, and connection to Harry Potter. | Involving: Tim, John | As a suggestion for John's team trip",
+        "Tim recommended \"The Name of the Wind,\" a fantasy novel by Patrick Rothfuss, to John for his trip. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John (user), Patrick Rothfuss (author) | In response to John's request for book recommendations.",
+        "Tim wore his Gryffindor scarf to the Harry Potter party. | When: Friday, December 08, 2023 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 5,
+      "question": "Based on Tim's collections, what is a shop that he would enjoy visiting in New York city?",
+      "expected_answer": "House of MinaLima",
+      "relevant_facts": [
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim",
+        "Tim wants to visit New York City and has added it to his travel list. | Involving: Tim | He heard there's so much to explore and try out, and John's recommendation.",
+        "Tim has a picture from MinaLima, who created all the props for the Harry Potter films, and he loves their work because it feels like having a piece of the wizarding world at home. | Involving: Tim, MinaLima | He loves their work and it connects him to the wizarding world."
+      ]
+    },
+    {
+      "q_idx": 6,
+      "question": "In which month's game did John achieve a career-high score in points?",
+      "expected_answer": "June 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 7,
+      "question": "Which geographical locations has Tim been to?",
+      "expected_answer": "California, London, the Smoky Mountains",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-related place in London a few years ago and went on an amazing tour, describing it as like walking into a Harry Potter movie. | When: a few years ago | Involving: Tim",
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | When: Recently | Involving: Tim, Harry Potter fan (met in CA)",
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 8,
+      "question": "Which outdoor gear company likely signed up John for an endorsement deal?",
+      "expected_answer": "Under Armour",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John | To find suitable brands for collaboration.",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John likes Under Armour and dreams of working with them. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 9,
+      "question": "Which endorsement deals has John been offered?",
+      "expected_answer": "basketball shoes and gear deal with Nike, potential sponsorship with Gatorade, Moxie a popular beverage company, outdoor gear company",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (January 1-7, 2024) | Involving: John | It is a dream come true and a result of his hard work.",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 10,
+      "question": "When was John in Seattle for a game?",
+      "expected_answer": "early August, 2023",
+      "relevant_facts": [
+        "John loves Seattle's energy, diversity, and food, specifically mentioning local seafood as a must-try. He also appreciates the incredible support from fans at games in Seattle. | Involving: John",
+        "John's team won an intense basketball game by a tight score, with John scoring the last basket. | When: Last week (between July 31 and August 6, 2023) | Involving: John, John's team, crowd"
+      ]
+    },
+    {
+      "q_idx": 11,
+      "question": "What sports does John like besides basketball?",
+      "expected_answer": "surfing",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling of riding waves as \"unreal,\" \"super exciting,\" and \"free-feeling.\" He started surfing five years ago and loves the connection to nature it provides. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 12,
+      "question": "What year did John start surfing?",
+      "expected_answer": "2018",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling of riding waves as \"unreal,\" \"super exciting,\" and \"free-feeling.\" He started surfing five years ago and loves the connection to nature it provides. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 13,
+      "question": "What does Tim do to escape reality?",
+      "expected_answer": "Read fantasy books.",
+      "relevant_facts": [
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | When: Currently (as of Aug 9, 2023) | Involving: Tim",
+        "Tim enjoys \"The Hobbit\" and another popular fantasy series, appreciating how these books transport readers to different worlds, offering a break from reality and an adventure. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he enjoys because they transport him to other places. | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim does not surf. He finds escape, freedom, and bliss by reading great fantasy books in a comfy spot, comparing it to John's experience with surfing. | Involving: Tim",
+        "Tim finds fantasy books like Lord of the Rings awesome because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim loves reading, finding it a way to escape to other worlds, and has a collection of books for this purpose. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim is trying to find a way to juggle studying with his fantasy reading hobby. | Involving: Tim | To manage his overwhelming academic workload and personal interests.",
+        "Tim loves to get lost in good books in his downtime. | Involving: Tim",
+        "Tim finds peace in reading fantasy books. | Involving: Tim",
+        "Tim is interested in reading and fantasy novels, enjoying sinking into different magical worlds. | Involving: Tim",
+        "Tim reads fantasy books as a way to take a break from stress. | Involving: Tim | To relieve stress"
+      ]
+    },
+    {
+      "q_idx": 14,
+      "question": "What kind of writing does Tim do?",
+      "expected_answer": "comments on favorite books in a fantasy literature forum, articles on fantasy novels, studying characters, themes, and making book recommendations, writing a fantasy novel",
+      "relevant_facts": [
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim's passions are writing and reading, which help him stay motivated and improve. | Involving: Tim | They help him stay motivated and push himself to get better.",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum because he loves fantasy, and the magazine liked his ideas. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting, and believes his hard work is paying off. | Involving: Tim",
+        "Tim has been writing more articles, which allows him to combine his love for reading and the joy of sharing great stories. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and got his ideas flowing again. | When: Last week | Involving: Tim",
+        "Tim draws inspiration for his stories from books, movies, real-life experiences (like reading about UK castles), and certain authors. | Involving: Tim",
+        "Tim had a tough time with his English lit class and did an analysis on a series for it. | Involving: Tim",
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go as he wanted, which he finds tough. | When: Last week | Involving: Tim",
+        "Tim is working on a Harry Potter fan project and has been discussing collaborations for it. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim | To discuss his favorite books and connect with others.",
+        "Tim's articles for the online magazine involve studying characters and themes of different fantasy novels and making book recommendations. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 15,
+      "question": "Who is Anthony?",
+      "expected_answer": "likely John's friend, colleague or family",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 16,
+      "question": "After how many weeks did Tim reconnect with the fellow Harry Potter fan from California?",
+      "expected_answer": "three weeks",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 17,
+      "question": "How many games has John mentioned winning?",
+      "expected_answer": "6",
+      "relevant_facts": [
+        "The best part of the recent basketball win for John was the camaraderie built with his team, which felt amazing and was worth the hard work. | When: recently | Involving: John, John's basketball team | The camaraderie made the win feel amazing and justified the hard work.",
+        "John's favorite game in his career was when he hit a buzzer-beater shot to win after his team was down by 10 points in the 4th quarter, an experience that made him love basketball. | Involving: John",
+        "John's team won an intense basketball game by a tight score, with John scoring the last basket. | When: Last week (between July 31 and August 6, 2023) | Involving: John, John's team, crowd",
+        "John's basketball team recently played a top team, fought hard, and won the game. | When: recently | Involving: John, John's basketball team",
+        "John's basketball team was trailing significantly in the 4th quarter of a game last year but managed to overturn the deficit and win, which was an amazing and unforgettable feeling. | When: Last year | Involving: John",
+        "John and his teammates won a tough basketball game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 18,
+      "question": "What authors has Tim read books from?",
+      "expected_answer": "J.K. Rowling, R.R. Martin, Patrick Rothfuss, Paulo Coelho, and J. R. R. Tolkien.",
+      "relevant_facts": [
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim finds fantasy books like Lord of the Rings awesome because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising its amazing world-building and character development. | Involving: Tim, John | Tim thinks the book is 'awesome'.",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim",
+        "Tim enjoys \"The Hobbit\" and another popular fantasy series, appreciating how these books transport readers to different worlds, offering a break from reality and an adventure. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he enjoys because they transport him to other places. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim (user's conversation partner)",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back | Involving: Tim",
+        "Tim has only read the Game of Thrones series by George R. R. Martin. | Involving: Tim (user's conversation partner), George R. R. Martin",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" describing its protagonist as a magician and musician, and praising its world-building and character development. | Involving: Tim",
+        "Tim is looking at a map of Middle-earth from Lord of the Rings and finds it cool to see all the different realms and regions. | Involving: Tim",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim",
+        "Tim recommended \"The Name of the Wind,\" a fantasy novel by Patrick Rothfuss, to John for his trip. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John (user), Patrick Rothfuss (author) | In response to John's request for book recommendations."
+      ]
+    },
+    {
+      "q_idx": 19,
+      "question": "What is a prominent charity organization that John might want to work with and why?",
+      "expected_answer": "Good Sports, because they work with Nike, Gatorade, and Under Armour and they aim toprovide youth sports opportunities for kids ages 3-18 in high-need communities.",
+      "relevant_facts": [
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform for positive community impact and to inspire others.",
+        "John also wants to make a difference away from the court through charity work or by inspiring people. | Involving: John | He feels basketball has been great to him and he wants to give something back.",
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy after his basketball career. | Involving: John",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John is exploring endorsement opportunities with brands, which excites him and makes him feel rewarded by his hard work. | Involving: John | To work with brands and do something special, as a payoff for his hard work.",
+        "John is focusing on improving his shooting and making more impact on the court, aiming to be a consistent performer and help his team. Off-court, he is seeking more endorsements and building his brand, as he considers life after basketball. | Involving: John",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity and bring people together.",
+        "John uses his contacts in the basketball industry and his marketing skills for networking to secure endorsements. | Involving: John",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in, including speaking at charity events. | Involving: John",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony",
+        "John plans to keep Tim updated on which brands he chooses for endorsement opportunities. | Involving: John, Tim",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John | To find suitable brands for collaboration.",
+        "John's professional growth includes improving his overall basketball game, securing endorsement deals, and learning to market himself and boost his brand. | Involving: John",
+        "John is making progress with exploring endorsements and has talked to some big companies, which looks promising. | Involving: John",
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)",
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John",
+        "John felt a sense of accomplishment and validation, believing his hard work and training hours paid off after sealing the endorsement deal. | Involving: John | It validated his efforts and hard work.",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and using it as a way to stay involved in the game during the off-season. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports.",
+        "John held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (January 1-7, 2024) | Involving: John | It is a dream come true and a result of his hard work.",
+        "John asked Tim for advice on how to pick the right endorsements. | When: Thursday, September 21, 2023 | Involving: John (user), Tim (assistant) | John is looking into more endorsements and building his brand.",
+        "Tim advised John to pick endorsements that align with his values and brand, suggesting he look for companies that share his desire to make a change and help others, ensuring authenticity to his followers. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John (user) | In response to John's request for advice on picking endorsements."
+      ]
+    },
+    {
+      "q_idx": 20,
+      "question": "Which city was John in before traveling to Chicago?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. He values experiencing other cultures and connecting with new people. | Involving: John",
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John loves Seattle's energy, diversity, and food, specifically mentioning local seafood as a must-try. He also appreciates the incredible support from fans at games in Seattle. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 21,
+      "question": "Which US cities does John mention visiting to Tim?",
+      "expected_answer": "Seattle, Chicago, New York",
+      "relevant_facts": [
+        "John loves discovering new cities and has visited New York City. | Involving: John",
+        "John found New York City amazing, exciting, and enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John",
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. He values experiencing other cultures and connecting with new people. | Involving: John",
+        "John loves Seattle's energy, diversity, and food, specifically mentioning local seafood as a must-try. He also appreciates the incredible support from fans at games in Seattle. | Involving: John",
+        "John initially had trouble figuring out the subway during his NYC trip, but it became easy after someone helped explain it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 22,
+      "question": "When did John meet with his teammates after returning from Chicago?",
+      "expected_answer": "August 15, 2023",
+      "relevant_facts": [
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. He values experiencing other cultures and connecting with new people. | Involving: John",
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and appreciating the electric atmosphere and team bond. | When: August 15, 2023 | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 23,
+      "question": "When is Tim attending a book conference?",
+      "expected_answer": "September 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 24,
+      "question": "Where was John between August 11 and August 15 2023?",
+      "expected_answer": "Chicago",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and as a reminder of their bond.",
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and appreciating the electric atmosphere and team bond. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. He values experiencing other cultures and connecting with new people. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 25,
+      "question": "What similar sports collectible do Tim and John own?",
+      "expected_answer": "signed basketball",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It reminds him of hard work.",
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 26,
+      "question": "Which TV series does Tim mention watching?",
+      "expected_answer": "That, Wheel of Time",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" coming out next month. | When: Next month | Involving: Tim",
+        "Tim enjoys getting lost in fantasy realms as an escape, and \"That\" is one of his favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 27,
+      "question": "Which popular time management technique does Tim use to prepare for exams?",
+      "expected_answer": "Pomodoro technique",
+      "relevant_facts": [
+        "Tim's study trick involves breaking studying into 25-minute sessions followed by 5-minute breaks for fun, which he finds less overwhelming and effective for staying on track. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 28,
+      "question": "Which popular music composer's tunes does Tim enjoy playing on the piano?",
+      "expected_answer": "John Williams",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is the theme from \"Harry Potter and the Philosopher's Stone\", which is special to him because it was the first movie in the series and he watched it with his family, creating magical memories. | Involving: Tim, Tim's family | The movie brings back great memories of watching it with his family.",
+        "Tim started learning to play the piano and finds the progress satisfying. | When: Since the last conversation | Involving: Tim",
+        "Tim also plays the piano. | Involving: Tim",
+        "Tim is learning to play the violin and is interested in classical music, jazz, and film scores, viewing it as a way to relax and be creative. | Involving: Tim | To chill and get creative."
+      ]
+    },
+    {
+      "q_idx": 29,
+      "question": "What schools did John play basketball in and how many years was he with his team during high school?",
+      "expected_answer": "Middle school, high school, and college and he was with his high school team for 4 years.",
+      "relevant_facts": [
+        "John and his old friends were teammates for four years in high school. | When: During high school | Involving: John, John's old friends",
+        "John has been playing basketball since he was a kid, watching NBA games with his dad and dreaming of playing professionally. He joined a local league at age ten, played through middle and high school, earned a college scholarship, and was eventually drafted by a team after college. | When: Since childhood, specifically at age ten for the league, then through middle/high school, college, and after college. | Involving: John, John's dad | It was his childhood dream to play professionally."
+      ]
+    },
+    {
+      "q_idx": 30,
+      "question": "Which cities has John been to?",
+      "expected_answer": "Seattle, Chicago, New York, and Paris.",
+      "relevant_facts": [
+        "John loves discovering new cities and has visited New York City. | Involving: John",
+        "John found New York City amazing, exciting, and enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John",
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John loves Seattle's energy, diversity, and food, specifically mentioning local seafood as a must-try. He also appreciates the incredible support from fans at games in Seattle. | Involving: John",
+        "John initially had trouble figuring out the subway during his NYC trip, but it became easy after someone helped explain it. | Involving: John",
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. He values experiencing other cultures and connecting with new people. | Involving: John",
+        "John has traveled to Paris, loved it, and found the view from the Eiffel Tower incredible. He believes traveling helps you see new things and is educational. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 31,
+      "question": "What month did Tim plan on going to Universal Studios?",
+      "expected_answer": "September, 2023",
+      "relevant_facts": [
+        "Tim is planning his first trip to Universal Studios next month and is excited for the Harry Potter attractions. | When: Next month | Involving: Tim",
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it.",
+        "Tim is currently busy and overwhelmed with assignments and exams. | When: This week (relative to August 26, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 32,
+      "question": "Which US states might Tim be in during September 2023 based on his plans of visiting Universal Studios?",
+      "expected_answer": "California or Florida",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 33,
+      "question": "When does John plan on traveling with his team on a team trip?",
+      "expected_answer": "October, 2023",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip next month (October 2023) to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To have some fun"
+      ]
+    },
+    {
+      "q_idx": 34,
+      "question": "What could John do after his basketball career?",
+      "expected_answer": "become a basketball coach since he likes giving back and leadership",
+      "relevant_facts": [
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy after his basketball career. | Involving: John",
+        "John is focusing on improving his shooting and making more impact on the court, aiming to be a consistent performer and help his team. Off-court, he is seeking more endorsements and building his brand, as he considers life after basketball. | Involving: John",
+        "John also wants to make a difference away from the court through charity work or by inspiring people. | Involving: John | He feels basketball has been great to him and he wants to give something back.",
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, and his commitment to putting others first and standing up for justice. | Involving: John, Aragorn | Aragorn's character traits and journey inspire John.",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity and bring people together.",
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires. | Involving: John, LeBron",
+        "John held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John has a painting of Aragorn in his room. | Involving: John, Aragorn | It serves as a reminder for John to stay true and be a leader in everything he does.",
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and using it as a way to stay involved in the game during the off-season. | Involving: John, younger players",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in, including speaking at charity events. | Involving: John",
+        "John started doing seminars to help people with their sports and marketing. | When: recently | Involving: John",
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)",
+        "John's tips for motivating others on a team include showing care, celebrating achievements, providing constructive feedback, reminding them of bigger goals, creating a positive environment, and giving pep talks before games. | Involving: John",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform for positive community impact and to inspire others.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports."
+      ]
+    },
+    {
+      "q_idx": 35,
+      "question": "What outdoor activities does John enjoy?",
+      "expected_answer": "Hiking, surfing",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling of riding waves as \"unreal,\" \"super exciting,\" and \"free-feeling.\" He started surfing five years ago and loves the connection to nature it provides. | Involving: John, John's friends",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John discovered the scenic spot shown in the picture while hiking. | Involving: John",
+        "Some of John's hiking club friends attended his wedding, despite him having only recently joined the club. | When: Last week | Involving: John, John's hiking club friends"
+      ]
+    },
+    {
+      "q_idx": 36,
+      "question": "Who is Tim and John's favorite basketball player?",
+      "expected_answer": "LeBron James",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires. | Involving: John, LeBron",
+        "Tim's favorite player is LeBron James, who inspires him with his determination, particularly recalling an epic block in a Finals game a few years ago that changed the game and led to a win. | When: A few years ago | Involving: Tim, LeBron James | LeBron's determination and the epic block inspire him."
+      ]
+    },
+    {
+      "q_idx": 37,
+      "question": "Which week did Tim visit the UK for the Harry Potter Conference?",
+      "expected_answer": "The week before October 13th, 2023.",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK. | When: Last week | Involving: Tim",
+        "Tim felt inspired and gained a new lease of life after attending the Harry Potter conference. | When: Last week | Involving: Tim | The conference connected him with people who shared his passion."
+      ]
+    },
+    {
+      "q_idx": 38,
+      "question": "which country has Tim visited most frequently in his travels?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-related place in London a few years ago and went on an amazing tour, describing it as like walking into a Harry Potter movie. | When: a few years ago | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK during his trip last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go as he wanted, which he finds tough. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 39,
+      "question": "What year did Tim go to the Smoky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 40,
+      "question": "Has Tim been to North Carolina and/or Tennesee states in the US?",
+      "expected_answer": "Yes",
+      "relevant_facts": [
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 41,
+      "question": "What kind of fiction stories does Tim write?",
+      "expected_answer": "Fantasy stories with plot twists",
+      "relevant_facts": [
+        "Tim loves how his passion for fantasy topics connects him with people from all over the world. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting, and believes his hard work is paying off. | Involving: Tim",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and got his ideas flowing again. | When: Last week | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 42,
+      "question": "What has John cooked?",
+      "expected_answer": "Soup, a slow cooker meal, and honey garlic chicken with roasted veg.",
+      "relevant_facts": [
+        "John offered to write down and mail the honey garlic chicken recipe to Tim. | Involving: John, Tim",
+        "John has been trying out cooking recipes and recently made a tasty soup using sage, which he made up on the spot. | When: Recently | Involving: John",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes. He also enjoys trying out new recipes. | Involving: John",
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables. | Involving: Tim, John",
+        "John asked Tim to inform him about the outcome of preparing the honey garlic chicken recipe. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 43,
+      "question": "What does John like about Lebron James?",
+      "expected_answer": "His heart, determination, skills, and leadership.",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires. | Involving: John, LeBron",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John",
+        "John remembers LeBron James's epic block in Game 7 of the 2016 Finals against Iguodala, where he pinned the ball against the backboard, and this determination and heart is a reason John loves basketball. | When: 2016 Finals (Game 7) | Involving: John, LeBron James, Iguodala | The determination and heart shown are why John loves basketball."
+      ]
+    },
+    {
+      "q_idx": 44,
+      "question": "When did John and his wife go on a European vacation?",
+      "expected_answer": "November, 2023.",
+      "relevant_facts": [
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 45,
+      "question": "Which country was Tim visiting in the second week of November?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a castle in the UK during his trip last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 46,
+      "question": "Where was Tim in the week before 16 November 2023?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a castle in the UK during his trip last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 47,
+      "question": "When did John get married at a greenhouse?",
+      "expected_answer": "last week of September 2023",
+      "relevant_facts": [
+        "John and his wife held their wedding ceremony in a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week | Involving: John, John's wife | To ensure everyone felt safe and to have their loved ones celebrate with them in an intimate setting."
+      ]
+    },
+    {
+      "q_idx": 48,
+      "question": "When did John get an ankle injury in 2023?",
+      "expected_answer": "around November 16, 2023",
+      "relevant_facts": [
+        "John focused on recovery and worked hard to strengthen his body after his ankle injury. | When: Last season | Involving: John | To overcome his ankle injury and return to playing.",
+        "John realized the importance of patience and perseverance from overcoming his ankle injury. | When: Last season | Involving: John | The experience of recovery taught him these values.",
+        "John found not being able to play or help his team frustrating due to his ankle injury. | When: Last season | Involving: John (and his team) | Inability to participate and contribute to the team.",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. | When: Last season | Involving: John",
+        "John injured himself not too long ago, which caused him to miss basketball games and be unable to help his team. | When: Not too long ago (prior to December 16, 2023) | Involving: John (and his team)",
+        "John achieved a milestone at the gym by jogging without pain, which was a huge relief after being out for so long. | When: Last Friday (December 15, 2023) | Involving: John | It was a huge success after being out for so long due to pain."
+      ]
+    },
+    {
+      "q_idx": 49,
+      "question": "How many times has John injured his ankle?",
+      "expected_answer": "two times",
+      "relevant_facts": [
+        "John focused on recovery and worked hard to strengthen his body after his ankle injury. | When: Last season | Involving: John | To overcome his ankle injury and return to playing.",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. | When: Last season | Involving: John",
+        "John injured himself not too long ago, which caused him to miss basketball games and be unable to help his team. | When: Not too long ago (prior to December 16, 2023) | Involving: John (and his team)",
+        "John realized the importance of patience and perseverance from overcoming his ankle injury. | When: Last season | Involving: John | The experience of recovery taught him these values.",
+        "John found not being able to play or help his team frustrating due to his ankle injury. | When: Last season | Involving: John (and his team) | Inability to participate and contribute to the team.",
+        "John achieved a milestone at the gym by jogging without pain, which was a huge relief after being out for so long. | When: Last Friday (December 15, 2023) | Involving: John | It was a huge success after being out for so long due to pain."
+      ]
+    },
+    {
+      "q_idx": 50,
+      "question": "Which book was John reading during his recovery from an ankle injury?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. | When: Last season | Involving: John",
+        "John recently finished rereading \"The Alchemist\", which inspired him to follow dreams and search for personal legends, making him feel motivated and hopeful. | When: Recently | Involving: John",
+        "John achieved a milestone at the gym by jogging without pain, which was a huge relief after being out for so long. | When: Last Friday (December 15, 2023) | Involving: John | It was a huge success after being out for so long due to pain."
+      ]
+    },
+    {
+      "q_idx": 51,
+      "question": "What kind of yoga for building core strength might John benefit from?",
+      "expected_answer": "Hatha Yoga",
+      "relevant_facts": [
+        "John shared a photo of himself in the Warrior II pose, explaining it is a good way to work out legs and core. | When: Friday, December 01, 2023 | Involving: John | To show Tim the pose he enjoys and for Tim to try it."
+      ]
+    },
+    {
+      "q_idx": 52,
+      "question": "What does John do to supplement his basketball training?",
+      "expected_answer": "Yoga, strength training",
+      "relevant_facts": [
+        "Incorporating strength training has significantly improved John's basketball performance by enhancing his shooting accuracy, agility, and speed, giving him an upper hand over opponents and boosting his confidence on the court. | Involving: John",
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, helps him become more explosive, and boosts his overall athleticism, which are all essential for basketball. | Involving: John",
+        "John had to overcome the hurdle of adapting and tweaking his routine at the new gym, eventually figuring out a balanced schedule that includes both basketball and strength training, while also listening to his body and ensuring enough rest. | Involving: John",
+        "John has noticed improvements from practicing yoga, including increased strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John is trying out yoga to gain strength and flexibility, finding it challenging but worthwhile. | Involving: John | To gain strength and flexibility.",
+        "John enjoys practicing specific yoga poses, including Warrior II (which makes him feel strong) and another that helps with balance and stability, loving how these poses challenge his body and mind. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John | To build strength and stability."
+      ]
+    },
+    {
+      "q_idx": 53,
+      "question": "What other exercises can help John with his basketball performance?",
+      "expected_answer": "Sprinting, long-distance running, and boxing.",
+      "relevant_facts": [
+        "Incorporating strength training has significantly improved John's basketball performance by enhancing his shooting accuracy, agility, and speed, giving him an upper hand over opponents and boosting his confidence on the court. | Involving: John",
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, helps him become more explosive, and boosts his overall athleticism, which are all essential for basketball. | Involving: John",
+        "John had to overcome the hurdle of adapting and tweaking his routine at the new gym, eventually figuring out a balanced schedule that includes both basketball and strength training, while also listening to his body and ensuring enough rest. | Involving: John",
+        "John enjoys practicing specific yoga poses, including Warrior II (which makes him feel strong) and another that helps with balance and stability, loving how these poses challenge his body and mind. | Involving: John",
+        "John has noticed improvements from practicing yoga, including increased strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John is trying out yoga to gain strength and flexibility, finding it challenging but worthwhile. | Involving: John | To gain strength and flexibility.",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John | To build strength and stability.",
+        "John achieved a milestone at the gym by jogging without pain, which was a huge relief after being out for so long. | When: Last Friday (December 15, 2023) | Involving: John | It was a huge success after being out for so long due to pain.",
+        "John shared a photo of himself in the Warrior II pose, explaining it is a good way to work out legs and core. | When: Friday, December 01, 2023 | Involving: John | To show Tim the pose he enjoys and for Tim to try it."
+      ]
+    },
+    {
+      "q_idx": 54,
+      "question": "When did John take a trip to the Rocky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "John took a stunning trip to the Rocky Mountains last year, finding nature great for clearing the mind and calming the soul, appreciating the fresh air and majestic peaks. | When: last year | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 55,
+      "question": "When did John start playing professionally?",
+      "expected_answer": "May, 2023",
+      "relevant_facts": [
+        "John plays as a shooting guard for the Minnesota Wolves. | Involving: John",
+        "John signed with the Minnesota Wolves. | When: Recently | Involving: John",
+        "The Minnesota Wolves' season opener is scheduled for next week. | When: Next week (May 22-28, 2023) | Involving: Minnesota Wolves (team)"
+      ]
+    },
+    {
+      "q_idx": 56,
+      "question": "When did Tim start playing the violin?",
+      "expected_answer": "August 2023",
+      "relevant_facts": [
+        "Tim is learning to play the violin and is interested in classical music, jazz, and film scores, viewing it as a way to relax and be creative. | Involving: Tim | To chill and get creative.",
+        "Tim is currently working on studies and recently started learning an instrument, which he finds challenging but fun due to his admiration for musicians. | When: Recently, as of December 6, 2023 | Involving: Tim | He always admired musicians.",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months as of December 6, 2023 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 57,
+      "question": "What instruments does Tim play?",
+      "expected_answer": "piano, violin",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is the theme from \"Harry Potter and the Philosopher's Stone\", which is special to him because it was the first movie in the series and he watched it with his family, creating magical memories. | Involving: Tim, Tim's family | The movie brings back great memories of watching it with his family.",
+        "Tim also plays the piano. | Involving: Tim",
+        "Tim started learning to play the piano and finds the progress satisfying. | When: Since the last conversation | Involving: Tim",
+        "Tim is learning to play the violin and is interested in classical music, jazz, and film scores, viewing it as a way to relax and be creative. | Involving: Tim | To chill and get creative."
+      ]
+    },
+    {
+      "q_idx": 58,
+      "question": "When did John attend the Harry Potter trivia?",
+      "expected_answer": "August 2023.",
+      "relevant_facts": [
+        "John attended a charity event featuring Harry Potter trivia. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 59,
+      "question": "Which career-high performances did John achieve in 2023?",
+      "expected_answer": "highest point score, highest assist",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a big basketball game against their rival. | When: Last Friday | Involving: John",
+        "John scored 40 points in a basketball game, which is his highest score ever, and feels his hard work is paying off. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 60,
+      "question": "When did John achieve a career-high assist performance?",
+      "expected_answer": "December 11, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 61,
+      "question": "What books has John read?",
+      "expected_answer": "inpsiring book on dreaming big, The Alchemist, fantasy series, non-fiction books on personal development, Dune",
+      "relevant_facts": [
+        "John is currently reading an inspiring book that reminds him to keep dreaming. | Involving: John",
+        "John read and loved \"The Alchemist\", finding that it made him think about life and the importance of following one's dreams. He highly recommends the book. | Involving: John",
+        "John recently finished an amazing fantasy series that had many twists, and he enjoys getting lost in fantasy worlds. | Involving: John",
+        "John likes non-fiction books about personal development and mindset, as they help him with self-knowledge. | Involving: John",
+        "John recently finished rereading \"The Alchemist\", which inspired him to follow dreams and search for personal legends, making him feel motivated and hopeful. | When: Recently | Involving: John",
+        "John is currently reading and enjoying \"Dune\" by Frank Herbert, which he highly recommends. He describes it as a great story about religion and human control over ecology. | Involving: John (user's conversation partner), Frank Herbert"
+      ]
+    },
+    {
+      "q_idx": 62,
+      "question": "What does John do to share his knowledge?",
+      "expected_answer": "gives seminars, mentors younger players.",
+      "relevant_facts": [
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and using it as a way to stay involved in the game during the off-season. | Involving: John, younger players",
+        "John started doing seminars to help people with their sports and marketing. | When: recently | Involving: John",
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)"
+      ]
+    },
+    {
+      "q_idx": 63,
+      "question": "When did John organize a basketball camp for kids?",
+      "expected_answer": "summer 2023",
+      "relevant_facts": [
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports."
+      ]
+    },
+    {
+      "q_idx": 64,
+      "question": "Which month was John in Italy?",
+      "expected_answer": "December, 2023",
+      "relevant_facts": [
+        "John visited Italy last month, finding the food, history, and architecture amazing. | When: Last month | Involving: John",
+        "John bought a book in Italy that has been inspiring his cooking. | When: Last month | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 65,
+      "question": "What fantasy movies does Tim like?",
+      "expected_answer": "Lord of the Rings, Harry Potter, and Star Wars.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim's favorite movie is Lord of the Rings. | Involving: Tim",
+        "Tim's favorite song to play on the piano is the theme from \"Harry Potter and the Philosopher's Stone\", which is special to him because it was the first movie in the series and he watched it with his family, creating magical memories. | Involving: Tim, Tim's family | The movie brings back great memories of watching it with his family.",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim is looking at a map of Middle-earth from Lord of the Rings and finds it cool to see all the different realms and regions. | Involving: Tim",
+        "Tim has special memories of watching \"Harry Potter and the Philosopher's Stone\" with his family, where they would get comfy with snacks and a blanket and be totally absorbed. | Involving: Tim, Tim's family | These moments were \"a dream come true\" and \"awesome\", full of magic.",
+        "Tim has a picture from MinaLima, who created all the props for the Harry Potter films, and he loves their work because it feels like having a piece of the wizarding world at home. | Involving: Tim, MinaLima | He loves their work and it connects him to the wizarding world.",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 66,
+      "question": "What is a Star Wars book that Tim might enjoy?",
+      "expected_answer": "Star Wars: Jedi Apprentice by Judy Blundell and David Farland. It is a highly rated and immersive series about his favorite movies.",
+      "relevant_facts": [
+        "Tim finds fantasy books like Lord of the Rings awesome because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from home. | Involving: Tim",
+        "Tim is interested in reading and fantasy novels, enjoying sinking into different magical worlds. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising its amazing world-building and character development. | Involving: Tim, John | Tim thinks the book is 'awesome'.",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and stimulating his imagination. | When: Currently (as of Aug 9, 2023) | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones, which he enjoys because they transport him to other places. | Involving: Tim",
+        "Tim enjoys \"The Hobbit\" and another popular fantasy series, appreciating how these books transport readers to different worlds, offering a break from reality and an adventure. | Involving: Tim",
+        "Tim loves reading, finding it a way to escape to other worlds, and has a collection of books for this purpose. | Involving: Tim",
+        "Tim's bookshelf is filled with his favorite fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim is always on the lookout for new books to read. | Involving: Tim (user's conversation partner)",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 67,
+      "question": "What would be a good hobby related to his travel dreams for Tim to pick up?",
+      "expected_answer": "Writing a travel blog.",
+      "relevant_facts": [
+        "Tim would love to explore real Harry Potter places someday. | When: someday | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting, and believes his hard work is paying off. | Involving: Tim",
+        "The book described the Himalayan trek as tough but worth it, involving challenging terrain, altitude sickness, and bad weather, but the hikers saw amazing sights, which motivated Tim. | Involving: Tim, hikers | The story motivated Tim for his own travel plans.",
+        "Tim draws inspiration for his stories from books, movies, real-life experiences (like reading about UK castles), and certain authors. | Involving: Tim",
+        "Tim loves traveling to new places to experience a different kind of magic. | Involving: Tim | It's one of the reasons he loves traveling.",
+        "Tim is researching visa requirements for various places he wants to visit, finding it overwhelming but exciting. | Involving: Tim | He wants to make his travel dreams a reality.",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim's articles for the online magazine involve studying characters and themes of different fantasy novels and making book recommendations. | Involving: Tim",
+        "Tim read an interesting book about castles in the UK and dreams of visiting them. | Involving: Tim",
+        "Tim is reading stories from travelers around the world from a book he found, using them to plan his next adventure. | Involving: Tim | To plan his next adventure.",
+        "Tim has been writing more articles, which allows him to combine his love for reading and the joy of sharing great stories. | Involving: Tim",
+        "Tim loves traveling, believes it is eye-opening, and wants to visit Paris to see the Eiffel Tower. | Involving: Tim",
+        "Tim joined a travel club because he is interested in different cultures and countries and wants to meet new people. | Involving: Tim | He is interested in different cultures and countries and wants to meet new people.",
+        "Tim visited a Harry Potter-related place in London a few years ago and went on an amazing tour, describing it as like walking into a Harry Potter movie. | When: a few years ago | Involving: Tim",
+        "Tim plans to visit more Harry Potter-related spots in the future, which makes him feel like he's stepping into the books. | When: In the future | Involving: Tim | To feel like he's stepping into the books.",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum because he loves fantasy, and the magazine liked his ideas. | Involving: Tim",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | When: Tuesday, December 26, 2023 | Involving: Tim | To plan his dream trip.",
+        "Tim joined a group of globetrotters who share his interests. | Involving: Tim",
+        "Tim loves how his passion for fantasy topics connects him with people from all over the world. | Involving: Tim",
+        "Tim's passions are writing and reading, which help him stay motivated and improve. | Involving: Tim | They help him stay motivated and push himself to get better.",
+        "Tim believes that creating a constructive atmosphere, setting an example by working hard, and using personal stories can inspire people. | Involving: Tim",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim wants to visit The Cliffs of Moher in Ireland, which he describes as having amazing ocean views and awesome cliffs, and is excited to explore nature. | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim",
+        "Tim visited a castle in the UK during his trip last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim",
+        "Tim suggested Edinburgh, Scotland, as a destination for John's team trip, highlighting its magical vibe, history, architecture, beauty, and connection to Harry Potter. | Involving: Tim, John | As a suggestion for John's team trip",
+        "Tim offered to provide tips for visiting Harry Potter places. | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go as he wanted, which he finds tough. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 68,
+      "question": "What day did Tim get into his study abroad program?",
+      "expected_answer": "Januarty 5, 2024",
+      "relevant_facts": [
+        "Tim was accepted into the study abroad program he applied for. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 69,
+      "question": "When will Tim leave for Ireland?",
+      "expected_answer": "February, 2024",
+      "relevant_facts": [
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 70,
+      "question": "Which Star Wars-related locations would Tim enjoy during his visit to Ireland?",
+      "expected_answer": "Skellig Michael, Malin Head, Loop Head, Ceann Sib\u00e9al, and Brow Head because they are Star Wars filming locations.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim was accepted into the study abroad program he applied for. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 71,
+      "question": "Which team did John sign with on 21 May, 2023?",
+      "expected_answer": "The Minnesota Wolves",
+      "relevant_facts": [
+        "John signed with the Minnesota Wolves. | When: Recently | Involving: John",
+        "The Minnesota Wolves' season opener is scheduled for next week. | When: Next week (May 22-28, 2023) | Involving: Minnesota Wolves (team)"
+      ]
+    },
+    {
+      "q_idx": 72,
+      "question": "What is John's position on the team he signed with?",
+      "expected_answer": "shooting guard",
+      "relevant_facts": [
+        "John plays as a shooting guard for the Minnesota Wolves. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 73,
+      "question": "What challenge did John encounter during pre-season training?",
+      "expected_answer": "fitting into the new team's style of play",
+      "relevant_facts": [
+        "John found fitting into the Minnesota Wolves' style of play challenging during pre-season training. | When: During pre-season | Involving: John, Minnesota Wolves"
+      ]
+    },
+    {
+      "q_idx": 74,
+      "question": "What aspects of the Harry Potter universe will be discussed in John's fan project collaborations?",
+      "expected_answer": "characters, spells, magical creatures",
+      "relevant_facts": [
+        "Tim and John will be discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 75,
+      "question": "What forum did Tim join recently?",
+      "expected_answer": "fantasy literature forum",
+      "relevant_facts": [
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum because he loves fantasy, and the magazine liked his ideas. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim | To discuss his favorite books and connect with others."
+      ]
+    },
+    {
+      "q_idx": 76,
+      "question": "What kind of picture did Tim share as part of their Harry Potter book collection?",
+      "expected_answer": "MinaLima's creation from the Harry Potter films",
+      "relevant_facts": [
+        "Tim has a picture from MinaLima, who created all the props for the Harry Potter films, and he loves their work because it feels like having a piece of the wizarding world at home. | Involving: Tim, MinaLima | He loves their work and it connects him to the wizarding world.",
+        "Tim shared a photo of his book collection. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 77,
+      "question": "What was the highest number of points John scored in a game recently?",
+      "expected_answer": "40 points",
+      "relevant_facts": [
+        "John scored 40 points in a basketball game, which is his highest score ever, and feels his hard work is paying off. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 78,
+      "question": "What did John celebrate at a restaurant with teammates?",
+      "expected_answer": "a tough win",
+      "relevant_facts": [
+        "John and his teammates celebrated their tough win at a restaurant, laughing and reliving intense moments. | When: After the game last week | Involving: John, John's teammates | To celebrate their tough win."
+      ]
+    },
+    {
+      "q_idx": 79,
+      "question": "What kind of deals did John sign with Nike and Gatorade?",
+      "expected_answer": "basketball shoe and gear deal with Nike, potential sponsorship deal with Gatorade",
+      "relevant_facts": [
+        "John signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is in talks with Gatorade about a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 80,
+      "question": "Which city is John excited to have a game at?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John loves Seattle's energy, diversity, and food, specifically mentioning local seafood as a must-try. He also appreciates the incredible support from fans at games in Seattle. | Involving: John",
+        "John has a game scheduled in Seattle next month. | When: Next month | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 81,
+      "question": "How long has John been surfing?",
+      "expected_answer": "five years",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling of riding waves as \"unreal,\" \"super exciting,\" and \"free-feeling.\" He started surfing five years ago and loves the connection to nature it provides. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 82,
+      "question": "How does John feel while surfing?",
+      "expected_answer": "super exciting and free-feeling",
+      "relevant_facts": [
+        "John had an awesome summer surfing with his friends, describing the feeling of riding waves as \"unreal,\" \"super exciting,\" and \"free-feeling.\" He started surfing five years ago and loves the connection to nature it provides. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 83,
+      "question": "What kind of articles has Tim been writing about for the online magazine?",
+      "expected_answer": "different fantasy novels, characters, themes, and book recommendations",
+      "relevant_facts": [
+        "Tim's articles for the online magazine involve studying characters and themes of different fantasy novels and making book recommendations. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 84,
+      "question": "Which two fantasy novels does Tim particularly enjoy writing about?",
+      "expected_answer": "Harry Potter and Game of Thrones",
+      "relevant_facts": [
+        "Tim is a big fan of Harry Potter and Game of Thrones and enjoys writing about them. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 85,
+      "question": "What did Anthony and John end up playing during the charity event?",
+      "expected_answer": "an intense Harry Potter trivia contest",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event. | Involving: John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 86,
+      "question": "What did John share with the person he skyped about?",
+      "expected_answer": "Characters from Harry Potter",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 87,
+      "question": "How did John describe the team bond?",
+      "expected_answer": "Awesome",
+      "relevant_facts": [
+        "The best part of the recent basketball win for John was the camaraderie built with his team, which felt amazing and was worth the hard work. | When: recently | Involving: John, John's basketball team | The camaraderie made the win feel amazing and justified the hard work."
+      ]
+    },
+    {
+      "q_idx": 88,
+      "question": "How did John get introduced to basketball?",
+      "expected_answer": "Dad signed him up for a local league",
+      "relevant_facts": [
+        "John has been playing basketball since he was a kid, watching NBA games with his dad and dreaming of playing professionally. He joined a local league at age ten, played through middle and high school, earned a college scholarship, and was eventually drafted by a team after college. | When: Since childhood, specifically at age ten for the league, then through middle/high school, college, and after college. | Involving: John, John's dad | It was his childhood dream to play professionally."
+      ]
+    },
+    {
+      "q_idx": 89,
+      "question": "What is John's number one goal in his basketball career?",
+      "expected_answer": "Winning a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 90,
+      "question": "What organization is John teaming up with for his charity work?",
+      "expected_answer": "A local organization helping disadvantaged kids with sports and school",
+      "relevant_facts": [
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform for positive community impact and to inspire others.",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs."
+      ]
+    },
+    {
+      "q_idx": 91,
+      "question": "When did John meet back up with his teammates after his trip in August 2023?",
+      "expected_answer": "Aug 15th",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and appreciating the electric atmosphere and team bond. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 92,
+      "question": "What did John's teammates give him when they met on Aug 15th?",
+      "expected_answer": "a basketball with autographs on it",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 93,
+      "question": "Why did John's teammates sign the basketball they gave him?",
+      "expected_answer": "to show their friendship and appreciation",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, and as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 94,
+      "question": "What is the main intention behind Tim wanting to attend the book conference?",
+      "expected_answer": "to learn more about literature and create a stronger bond to it",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 95,
+      "question": "What new activity has Tim started learning in August 2023?",
+      "expected_answer": "play the piano",
+      "relevant_facts": [
+        "Tim started learning to play the piano and finds the progress satisfying. | When: Since the last conversation | Involving: Tim",
+        "Tim is currently working on studies and recently started learning an instrument, which he finds challenging but fun due to his admiration for musicians. | When: Recently, as of December 6, 2023 | Involving: Tim | He always admired musicians.",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months as of December 6, 2023 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 96,
+      "question": "Which movie's theme is Tim's favorite to play on the piano?",
+      "expected_answer": "\"Harry Potter and the Philosopher's Stone\"",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is the theme from \"Harry Potter and the Philosopher's Stone\", which is special to him because it was the first movie in the series and he watched it with his family, creating magical memories. | Involving: Tim, Tim's family | The movie brings back great memories of watching it with his family.",
+        "Tim also plays the piano. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 97,
+      "question": "What special memory does \"Harry Potter and the Philosopher's Stone\" bring to Tim?",
+      "expected_answer": "Watching it with his family",
+      "relevant_facts": [
+        "Tim has special memories of watching \"Harry Potter and the Philosopher's Stone\" with his family, where they would get comfy with snacks and a blanket and be totally absorbed. | Involving: Tim, Tim's family | These moments were \"a dream come true\" and \"awesome\", full of magic.",
+        "Tim's favorite song to play on the piano is the theme from \"Harry Potter and the Philosopher's Stone\", which is special to him because it was the first movie in the series and he watched it with his family, creating magical memories. | Involving: Tim, Tim's family | The movie brings back great memories of watching it with his family."
+      ]
+    },
+    {
+      "q_idx": 98,
+      "question": "Which movie does Tim mention they enjoy watching during Thanksgiving?",
+      "expected_answer": "\"Home Alone\"",
+      "relevant_facts": [
+        "Tim's family celebrates Thanksgiving by prepping a feast, discussing what they are thankful for, and watching movies afterwards. | When: Annually during Thanksgiving | Involving: Tim's family | It is a special tradition for them.",
+        "Tim's family enjoys watching \"Home Alone\", \"Elf\", and \"The Santa Clause\" during the holidays. | When: During Thanksgiving and other holidays | Involving: Tim's family | These movies bring laughs, make them feel festive, and are heartwarming."
+      ]
+    },
+    {
+      "q_idx": 99,
+      "question": "What tradition does Tim mention they love during Thanksgiving?",
+      "expected_answer": "Prepping the feast and talking about what they're thankful for",
+      "relevant_facts": [
+        "Tim's family celebrates Thanksgiving by prepping a feast, discussing what they are thankful for, and watching movies afterwards. | When: Annually during Thanksgiving | Involving: Tim's family | It is a special tradition for them."
+      ]
+    },
+    {
+      "q_idx": 100,
+      "question": "How long did John and his high school basketball teammates play together?",
+      "expected_answer": "Four years",
+      "relevant_facts": [
+        "John and his old friends were teammates for four years in high school. | When: During high school | Involving: John, John's old friends"
+      ]
+    },
+    {
+      "q_idx": 101,
+      "question": "How was John's experience in New York City?",
+      "expected_answer": "Amazing",
+      "relevant_facts": [
+        "John found New York City amazing, exciting, and enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 102,
+      "question": "What did John say about NYC, enticing Tim to visit?",
+      "expected_answer": "It's got so much to check out - the culture, food - you won't regret it.",
+      "relevant_facts": [
+        "John found New York City amazing, exciting, and enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 103,
+      "question": "What kind of soup did John make recently?",
+      "expected_answer": "tasty soup with sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty soup using sage, which he made up on the spot. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 104,
+      "question": "What spice did John add to the soup for flavor?",
+      "expected_answer": "sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty soup using sage, which he made up on the spot. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 105,
+      "question": "What is Tim excited to see at Universal Studios?",
+      "expected_answer": "The Harry Potter stuff",
+      "relevant_facts": [
+        "Tim is planning his first trip to Universal Studios next month and is excited for the Harry Potter attractions. | When: Next month | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 106,
+      "question": "Where are John and his teammates planning to explore on a team trip?",
+      "expected_answer": "a new city",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip next month (October 2023) to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To have some fun"
+      ]
+    },
+    {
+      "q_idx": 107,
+      "question": "What city did Tim suggest to John for the team trip next month?",
+      "expected_answer": "Edinburgh, Scotland",
+      "relevant_facts": [
+        "Tim suggested Edinburgh, Scotland, as a destination for John's team trip, highlighting its magical vibe, history, architecture, beauty, and connection to Harry Potter. | Involving: Tim, John | As a suggestion for John's team trip",
+        "John and his teammates are planning a team trip next month (October 2023) to explore a new city and have fun. | When: Next month (October 2023) | Involving: John, John's teammates | To have some fun",
+        "John asked Tim for suggestions for their team trip destination. | Involving: John, Tim",
+        "John considers Edinburgh, Scotland, a great idea and a place worth considering for their team trip, and he has not been there before. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 108,
+      "question": "What does John want to do after his basketball career?",
+      "expected_answer": "positively influence and inspire others, potentially start a foundation and engage in charity work",
+      "relevant_facts": [
+        "John also wants to make a difference away from the court through charity work or by inspiring people. | Involving: John | He feels basketball has been great to him and he wants to give something back.",
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy after his basketball career. | Involving: John",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform for positive community impact and to inspire others.",
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in, including speaking at charity events. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 109,
+      "question": "What advice did Tim give John about picking endorsements?",
+      "expected_answer": "Ensure they align with values and brand, look for companies that share the desire to make a change and help others, make sure the endorsement feels authentic",
+      "relevant_facts": [
+        "Tim advised John to pick endorsements that align with his values and brand, suggesting he look for companies that share his desire to make a change and help others, ensuring authenticity to his followers. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John (user) | In response to John's request for advice on picking endorsements."
+      ]
+    },
+    {
+      "q_idx": 110,
+      "question": "What book recommendation did Tim give to John for the trip?",
+      "expected_answer": "A fantasy novel by Patrick Rothfuss",
+      "relevant_facts": [
+        "John plans to check out the book by Patrick Rothfuss that Tim recommended. | Involving: John, Tim",
+        "John plans to check out and read \"The Name of the Wind\" during his trip. | Involving: John (user) | Tim recommended the book, and John thinks it looks like a great book to read while traveling.",
+        "Tim recommended a book by Patrick Rothfuss, praising its amazing world-building and character development. | Involving: Tim, John | Tim thinks the book is 'awesome'.",
+        "John asked Tim for book recommendations for his upcoming trip. | When: Thursday, September 21, 2023 | Involving: John (user), Tim (assistant) | John is planning a trip and wants reading material.",
+        "John plans to add \"The Name of the Wind\" to his reading list based on Tim's recommendation. | Involving: John, Tim",
+        "Tim recommended \"The Name of the Wind,\" a fantasy novel by Patrick Rothfuss, to John for his trip. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John (user), Patrick Rothfuss (author) | In response to John's request for book recommendations.",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" describing its protagonist as a magician and musician, and praising its world-building and character development. | Involving: Tim",
+        "John loves fantasy novels with strong characters and good world-building and plans to add \"The Name of the Wind\" to his reading list. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 111,
+      "question": "What type of venue did John and his girlfriend choose for their wedding ceremony?",
+      "expected_answer": "Greenhouse",
+      "relevant_facts": [
+        "John and his girlfriend had an amazing and emotional wedding ceremony. | When: Last week | Involving: John, John's girlfriend (now wife)",
+        "John and his wife held their wedding ceremony in a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week | Involving: John, John's wife | To ensure everyone felt safe and to have their loved ones celebrate with them in an intimate setting."
+      ]
+    },
+    {
+      "q_idx": 112,
+      "question": "What was the setting for John and his wife's first dance?",
+      "expected_answer": "Cozy restaurant",
+      "relevant_facts": [
+        "John and his wife had their first dance at a cozy restaurant, which was dreamy with music and candlelight. | When: Last week | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 113,
+      "question": "Which basketball team does Tim support?",
+      "expected_answer": "The Wolves",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 114,
+      "question": "What passion does Tim mention connects him with people from all over the world?",
+      "expected_answer": "passion for fantasy stuff",
+      "relevant_facts": [
+        "Tim loves how his passion for fantasy topics connects him with people from all over the world. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 115,
+      "question": "How does John describe the game season for his team?",
+      "expected_answer": "intense with tough losses and great wins",
+      "relevant_facts": [
+        "John's team had an intense season, experiencing both tough losses and great wins, and performed pretty well overall. | Involving: John, John's team"
+      ]
+    },
+    {
+      "q_idx": 116,
+      "question": "How does John say his team handles tough opponents?",
+      "expected_answer": "by backing each other up and not quitting",
+      "relevant_facts": [
+        "John's team is driven to improve by facing tough opponents, and they support each other and are resilient. | Involving: John, John's team"
+      ]
+    },
+    {
+      "q_idx": 117,
+      "question": "What motivates John's team to get better, according to John?",
+      "expected_answer": "facing tough opponents",
+      "relevant_facts": [
+        "John's team is driven to improve by facing tough opponents, and they support each other and are resilient. | Involving: John, John's team"
+      ]
+    },
+    {
+      "q_idx": 118,
+      "question": "What did John's team win at the end of the season?",
+      "expected_answer": "a trophy",
+      "relevant_facts": [
+        "John's team won a trophy, making their hard work and effort feel worthwhile. | Involving: John, John's team",
+        "John was elated about his team winning a trophy and appreciates Tim's support, stating he will continue to work hard. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 119,
+      "question": "Where did Tim capture the photography of the sunset over the mountain range?",
+      "expected_answer": "Smoky Mountains",
+      "relevant_facts": [
+        "Tim took a stunning picture of a sunset over a mountain with a tree during a trip to the Smoky Mountains. | When: Last summer | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 120,
+      "question": "How does John feel about being seen as a mentor by some of the younger players?",
+      "expected_answer": "It feels great",
+      "relevant_facts": [
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and using it as a way to stay involved in the game during the off-season. | Involving: John, younger players",
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports."
+      ]
+    },
+    {
+      "q_idx": 121,
+      "question": "What does John find rewarding about mentoring the younger players?",
+      "expected_answer": "Seeing their growth, improvement, and confidence",
+      "relevant_facts": [
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports."
+      ]
+    },
+    {
+      "q_idx": 122,
+      "question": "What has John been able to help the younger players achieve?",
+      "expected_answer": "reach their goals",
+      "relevant_facts": [
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and using it as a way to stay involved in the game during the off-season. | Involving: John, younger players",
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform for positive community impact and to inspire others.",
+        "John's tips for motivating others on a team include showing care, celebrating achievements, providing constructive feedback, reminding them of bigger goals, creating a positive environment, and giving pep talks before games. | Involving: John",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated, making him happy to share his knowledge. | Involving: John, aspiring professionals",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports."
+      ]
+    },
+    {
+      "q_idx": 123,
+      "question": "What genre is the novel that Tim is writing?",
+      "expected_answer": "Fantasy",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which he finds nerve-wracking but exciting, and believes his hard work is paying off. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 124,
+      "question": "Who is one of Tim's sources of inspiration for writing?",
+      "expected_answer": "J.K. Rowling",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 125,
+      "question": "What J.K. Rowling quote does Tim resonate with?",
+      "expected_answer": "\"Turn on the light - happiness hides in the darkest of times.\"",
+      "relevant_facts": [
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 126,
+      "question": "What does John write on the whiteboard to help him stay motivated?",
+      "expected_answer": "motivational quotes and strategies",
+      "relevant_facts": [
+        "John wrote motivational quotes and strategies on a whiteboard to help him stay focused, push through tough workouts, and stay motivated for improvement. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 127,
+      "question": "What hobby is a therapy for John when away from the court?",
+      "expected_answer": "Cooking",
+      "relevant_facts": [
+        "John enjoys cuddling up with a book as his chill time and finds cooking therapeutic, creative, and a way to experiment with flavors and take a break when he's away from the court. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 128,
+      "question": "What type of meal does John often cook using a slow cooker?",
+      "expected_answer": "honey garlic chicken with roasted veg",
+      "relevant_facts": [
+        "John offered to write down and mail the honey garlic chicken recipe to Tim. | Involving: John, Tim",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes. He also enjoys trying out new recipes. | Involving: John",
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables. | Involving: Tim, John",
+        "Tim is looking forward to trying John's honey garlic chicken recipe. | Involving: Tim, John",
+        "John asked Tim to inform him about the outcome of preparing the honey garlic chicken recipe. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 129,
+      "question": "How will John share the honey garlic chicken recipe with the other person?",
+      "expected_answer": "write it down and mail it",
+      "relevant_facts": [
+        "John offered to write down and mail the honey garlic chicken recipe to Tim. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 130,
+      "question": "What was Tim's huge writing issue last week,as mentioned on November 6, 2023?",
+      "expected_answer": "He got stuck on a plot twist",
+      "relevant_facts": [
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and got his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 131,
+      "question": "What does Tim have that serves as a reminder of hard work and is his prized possession?",
+      "expected_answer": "a basketball signed by his favorite player",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 132,
+      "question": "Why do Tim and John find LeBron inspiring?",
+      "expected_answer": "LeBron's determination and the epic block in Game 7 of the '16 Finals",
+      "relevant_facts": [
+        "Tim's favorite player is LeBron James, who inspires him with his determination, particularly recalling an epic block in a Finals game a few years ago that changed the game and led to a win. | When: A few years ago | Involving: Tim, LeBron James | LeBron's determination and the epic block inspire him.",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John",
+        "John remembers LeBron James's epic block in Game 7 of the 2016 Finals against Iguodala, where he pinned the ball against the backboard, and this determination and heart is a reason John loves basketball. | When: 2016 Finals (Game 7) | Involving: John, LeBron James, Iguodala | The determination and heart shown are why John loves basketball.",
+        "Tim confirms that the epic block by LeBron James in Game 7 of the 2016 Finals is the one he was referring to, and such moments make him love sports and admire players' determination and heart. | Involving: Tim | Such moments of determination and heart make him love sports."
+      ]
+    },
+    {
+      "q_idx": 133,
+      "question": "How did John describe the views during their road trip out on the European coastline?",
+      "expected_answer": "Spectacular",
+      "relevant_facts": [
+        "John and his wife took a road trip along the European coastline, which they found amazing with spectacular views, fostering bonding and creating memories, and serving as a refreshing change from John's usual routine. | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 134,
+      "question": "What is one of Tim's favorite fantasy TV shows, as mentioned on November 11, 2023?",
+      "expected_answer": "\"That\"",
+      "relevant_facts": [
+        "Tim enjoys getting lost in fantasy realms as an escape, and \"That\" is one of his favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 135,
+      "question": "How does Tim stay motivated during difficult study sessions?",
+      "expected_answer": "Visualizing goals and success",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 136,
+      "question": "What did Tim say about his injury on 16 November, 2023?",
+      "expected_answer": "The doctor said it's not too serious",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 137,
+      "question": "What was the setback Tim faced in his writing project on 21 November, 2023?",
+      "expected_answer": "Story based on experiences in the UK didn't go as planned",
+      "relevant_facts": [
+        "Last week, Tim had a setback trying to write a story based on his experiences in the UK, and it didn't go as he wanted, which he finds tough. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 138,
+      "question": "How did John overcome his ankle injury from last season?",
+      "expected_answer": "stayed focused on recovery and worked hard to strengthen his body",
+      "relevant_facts": [
+        "John had to overcome the hurdle of adapting and tweaking his routine at the new gym, eventually figuring out a balanced schedule that includes both basketball and strength training, while also listening to his body and ensuring enough rest. | Involving: John",
+        "John focused on recovery and worked hard to strengthen his body after his ankle injury. | When: Last season | Involving: John | To overcome his ankle injury and return to playing.",
+        "John is currently doing daily physical therapy exercises as part of his rehab to stay active and recover from his injury. | When: Every day (currently) | Involving: John | To recover from his injury and stay active.",
+        "John plans to continue pushing and staying positive with his recovery and exercise. | Involving: John | To maintain progress and return to full fitness.",
+        "John has noticed improvements from practicing yoga, including increased strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, helps him become more explosive, and boosts his overall athleticism, which are all essential for basketball. | Involving: John",
+        "John and his wife hosted a small get-together with friends and family to celebrate John's milestone of jogging without pain. They had a ton of fun. | When: After John's jogging milestone (likely Friday evening, December 15, 2023, or Saturday, December 16, 2023) | Involving: John, John's wife, friends, family | To celebrate John's success in jogging without pain.",
+        "Incorporating strength training has significantly improved John's basketball performance by enhancing his shooting accuracy, agility, and speed, giving him an upper hand over opponents and boosting his confidence on the court. | Involving: John",
+        "John is trying out yoga to gain strength and flexibility, finding it challenging but worthwhile. | Involving: John | To gain strength and flexibility.",
+        "John achieved a milestone at the gym by jogging without pain, which was a huge relief after being out for so long. | When: Last Friday (December 15, 2023) | Involving: John | It was a huge success after being out for so long due to pain.",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John | To build strength and stability.",
+        "John wrote motivational quotes and strategies on a whiteboard to help him stay focused, push through tough workouts, and stay motivated for improvement. | Involving: John",
+        "John enjoys practicing specific yoga poses, including Warrior II (which makes him feel strong) and another that helps with balance and stability, loving how these poses challenge his body and mind. | Involving: John",
+        "John shared a photo of himself in the Warrior II pose, explaining it is a good way to work out legs and core. | When: Friday, December 01, 2023 | Involving: John | To show Tim the pose he enjoys and for Tim to try it."
+      ]
+    },
+    {
+      "q_idx": 139,
+      "question": "What motivated Tim to keep pushing himself to get better in writing and reading?",
+      "expected_answer": "Love for writing and reading",
+      "relevant_facts": [
+        "Tim's passions are writing and reading, which help him stay motivated and improve. | Involving: Tim | They help him stay motivated and push himself to get better.",
+        "J.K. Rowling is an inspiring writer for Tim, whose captivating books and storytelling style he studies for his own writing. He has been reading her works for a long time and they continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: September 2023 | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 140,
+      "question": "How did John overcome a mistake he made during a big game in basketball?",
+      "expected_answer": "Worked hard to get better and focused on growth",
+      "relevant_facts": [
+        "John messed up during a big basketball game, which was really hard for him to accept. | Involving: John",
+        "Instead of getting stuck in the moment after messing up in a big game, John worked hard to get better. | Involving: John | To improve and not dwell on the mistake.",
+        "John learned that resilience is key and owning up to mistakes is important from his basketball experiences. | Involving: John | These lessons help him grow as a player and teammate.",
+        "When facing challenges on the court, John tries to reflect on what went wrong and find ways to improve. | Involving: John | To improve and overcome challenges.",
+        "John values growth and improvement, both personally and in sports. | Involving: John",
+        "John believes struggles make achievements more worthwhile, especially in sports, and that challenges foster development and improvement. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 141,
+      "question": "What book did John recently finish rereading that left him feeling inspired and hopeful about following dreams?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently finished rereading \"The Alchemist\", which inspired him to follow dreams and search for personal legends, making him feel motivated and hopeful. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 142,
+      "question": "How did \"The Alchemist\" impact John's perspective on following dreams?",
+      "expected_answer": "made him think again about following dreams and searching for personal legends",
+      "relevant_facts": [
+        "John read and loved \"The Alchemist\", finding that it made him think about life and the importance of following one's dreams. He highly recommends the book. | Involving: John",
+        "John recently finished rereading \"The Alchemist\", which inspired him to follow dreams and search for personal legends, making him feel motivated and hopeful. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 143,
+      "question": "What is John trying out to improve his strength and flexibility after recovery from ankle injury?",
+      "expected_answer": "yoga",
+      "relevant_facts": [
+        "John focused on recovery and worked hard to strengthen his body after his ankle injury. | When: Last season | Involving: John | To overcome his ankle injury and return to playing.",
+        "John is trying out yoga to gain strength and flexibility, finding it challenging but worthwhile. | Involving: John | To gain strength and flexibility.",
+        "John has noticed improvements from practicing yoga, including increased strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. | When: Last season | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John | To build strength and stability.",
+        "John enjoys practicing specific yoga poses, including Warrior II (which makes him feel strong) and another that helps with balance and stability, loving how these poses challenge his body and mind. | Involving: John",
+        "John shared a photo of himself in the Warrior II pose, explaining it is a good way to work out legs and core. | When: Friday, December 01, 2023 | Involving: John | To show Tim the pose he enjoys and for Tim to try it."
+      ]
+    },
+    {
+      "q_idx": 144,
+      "question": "How long does John usually hold the yoga pose he shared with Tim?",
+      "expected_answer": "30-60 seconds",
+      "relevant_facts": [
+        "John shared a photo of himself in the Warrior II pose, explaining it is a good way to work out legs and core. | When: Friday, December 01, 2023 | Involving: John | To show Tim the pose he enjoys and for Tim to try it.",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps him build strength and stability. | Involving: John | To build strength and stability."
+      ]
+    },
+    {
+      "q_idx": 145,
+      "question": "Where was the forest picture shared by John on December 1,2023 taken?",
+      "expected_answer": "near his hometown",
+      "relevant_facts": [
+        "John shared a photo of a tranquil forest located near his hometown. | Involving: John",
+        "Tim and John both appreciate having beautiful natural places, like the forest in John's photo, near their homes. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 146,
+      "question": "What did Tim recently start learning in addition to being part of a travel club and working on studies?",
+      "expected_answer": "an instrument",
+      "relevant_facts": [
+        "Tim is currently working on studies and recently started learning an instrument, which he finds challenging but fun due to his admiration for musicians. | When: Recently, as of December 6, 2023 | Involving: Tim | He always admired musicians.",
+        "Tim joined a travel club because he is interested in different cultures and countries and wants to meet new people. | Involving: Tim | He is interested in different cultures and countries and wants to meet new people."
+      ]
+    },
+    {
+      "q_idx": 147,
+      "question": "What instrument is Tim learning to play in December 2023?",
+      "expected_answer": "violin",
+      "relevant_facts": [
+        "Tim is currently working on studies and recently started learning an instrument, which he finds challenging but fun due to his admiration for musicians. | When: Recently, as of December 6, 2023 | Involving: Tim | He always admired musicians.",
+        "Tim is learning to play the violin and is interested in classical music, jazz, and film scores, viewing it as a way to relax and be creative. | Involving: Tim | To chill and get creative."
+      ]
+    },
+    {
+      "q_idx": 148,
+      "question": "How long has Tim been playing the piano for, as of December 2023?",
+      "expected_answer": "about four months",
+      "relevant_facts": [
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months as of December 6, 2023 | Involving: Tim",
+        "Tim is currently working on studies and recently started learning an instrument, which he finds challenging but fun due to his admiration for musicians. | When: Recently, as of December 6, 2023 | Involving: Tim | He always admired musicians.",
+        "Tim started learning to play the piano and finds the progress satisfying. | When: Since the last conversation | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 149,
+      "question": "What book did Tim just finish reading on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim (user's conversation partner)",
+        "Tim recently attended a Harry Potter party where he met many like-minded people and had a lot of fun. | When: Friday, December 08, 2023 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 150,
+      "question": "Which book did Tim recommend to John as a good story on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 151,
+      "question": "What is the topic of discussion between John and Tim on 11 December, 2023?",
+      "expected_answer": "Academic achievements and sports successes",
+      "relevant_facts": [
+        "Tim is currently working on studies and recently started learning an instrument, which he finds challenging but fun due to his admiration for musicians. | When: Recently, as of December 6, 2023 | Involving: Tim | He always admired musicians.",
+        "Tim has been playing an unspecified activity for about four months and is enjoying the progress he is making. | When: For about four months as of December 6, 2023 | Involving: Tim",
+        "John has been playing basketball professionally for just under a year. | When: For just under a year as of December 6, 2023 | Involving: John",
+        "John's team won a close basketball game against another team. | When: Last week (Saturday, December 9, 2023) | Involving: John (and his team)",
+        "Tim has been swamped with exams this week but is diligently working through them and feeling optimistic. | When: This week | Involving: Tim",
+        "John has been dealing with an injury this week, which has made it tough, but he is staying positive. | When: This week | Involving: John",
+        "John and his team put in maximum effort during a scrimmage. | When: Last week | Involving: John, John's team",
+        "Tim had a tough exam last week that made him doubt himself, but he turned it into a learning experience, studied hard, and realized his resilience and determination. | When: Last week | Involving: Tim | It was a learning experience that revealed his resilience and determination."
+      ]
+    },
+    {
+      "q_idx": 152,
+      "question": "What kind of game did John have a career-high in assists in?",
+      "expected_answer": "basketball",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a big basketball game against their rival. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 153,
+      "question": "What was John's way of dealing with doubts and stress when he was younger?",
+      "expected_answer": "practicing basketball outside for hours",
+      "relevant_facts": [
+        "When he was younger, John used to practice basketball outside for hours, dreaming of playing in big games, and it served as his way of dealing with doubts and stress. | When: When he was younger | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 154,
+      "question": "How did John feel about the atmosphere during the big game against the rival team?",
+      "expected_answer": "electric and intense",
+      "relevant_facts": [
+        "John felt great making plays for his team, loved seeing teammates succeed due to opportunities he created, and found the arena atmosphere electric with added intensity from playing rivals. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 155,
+      "question": "How did John feel after being able to jog without pain?",
+      "expected_answer": "It was a huge success.",
+      "relevant_facts": [
+        "John achieved a milestone at the gym by jogging without pain, which was a huge relief after being out for so long. | When: Last Friday (December 15, 2023) | Involving: John | It was a huge success after being out for so long due to pain.",
+        "John and his wife hosted a small get-together with friends and family to celebrate John's milestone of jogging without pain. They had a ton of fun. | When: After John's jogging milestone (likely Friday evening, December 15, 2023, or Saturday, December 16, 2023) | Involving: John, John's wife, friends, family | To celebrate John's success in jogging without pain."
+      ]
+    },
+    {
+      "q_idx": 156,
+      "question": "What kind of deal did John get in December?",
+      "expected_answer": "Deal with a renowned outdoor gear company",
+      "relevant_facts": [
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 157,
+      "question": "Where was the photoshoot done for John's gear deal?",
+      "expected_answer": "In a gorgeous forest",
+      "relevant_facts": [
+        "John had a successful photoshoot in a gorgeous forest, where the photographer captured epic shots of him. | When: Last week | Involving: John, photographer"
+      ]
+    },
+    {
+      "q_idx": 158,
+      "question": "In which area has John's team seen the most growth during training?",
+      "expected_answer": "Communication and bonding",
+      "relevant_facts": [
+        "John's team has experienced significant growth in communication and bonding, which has helped their performances by allowing them to understand each other's strengths and weaknesses. | Involving: John, John's team | The growth in communication and bonding has improved their performances."
+      ]
+    },
+    {
+      "q_idx": 159,
+      "question": "What type of seminars is John conducting?",
+      "expected_answer": "Sports and marketing seminars",
+      "relevant_facts": [
+        "John started doing seminars to help people with their sports and marketing. | When: recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 160,
+      "question": "What activity did Tim do after reading the stories about the Himalayan trek?",
+      "expected_answer": "visited a travel agency",
+      "relevant_facts": [
+        "The book described the Himalayan trek as tough but worth it, involving challenging terrain, altitude sickness, and bad weather, but the hikers saw amazing sights, which motivated Tim. | Involving: Tim, hikers | The story motivated Tim for his own travel plans.",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | When: Tuesday, December 26, 2023 | Involving: Tim | To plan his dream trip."
+      ]
+    },
+    {
+      "q_idx": 161,
+      "question": "What is one cause that John supports with his influence and resources?",
+      "expected_answer": "youth sports and fair chances in sports",
+      "relevant_facts": [
+        "Making a difference is important to John, and he uses his influence and resources to help causes he believes in, including speaking at charity events. | Involving: John",
+        "John plans to kick off his charity work by teaming up with a local organization that helps disadvantaged kids with sports and school. | Involving: John, local organization | He hopes to use his platform for positive community impact and to inspire others.",
+        "John finds mentoring challenging due to individual differences among players, but he enjoys gaining experience, adapting, motivating, and encouraging them. He finds it fulfilling to witness their growth, improvement, and confidence, to make a positive impact on their lives by providing advice and support, and to be a positive role model who helps shape their future and inspire their dreams. He feels great having their trust and admiration. | Involving: John, younger players (young athletes)",
+        "John works on supporting youth sports and fighting for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs.",
+        "John wants to use his platform to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy after his basketball career. | Involving: John",
+        "John also wants to make a difference away from the court through charity work or by inspiring people. | Involving: John | He feels basketball has been great to him and he wants to give something back.",
+        "John is mentoring younger players on his team, finding it rewarding to share his skills and knowledge, and using it as a way to stay involved in the game during the off-season. | Involving: John, younger players",
+        "Tim advised John to pick endorsements that align with his values and brand, suggesting he look for companies that share his desire to make a change and help others, ensuring authenticity to his followers. | When: Thursday, September 21, 2023 | Involving: Tim (assistant), John (user) | In response to John's request for advice on picking endorsements.",
+        "John organized a basketball camp for kids in his hometown last summer, which was an awesome experience full of laughs, high-fives, and personal growth. | When: Summer 2023 | Involving: John, kids | To inspire kids and show them their potential through sports."
+      ]
+    },
+    {
+      "q_idx": 162,
+      "question": "What new fantasy TV series is Tim excited about?",
+      "expected_answer": "\"The Wheel of Time\"",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" coming out next month. | When: Next month | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 163,
+      "question": "Which language is Tim learning?",
+      "expected_answer": "German",
+      "relevant_facts": [
+        "Tim uses a language learning app for German. | Involving: Tim",
+        "Tim is learning German, finding it tough but fun and worth it, and likes its structure, noting it's easier than French which he took in high school. | Involving: Tim",
+        "Tim plans to continue with his German lessons. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 164,
+      "question": "What language does Tim know besides German?",
+      "expected_answer": "Spanish",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 165,
+      "question": "What book did Tim get in Italy that inspired him to cook?",
+      "expected_answer": "a cooking book",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 166,
+      "question": "What is John's favorite book series?",
+      "expected_answer": "Harry Potter",
+      "relevant_facts": [
+        "John loves \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 167,
+      "question": "According to John, who is his favorite character from Lord of the Rings?",
+      "expected_answer": "Aragorn",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, and his commitment to putting others first and standing up for justice. | Involving: John, Aragorn | Aragorn's character traits and journey inspire John."
+      ]
+    },
+    {
+      "q_idx": 168,
+      "question": "Why does John like Aragorn from Lord of the Rings?",
+      "expected_answer": "brave, selfless, down-to-earth attitude",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, and his commitment to putting others first and standing up for justice. | Involving: John, Aragorn | Aragorn's character traits and journey inspire John."
+      ]
+    },
+    {
+      "q_idx": 169,
+      "question": "What kind of painting does John have in his room as a reminder?",
+      "expected_answer": "a painting of Aragorn",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room. | Involving: John, Aragorn | It serves as a reminder for John to stay true and be a leader in everything he does."
+      ]
+    },
+    {
+      "q_idx": 170,
+      "question": "What is the painting of Aragorn a reminder for John to be in everything he does?",
+      "expected_answer": "be a leader",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room. | Involving: John, Aragorn | It serves as a reminder for John to stay true and be a leader in everything he does."
+      ]
+    },
+    {
+      "q_idx": 171,
+      "question": "What map does Tim show to his friend John?",
+      "expected_answer": "a map of Middle-earth from LOTR",
+      "relevant_facts": [
+        "Tim is looking at a map of Middle-earth from Lord of the Rings and finds it cool to see all the different realms and regions. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 172,
+      "question": "Where will Tim be going for a semester abroad?",
+      "expected_answer": "Ireland",
+      "relevant_facts": [
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 173,
+      "question": "Which city in Ireland will Tim be staying in during his semester abroad?",
+      "expected_answer": "Galway",
+      "relevant_facts": [
+        "Tim will stay in Galway, Ireland, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim was accepted into the study abroad program he applied for. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 174,
+      "question": "What charity event did John organize recently in 2024?",
+      "expected_answer": "benefit basketball game",
+      "relevant_facts": [
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John | To raise money for charity and bring people together.",
+        "John held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 175,
+      "question": "What achievement did John share with Tim in January 2024?",
+      "expected_answer": "endorsement with a popular beverage company",
+      "relevant_facts": [
+        "John plans to keep Tim updated on which brands he chooses for endorsement opportunities. | Involving: John, Tim",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (January 1-7, 2024) | Involving: John | It is a dream come true and a result of his hard work."
+      ]
+    },
+    {
+      "q_idx": 176,
+      "question": "What was Johns's reaction to sealing the deal with the beverage company?",
+      "expected_answer": "crazy feeling, sense of accomplishment",
+      "relevant_facts": [
+        "John felt a sense of accomplishment and validation, believing his hard work and training hours paid off after sealing the endorsement deal. | Involving: John | It validated his efforts and hard work.",
+        "John secured an endorsement deal with a popular beverage company. | When: Last week (January 1-7, 2024) | Involving: John | It is a dream come true and a result of his hard work."
+      ]
+    },
+    {
+      "q_idx": 177,
+      "question": "Which city did John recommend to Tim in January 2024?",
+      "expected_answer": "Barcelona",
+      "relevant_facts": [
+        "John recommends Barcelona as a must-visit city, highlighting its culture, architecture, food, and nearby beaches. | Involving: John (recommending to Tim)",
+        "Tim plans to add Barcelona to his travel list. | Involving: Tim | Based on John's recommendation and positive things he has heard."
+      ]
+    }
+  ],
+  "embedding_id": "cohere-embed-english-light-v3.0",
+  "bank_id": "emb_cohere-embed-english-light-v3-0_1772633289"
+}

--- a/benchmark-runner/datasets/locomo_embeddings_gt_cohere-embed-english-v3-0.json
+++ b/benchmark-runner/datasets/locomo_embeddings_gt_cohere-embed-english-v3-0.json
@@ -1,0 +1,1806 @@
+{
+  "annotations": [
+    {
+      "q_idx": 0,
+      "question": "what are John's goals with regards to his basketball career?",
+      "expected_answer": "improve shooting percentage, win a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John",
+        "John's goal is to improve his shooting percentage, and he has been practicing hard to achieve it. | Involving: John",
+        "John's current goals include improving his shooting, making a greater impact on the court, becoming a consistent performer, helping his team, seeking more endorsements, and building his brand. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 1,
+      "question": "What are John's goals for his career that are not related to his basketball skills?",
+      "expected_answer": "get endorsements, build his brand, do charity work",
+      "relevant_facts": [
+        "John uses his contacts in the basketball industry and marketing skills for networking to secure endorsements. | Involving: John",
+        "John aims to make a difference off the court through charity work or by inspiring people, motivated by his desire to give back to the community because of basketball's positive influence on his life. | Involving: John | He wants to give back to the community because basketball has been great to him.",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. He considers thinking about life after basketball important. | Involving: John",
+        "John's current goals include improving his shooting, making a greater impact on the court, becoming a consistent performer, helping his team, seeking more endorsements, and building his brand. | Involving: John",
+        "John's benefit basketball game was a success, attracting many people and raising money for charity. | When: Last week (between January 1 and January 6, 2024) | Involving: John | To raise money for charity",
+        "John signed a deal with Nike for basketball shoes and gear. | When: Recently | Involving: John",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school, planning to use his platform to create a positive impact on the community and inspire others. | Involving: John, local organization | To have a positive impact on the community and inspire others.",
+        "John held a benefit basketball game. | When: Last week (between January 1 and January 6, 2024) | Involving: John",
+        "John is exploring endorsement opportunities with brands. | Involving: John | He is excited about the possibilities and feels rewarded by his hard work paying off.",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and sees the positive difference sports make.",
+        "John is making progress with exploring endorsements and has had promising discussions with some 'big names'. | Involving: John",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "Some younger players see John as a mentor, and he enjoys being a positive role model, providing advice and support on and off the court. He feels great having their trust and admiration and hopes his experiences inspire their dreams. | Involving: John, younger players",
+        "John is considering sports brands like Nike and Under Armour for endorsement, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing.",
+        "Making a difference is important to John, who uses his influence and resources to support causes he believes in to improve the world. | Involving: John",
+        "John plans to keep Tim updated on which brands he chooses for endorsement. | Involving: John, Tim",
+        "Tim advised John to choose endorsements that align with his values and brand, partner with companies that share his desire to make a positive change, and ensure authenticity for his followers. | Involving: Tim, John | Provided in response to John's request for advice.",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John is learning how to market himself and boost his brand. | Involving: John",
+        "John organized a week-long basketball camp for kids in his hometown last summer, which was an awesome experience that inspired the kids and fostered personal growth. | When: Last summer | Involving: John, kids | He wanted to inspire the kids and show them their potential.",
+        "John has secured endorsement deals. | Involving: John",
+        "John felt a sense of accomplishment and that his hard work and training hours paid off after securing the endorsement deal. | Involving: John | It validated his efforts.",
+        "John spoke at a charity event. | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John secured an endorsement with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and incredible for him.",
+        "John is trying to figure out how to pick the right endorsements and asked Tim for advice. | Involving: John, Tim",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He was very excited about it.",
+        "The photoshoot for John's outdoor gear endorsement deal went very well, taking place in a gorgeous forest where the photographer captured epic shots of him. | Involving: John, photographer",
+        "John attended a charity event that featured Harry Potter trivia last August. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 2,
+      "question": "What items does John collect?",
+      "expected_answer": "sneakers, fantasy movie DVDs, jerseys",
+      "relevant_facts": [
+        "John likes to collect jerseys. | Involving: John",
+        "John loves the first Harry Potter movie and owns the entire Harry Potter collection. | Involving: John",
+        "John loves talking to people about his sneaker collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 3,
+      "question": "Would Tim enjoy reading books by C. S. Lewis or John Greene?",
+      "expected_answer": "C. S.Lewis",
+      "relevant_facts": [
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim finds fantasy books like Lord of the Rings (LOTR) awesome because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from the comfort of his home. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that he describes as transporting him to another world, keeping him on the edge of his seat, and making his imagination soar. | When: Currently | Involving: Tim",
+        "Tim enjoys reading fantasy novels, specifically Harry Potter and Game of Thrones, and also non-fiction books on growth, psychology, and self-improvement, viewing them as companions on his growth journey. | Involving: Tim",
+        "John is aware that Tim finds peace in reading fantasy books. | Involving: John, Tim",
+        "Tim does not surf. He finds reading great fantasy books in a comfy spot helps him escape, feel free, and experience bliss, like being in another world. | Involving: Tim",
+        "Tim and John both share an interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim has never been on a sports team; he is more into reading fantasy novels, loves sinking into different magical worlds, and enjoys traveling to new places to experience a different kind of magic. | Involving: Tim",
+        "Tim loves to read books in his downtime, and the Harry Potter series is one of his favorite book series. | Involving: Tim",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim loves reading, finding it a way to escape to other worlds, and he has a collection of books for this purpose. | Involving: Tim",
+        "Tim enjoys being lost in awesome fantasy realms as an escape. | Involving: Tim",
+        "Tim loves fantasy. | Involving: Tim | This preference led him to seek out writing opportunities in the genre.",
+        "J.K. Rowling is an inspiring writer for Tim, whose books are captivating due to their detail and creative storytelling. Tim takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim has been focusing on school and reading fantasy books to take a break from stress. | When: Since the last conversation | Involving: Tim | To take a break from stress.",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on character studies, themes, and book recommendations. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is going well, though he finds it nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim is currently overwhelmed with assignments and exams but is trying to find a way to balance studying with his fantasy reading hobby. | When: This week | Involving: Tim",
+        "Tim is currently reading an inspiring fantasy novel series that focuses on the themes of friendship and loyalty. | When: Currently, as of December 8, 2023 | Involving: Tim",
+        "Tim's favorite novels are fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim loves fantasy books because they allow him to take a break from reality and have an awesome adventure. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising its \"awesome\" world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books. | When: Last night | Involving: Tim | He found the discussion enriching.",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" coming out next month, which is based on a book series he loves. | When: next month | Involving: Tim",
+        "Tim is hooked on Harry Potter and Game of Thrones and loves writing about these specific fantasy novels. | Involving: Tim",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 4,
+      "question": "What books has Tim read?",
+      "expected_answer": "Harry Potter, Game of Thrones, the Name of the Wind, The Alchemist, The Hobbit, A Dance with Dragons, and the Wheel of Time.",
+      "relevant_facts": [
+        "Tim loves to read books in his downtime, and the Harry Potter series is one of his favorite book series. | Involving: Tim",
+        "Tim enjoys reading fantasy novels, specifically Harry Potter and Game of Thrones, and also non-fiction books on growth, psychology, and self-improvement, viewing them as companions on his growth journey. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim recommended \"The Name of the Wind,\" a fantasy novel by Patrick Rothfuss, for John's trip. | Involving: Tim, John, Patrick Rothfuss | In response to John's request for book recommendations.",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim considers \"The Alchemist\" one of his favorite books. | Involving: Tim",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back (before November 21, 2023) | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" coming out next month, which is based on a book series he loves. | When: next month | Involving: Tim",
+        "Tim is hooked on Harry Potter and Game of Thrones and loves writing about these specific fantasy novels. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 5,
+      "question": "Based on Tim's collections, what is a shop that he would enjoy visiting in New York city?",
+      "expected_answer": "House of MinaLima",
+      "relevant_facts": [
+        "Tim finds the New York City skyline amazing and has added NYC to his travel list, expressing excitement to visit and experience its culture and food. | Involving: Tim",
+        "Tim owns a picture from MinaLima, the company that created all the props for the Harry Potter films. | Involving: Tim, MinaLima | He loves their work and feels it's like having a piece of the wizarding world at home.",
+        "Tim uses reminders of the wizarding world, such as the MinaLima picture, as a way to escape reality and the daily grind. | Involving: Tim | It helps him escape reality."
+      ]
+    },
+    {
+      "q_idx": 6,
+      "question": "In which month's game did John achieve a career-high score in points?",
+      "expected_answer": "June 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 7,
+      "question": "Which geographical locations has Tim been to?",
+      "expected_answer": "California, London, the Smoky Mountains",
+      "relevant_facts": [
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration, and enjoyed talking to someone who understands his interest. | Involving: Tim, Harry Potter fan | Tim enjoyed talking to someone who understands his interest.",
+        "Tim had a setback last week while trying to write a story based on his experiences in the UK, as it didn't go as he wanted. | When: Last week | Involving: Tim",
+        "Tim visited a Harry Potter-themed place in London and took a tour a few years ago, describing the experience as amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim has previously visited Europe. | Involving: Tim",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim",
+        "Tim had a nice chat with a Harry Potter fan in California, which he described as a magical experience. | When: Last week | Involving: Tim, a Harry Potter fan | It was a magical experience, implying a shared passion.",
+        "Tim visited a castle in the UK during a trip and found its architecture and history amazing. | When: Last Friday, November 10, 2023 | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling like he got a new lease of life. | When: Last week (October 2-8, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 8,
+      "question": "Which outdoor gear company likely signed up John for an endorsement deal?",
+      "expected_answer": "Under Armour",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsement, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He was very excited about it.",
+        "The photoshoot for John's outdoor gear endorsement deal went very well, taking place in a gorgeous forest where the photographer captured epic shots of him. | Involving: John, photographer",
+        "John likes Under Armour and dreams of working with them. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 9,
+      "question": "Which endorsement deals has John been offered?",
+      "expected_answer": "basketball shoes and gear deal with Nike, potential sponsorship with Gatorade, Moxie a popular beverage company, outdoor gear company",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John is considering sports brands like Nike and Under Armour for endorsement, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He was very excited about it.",
+        "John signed a deal with Nike for basketball shoes and gear. | When: Recently | Involving: John",
+        "The photoshoot for John's outdoor gear endorsement deal went very well, taking place in a gorgeous forest where the photographer captured epic shots of him. | Involving: John, photographer",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John secured an endorsement with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and incredible for him."
+      ]
+    },
+    {
+      "q_idx": 10,
+      "question": "When was John in Seattle for a game?",
+      "expected_answer": "early August, 2023",
+      "relevant_facts": [
+        "John loves Seattle for its energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John attended a charity event that featured Harry Potter trivia last August. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 11,
+      "question": "What sports does John like besides basketball?",
+      "expected_answer": "surfing",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with his friends, which he described as an unreal feeling. He loves the connection to nature that surfing provides, finding the waves and wind super exciting and free-feeling. | When: Started five years ago; had an awesome summer (past) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 12,
+      "question": "What year did John start surfing?",
+      "expected_answer": "2018",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with his friends, which he described as an unreal feeling. He loves the connection to nature that surfing provides, finding the waves and wind super exciting and free-feeling. | When: Started five years ago; had an awesome summer (past) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 13,
+      "question": "What does Tim do to escape reality?",
+      "expected_answer": "Read fantasy books.",
+      "relevant_facts": [
+        "Tim finds fantasy books like Lord of the Rings (LOTR) awesome because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from the comfort of his home. | Involving: Tim",
+        "Tim does not surf. He finds reading great fantasy books in a comfy spot helps him escape, feel free, and experience bliss, like being in another world. | Involving: Tim",
+        "Tim's favorite novels are fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim enjoys being lost in awesome fantasy realms as an escape. | Involving: Tim",
+        "Tim loves reading, finding it a way to escape to other worlds, and he has a collection of books for this purpose. | Involving: Tim",
+        "Tim loves fantasy books because they allow him to take a break from reality and have an awesome adventure. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that he describes as transporting him to another world, keeping him on the edge of his seat, and making his imagination soar. | When: Currently | Involving: Tim",
+        "Tim has never been on a sports team; he is more into reading fantasy novels, loves sinking into different magical worlds, and enjoys traveling to new places to experience a different kind of magic. | Involving: Tim",
+        "Tim has been focusing on school and reading fantasy books to take a break from stress. | When: Since the last conversation | Involving: Tim | To take a break from stress."
+      ]
+    },
+    {
+      "q_idx": 14,
+      "question": "What kind of writing does Tim do?",
+      "expected_answer": "comments on favorite books in a fantasy literature forum, articles on fantasy novels, studying characters, themes, and making book recommendations, writing a fantasy novel",
+      "relevant_facts": [
+        "Tim loves fantasy. | Involving: Tim | This preference led him to seek out writing opportunities in the genre.",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and got his ideas flowing again. | When: Last week | Involving: Tim",
+        "Tim is hooked on Harry Potter and Game of Thrones and loves writing about these specific fantasy novels. | Involving: Tim",
+        "John believes in Tim's fantasy writing. | Involving: John, Tim",
+        "Tim had a setback last week while trying to write a story based on his experiences in the UK, as it didn't go as he wanted. | When: Last week | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is going well, though he finds it nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim shared his ideas for articles with the online magazine, and the magazine liked them. | Involving: Tim, online magazine | This led to him getting the writing opportunity.",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on character studies, themes, and book recommendations. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books. | When: Last night | Involving: Tim | He found the discussion enriching.",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing stories. | Involving: Tim",
+        "Tim found the opportunity to write articles for an online magazine on a fantasy literature forum. | Involving: Tim",
+        "John advises Tim to reflect on what went wrong and find ways to improve with his storytelling, drawing a parallel to how he handles challenges on the basketball court. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 15,
+      "question": "Who is Anthony?",
+      "expected_answer": "likely John's friend, colleague or family",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest. | Involving: John, Anthony",
+        "A \"super-nerd\" won a signed Harry Potter book as a prize at the Harry Potter trivia contest where John and Anthony participated. | Involving: super-nerd, John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 16,
+      "question": "After how many weeks did Tim reconnect with the fellow Harry Potter fan from California?",
+      "expected_answer": "three weeks",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 17,
+      "question": "How many games has John mentioned winning?",
+      "expected_answer": "6",
+      "relevant_facts": [
+        "John's basketball team was trailing significantly in the 4th quarter of a game last year, but they managed to overturn the deficit and win, which was an unforgettable feeling for John. | When: Last year | Involving: John",
+        "John's favorite game was when he hit a buzzer-beater shot to win after his team was down by 10 points in the 4th quarter. | Involving: John, his team | These thrilling moments make him love basketball.",
+        "John and his teammates, feeling exhausted but happy, celebrated their tough win at a restaurant, laughing and reliving intense moments. | When: After the game last week | Involving: John, John's teammates | To celebrate their tough win.",
+        "John and his teammates won a tough basketball game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates | It was a tough win and an incredible experience.",
+        "John was elated about winning the trophy and appreciates Tim's support, stating he will keep working hard. | Involving: John, Tim",
+        "For John, the best part of his basketball team's recent win was the camaraderie built both on and off the court. | Involving: John",
+        "John's team won an intense basketball game by a tight score, with John scoring the last basket, which he found awesome. | When: Last week | Involving: John, John's team, crowd",
+        "John's team won a trophy, making all their hard work and effort feel worthwhile. | Involving: John (and his team)",
+        "John won a trophy, likely a basketball trophy, after putting in significant time and energy. | Involving: John",
+        "John's basketball team won a close game against another team last week, with the win secured at the final buzzer. | When: Last week | Involving: John (and his team)",
+        "John's basketball team recently played a tough game against a top team and secured a win. | When: Lately, prior to December 8, 2023 | Involving: John (and his basketball team)"
+      ]
+    },
+    {
+      "q_idx": 18,
+      "question": "What authors has Tim read books from?",
+      "expected_answer": "J.K. Rowling, R.R. Martin, Patrick Rothfuss, Paulo Coelho, and J. R. R. Tolkien.",
+      "relevant_facts": [
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: A while back (before November 21, 2023) | Involving: Tim",
+        "Tim finds fantasy books like Lord of the Rings (LOTR) awesome because they allow him to get lost in another world, appreciate tiny details, and explore other cultures and landscapes from the comfort of his home. | Involving: Tim",
+        "Tim loves to read books in his downtime, and the Harry Potter series is one of his favorite book series. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, whose books are captivating due to their detail and creative storytelling. Tim takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling",
+        "Tim enjoys reading fantasy novels, specifically Harry Potter and Game of Thrones, and also non-fiction books on growth, psychology, and self-improvement, viewing them as companions on his growth journey. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss, praising its \"awesome\" world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "Tim recommended \"The Name of the Wind,\" a fantasy novel by Patrick Rothfuss, for John's trip. | Involving: Tim, John, Patrick Rothfuss | In response to John's request for book recommendations.",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling",
+        "Tim considers \"The Alchemist\" one of his favorite books. | Involving: Tim",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim is currently reading the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss and finds it really good. | Involving: Tim",
+        "Tim is hooked on Harry Potter and Game of Thrones and loves writing about these specific fantasy novels. | Involving: Tim",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 19,
+      "question": "What is a prominent charity organization that John might want to work with and why?",
+      "expected_answer": "Good Sports, because they work with Nike, Gatorade, and Under Armour and they aim toprovide youth sports opportunities for kids ages 3-18 in high-need communities.",
+      "relevant_facts": [
+        "John aims to make a difference off the court through charity work or by inspiring people, motivated by his desire to give back to the community because of basketball's positive influence on his life. | Involving: John | He wants to give back to the community because basketball has been great to him.",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. He considers thinking about life after basketball important. | Involving: John",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school, planning to use his platform to create a positive impact on the community and inspire others. | Involving: John, local organization | To have a positive impact on the community and inspire others.",
+        "Tim advised John to choose endorsements that align with his values and brand, partner with companies that share his desire to make a positive change, and ensure authenticity for his followers. | Involving: Tim, John | Provided in response to John's request for advice.",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and sees the positive difference sports make.",
+        "John spoke at a charity event. | Involving: John",
+        "John likes Under Armour and dreams of working with them. | Involving: John",
+        "John is mentoring younger players on his team, a role he took on to stay involved in the game during the off-season. | Involving: John, younger players | To stay involved in the game during the off-season.",
+        "John's benefit basketball game was a success, attracting many people and raising money for charity. | When: Last week (between January 1 and January 6, 2024) | Involving: John | To raise money for charity",
+        "John finds mentoring rewarding and fulfilling, enjoying sharing his skills, gaining experience, adapting, motivating, and encouraging players despite challenges, and seeing their development, growth, improvement, and confidence. | Involving: John, players",
+        "John held a benefit basketball game. | When: Last week (between January 1 and January 6, 2024) | Involving: John",
+        "Some younger players see John as a mentor, and he enjoys being a positive role model, providing advice and support on and off the court. He feels great having their trust and admiration and hopes his experiences inspire their dreams. | Involving: John, younger players",
+        "John is considering sports brands like Nike and Under Armour for endorsement, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John organized a week-long basketball camp for kids in his hometown last summer, which was an awesome experience that inspired the kids and fostered personal growth. | When: Last summer | Involving: John, kids | He wanted to inspire the kids and show them their potential.",
+        "Making a difference is important to John, who uses his influence and resources to support causes he believes in to improve the world. | Involving: John",
+        "John attended a charity event that featured Harry Potter trivia last August. | When: August 2023 | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John signed a deal with Nike for basketball shoes and gear. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 20,
+      "question": "Which city was John in before traveling to Chicago?",
+      "expected_answer": "Seattle",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 21,
+      "question": "Which US cities does John mention visiting to Tim?",
+      "expected_answer": "Seattle, Chicago, New York",
+      "relevant_facts": [
+        "John loves discovering new cities and had an amazing trip to New York City, where he enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John",
+        "Tim asked John for travel recommendations. | Involving: Tim, John",
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John initially had trouble figuring out the subway during his NYC trip but found it easy after someone helped explain it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 22,
+      "question": "When did John meet with his teammates after returning from Chicago?",
+      "expected_answer": "August 15, 2023",
+      "relevant_facts": [
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. | Involving: John",
+        "John's teammates gave him a signed basketball on August 15th to show their friendship and appreciation, serving as a reminder of their bond. | When: August 15, 2023 | Involving: John, John's teammates | To show friendship and appreciation, and as a reminder of their bond.",
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and lucky to be part of the team due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 23,
+      "question": "When is Tim attending a book conference?",
+      "expected_answer": "September 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and strengthen his bond with it."
+      ]
+    },
+    {
+      "q_idx": 24,
+      "question": "Where was John between August 11 and August 15 2023?",
+      "expected_answer": "Chicago",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and lucky to be part of the team due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 25,
+      "question": "What similar sports collectible do Tim and John own?",
+      "expected_answer": "signed basketball",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball on August 15th to show their friendship and appreciation, serving as a reminder of their bond. | When: August 15, 2023 | Involving: John, John's teammates | To show friendship and appreciation, and as a reminder of their bond.",
+        "Tim owns a basketball signed by his favorite player, LeBron James, which is his prized possession and serves as a reminder of hard work. | Involving: Tim, LeBron James | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 26,
+      "question": "Which TV series does Tim mention watching?",
+      "expected_answer": "That, Wheel of Time",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" coming out next month, which is based on a book series he loves. | When: next month | Involving: Tim",
+        "\"That\" is one of Tim's favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 27,
+      "question": "Which popular time management technique does Tim use to prepare for exams?",
+      "expected_answer": "Pomodoro technique",
+      "relevant_facts": [
+        "Tim's study trick is breaking up studying into smaller parts, specifically 25 minutes on and 5 minutes off for something fun, to make it less overwhelming and stay on track. | Involving: Tim | To make studying less overwhelming and stay on track."
+      ]
+    },
+    {
+      "q_idx": 28,
+      "question": "Which popular music composer's tunes does Tim enjoy playing on the piano?",
+      "expected_answer": "John Williams",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 29,
+      "question": "What schools did John play basketball in and how many years was he with his team during high school?",
+      "expected_answer": "Middle school, high school, and college and he was with his high school team for 4 years.",
+      "relevant_facts": [
+        "John played basketball throughout middle and high school, eventually earning a college scholarship for the sport. | When: During middle and high school | Involving: John",
+        "John and the friends in his picture were teammates on a sports team for four years in high school. | Involving: John, John's friends (teammates)",
+        "After completing college, John was drafted by a professional basketball team, realizing his childhood dream. | When: After college | Involving: John | This was the fulfillment of his long-held dream."
+      ]
+    },
+    {
+      "q_idx": 30,
+      "question": "Which cities has John been to?",
+      "expected_answer": "Seattle, Chicago, New York, and Paris.",
+      "relevant_facts": [
+        "John loves discovering new cities and had an amazing trip to New York City, where he enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John",
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John's recent trip was to Chicago, which he found awesome due to its energy and friendly locals. | Involving: John",
+        "John has been to Paris and loved it, finding the view from there incredible. | Involving: John",
+        "John loves Seattle for its energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 31,
+      "question": "What month did Tim plan on going to Universal Studios?",
+      "expected_answer": "September, 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and strengthen his bond with it.",
+        "Tim is planning his first trip to Universal Studios next month and is excited for the Harry Potter attractions. | When: Next month | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 32,
+      "question": "Which US states might Tim be in during September 2023 based on his plans of visiting Universal Studios?",
+      "expected_answer": "California or Florida",
+      "relevant_facts": [
+        "Tim is planning his first trip to Universal Studios next month and is excited for the Harry Potter attractions. | When: Next month | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 33,
+      "question": "When does John plan on traveling with his team on a team trip?",
+      "expected_answer": "October, 2023",
+      "relevant_facts": [
+        "John and his new teammates are planning a team trip next month to explore a new city and have some fun. | When: Next month (October 2023) | Involving: John, John's new teammates | To explore a new city and have some fun"
+      ]
+    },
+    {
+      "q_idx": 34,
+      "question": "What could John do after his basketball career?",
+      "expected_answer": "become a basketball coach since he likes giving back and leadership",
+      "relevant_facts": [
+        "John aims to make a difference off the court through charity work or by inspiring people, motivated by his desire to give back to the community because of basketball's positive influence on his life. | Involving: John | He wants to give back to the community because basketball has been great to him.",
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. He considers thinking about life after basketball important. | Involving: John",
+        "John is mentoring younger players on his team, a role he took on to stay involved in the game during the off-season. | Involving: John, younger players | To stay involved in the game during the off-season.",
+        "John's benefit basketball game was a success, attracting many people and raising money for charity. | When: Last week (between January 1 and January 6, 2024) | Involving: John | To raise money for charity",
+        "John held a benefit basketball game. | When: Last week (between January 1 and January 6, 2024) | Involving: John",
+        "John finds mentoring rewarding and fulfilling, enjoying sharing his skills, gaining experience, adapting, motivating, and encouraging players despite challenges, and seeing their development, growth, improvement, and confidence. | Involving: John, players",
+        "John's tips for motivating teammates include showing care, celebrating achievements, providing constructive feedback, reminding them of the bigger goal, creating a positive environment, and giving pep talks before a game. | Involving: John | In response to Tim's request for advice.",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school, planning to use his platform to create a positive impact on the community and inspire others. | Involving: John, local organization | To have a positive impact on the community and inspire others.",
+        "Some younger players see John as a mentor, and he enjoys being a positive role model, providing advice and support on and off the court. He feels great having their trust and admiration and hopes his experiences inspire their dreams. | Involving: John, younger players",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and sees the positive difference sports make.",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing.",
+        "Making a difference is important to John, who uses his influence and resources to support causes he believes in to improve the world. | Involving: John",
+        "John's seminars went really well, and the aspiring professionals were eager and motivated. | When: Recently | Involving: John, aspiring professionals | John was happy to share his knowledge and help out.",
+        "John organized a week-long basketball camp for kids in his hometown last summer, which was an awesome experience that inspired the kids and fostered personal growth. | When: Last summer | Involving: John, kids | He wanted to inspire the kids and show them their potential.",
+        "John spoke at a charity event. | Involving: John",
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, perseverance, and commitment to justice. | Involving: John",
+        "John has a painting of Aragorn in his room to remind him to stay true and be a leader in everything he does. | Involving: John | To remind him to stay true and be a leader.",
+        "John attended a charity event that featured Harry Potter trivia last August. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 35,
+      "question": "What outdoor activities does John enjoy?",
+      "expected_answer": "Hiking, surfing",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with his friends, which he described as an unreal feeling. He loves the connection to nature that surfing provides, finding the waves and wind super exciting and free-feeling. | When: Started five years ago; had an awesome summer (past) | Involving: John, John's friends",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "The photoshoot for John's outdoor gear endorsement deal went very well, taking place in a gorgeous forest where the photographer captured epic shots of him. | Involving: John, photographer",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He was very excited about it.",
+        "John stumbled upon a specific spot while hiking where the sound of the river was soothing and he felt at peace surrounded by rocks. | Involving: John | He felt at peace and admired nature's beauty.",
+        "Some of John's hiking club friends attended his wedding, even though he had just joined the club. | When: Last week (relative to October 2, 2023) | Involving: John, John's hiking club friends"
+      ]
+    },
+    {
+      "q_idx": 36,
+      "question": "Who is Tim and John's favorite basketball player?",
+      "expected_answer": "LeBron James",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires as an inspiration. | Involving: John, LeBron, The Wolves",
+        "Tim owns a basketball signed by his favorite player, LeBron James, which is his prized possession and serves as a reminder of hard work. | Involving: Tim, LeBron James | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 37,
+      "question": "Which week did Tim visit the UK for the Harry Potter Conference?",
+      "expected_answer": "The week before October 13th, 2023.",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling like he got a new lease of life. | When: Last week (October 2-8, 2023) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 38,
+      "question": "which country has Tim visited most frequently in his travels?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-themed place in London and took a tour a few years ago, describing the experience as amazing and like walking into a movie. | When: A few years ago | Involving: Tim",
+        "Tim visited a castle in the UK during a trip and found its architecture and history amazing. | When: Last Friday, November 10, 2023 | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK, which he found incredible and inspiring, feeling like he got a new lease of life. | When: Last week (October 2-8, 2023) | Involving: Tim",
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim",
+        "Tim had a setback last week while trying to write a story based on his experiences in the UK, as it didn't go as he wanted. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 39,
+      "question": "What year did Tim go to the Smoky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 40,
+      "question": "Has Tim been to North Carolina and/or Tennesee states in the US?",
+      "expected_answer": "Yes",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 41,
+      "question": "What kind of fiction stories does Tim write?",
+      "expected_answer": "Fantasy stories with plot twists",
+      "relevant_facts": [
+        "John believes in Tim's fantasy writing. | Involving: John, Tim",
+        "Tim is currently writing a fantasy novel, which is going well, though he finds it nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and got his ideas flowing again. | When: Last week | Involving: Tim",
+        "Tim loves fantasy. | Involving: Tim | This preference led him to seek out writing opportunities in the genre.",
+        "John advises Tim to reflect on what went wrong and find ways to improve with his storytelling, drawing a parallel to how he handles challenges on the basketball court. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 42,
+      "question": "What has John cooked?",
+      "expected_answer": "Soup, a slow cooker meal, and honey garlic chicken with roasted veg.",
+      "relevant_facts": [
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables, and John agreed to write it down and mail it to him. Tim is eager to try it. | Involving: Tim, John",
+        "John has been trying out cooking recipes and recently made a tasty soup. | Involving: John",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes, and he enjoys trying out new recipes. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 43,
+      "question": "What does John like about Lebron James?",
+      "expected_answer": "His heart, determination, skills, and leadership.",
+      "relevant_facts": [
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires as an inspiration. | Involving: John, LeBron, The Wolves",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John | Inspired by LeBron's moments of determination and heart.",
+        "John remembers LeBron James' epic block in Game 7 of the 2016 Finals against Iguodala, where he chased down Iguodala and pinned the ball against the backboard. This act of determination and heart is why John loves basketball. | When: 2016 Finals, Game 7 | Involving: John, LeBron James, Iguodala | It exemplifies the determination and heart John loves in basketball."
+      ]
+    },
+    {
+      "q_idx": 44,
+      "question": "When did John and his wife go on a European vacation?",
+      "expected_answer": "November, 2023.",
+      "relevant_facts": [
+        "John and his wife went on a road trip on the European coastline, which they found amazing with spectacular views, and it was a nice change from his regular life. | When: Recently, before November 11, 2023 | Involving: John, John's wife",
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 45,
+      "question": "Which country was Tim visiting in the second week of November?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a castle in the UK during a trip and found its architecture and history amazing. | When: Last Friday, November 10, 2023 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 46,
+      "question": "Where was Tim in the week before 16 November 2023?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim had a setback last week while trying to write a story based on his experiences in the UK, as it didn't go as he wanted. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK during a trip and found its architecture and history amazing. | When: Last Friday, November 10, 2023 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 47,
+      "question": "When did John get married at a greenhouse?",
+      "expected_answer": "last week of September 2023",
+      "relevant_facts": [
+        "John and his wife held their wedding ceremony in a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week (relative to October 2, 2023) | Involving: John, John's wife | To ensure everyone felt safe and to celebrate with loved ones."
+      ]
+    },
+    {
+      "q_idx": 48,
+      "question": "When did John get an ankle injury in 2023?",
+      "expected_answer": "around November 16, 2023",
+      "relevant_facts": [
+        "John has an injury that has made his week tough, but he is staying positive. | When: This week (leading up to November 16, 2023) | Involving: John",
+        "John achieved a milestone at the gym by jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John | It was a significant step in his recovery/fitness journey after being out for a long time."
+      ]
+    },
+    {
+      "q_idx": 49,
+      "question": "How many times has John injured his ankle?",
+      "expected_answer": "two times",
+      "relevant_facts": [
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. He found it frustrating because he couldn't play or help his team, but he stayed focused on recovery and worked hard, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John recently sustained an injury, which prevented him from playing in basketball games and assisting his team. | When: Not too long ago | Involving: John (and his team)",
+        "John is currently undergoing daily physical therapy exercises as part of his rehabilitation efforts to stay active following his injury. | When: Every day | Involving: John",
+        "John achieved a milestone at the gym by jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John | It was a significant step in his recovery/fitness journey after being out for a long time."
+      ]
+    },
+    {
+      "q_idx": 50,
+      "question": "Which book was John reading during his recovery from an ankle injury?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. He found it frustrating because he couldn't play or help his team, but he stayed focused on recovery and worked hard, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John enjoys cuddling up with a book for chill time and finds cooking therapeutic, creative, and a way to experiment with flavors and take a break when he's away from the court. | Involving: John",
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and search for personal legends, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John",
+        "John achieved a milestone at the gym by jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John | It was a significant step in his recovery/fitness journey after being out for a long time."
+      ]
+    },
+    {
+      "q_idx": 51,
+      "question": "What kind of yoga for building core strength might John benefit from?",
+      "expected_answer": "Hatha Yoga",
+      "relevant_facts": [
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as he loves how these poses challenge his body and mind. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 52,
+      "question": "What does John do to supplement his basketball training?",
+      "expected_answer": "Yoga, strength training",
+      "relevant_facts": [
+        "John developed a workout schedule that incorporates both basketball training and strength training. | Involving: John | To balance his training and stay on track, and to overcome the hurdle of adapting his routine.",
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism, all crucial for basketball. | Involving: John | To improve his physical capabilities for professional basketball.",
+        "Incorporating strength training has improved John's shooting accuracy, agility, and speed, giving him an advantage over opponents and boosting his confidence in basketball. | Involving: John | These improvements are crucial for his performance in professional basketball.",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as he loves how these poses challenge his body and mind. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 53,
+      "question": "What other exercises can help John with his basketball performance?",
+      "expected_answer": "Sprinting, long-distance running, and boxing.",
+      "relevant_facts": [
+        "Incorporating strength training has improved John's shooting accuracy, agility, and speed, giving him an advantage over opponents and boosting his confidence in basketball. | Involving: John | These improvements are crucial for his performance in professional basketball.",
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism, all crucial for basketball. | Involving: John | To improve his physical capabilities for professional basketball.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as he loves how these poses challenge his body and mind. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John developed a workout schedule that incorporates both basketball training and strength training. | Involving: John | To balance his training and stay on track, and to overcome the hurdle of adapting his routine.",
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 54,
+      "question": "When did John take a trip to the Rocky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "John took a stunning trip to the Rocky Mountains last year, appreciating the fresh air and majestic peaks, which made him realize how incredible the world is. | When: Last year (2022) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 55,
+      "question": "When did John start playing professionally?",
+      "expected_answer": "May, 2023",
+      "relevant_facts": [
+        "John found fitting into the Minnesota Wolves' style of play challenging during pre-season training. | When: During pre-season (before May 21, 2023) | Involving: John, Minnesota Wolves",
+        "John signed with a new team, the Minnesota Wolves. | When: Recently, around May 21, 2023 | Involving: John",
+        "The Minnesota Wolves' season opener is scheduled for next week. | When: Next week (May 22-28, 2023) | Involving: Minnesota Wolves"
+      ]
+    },
+    {
+      "q_idx": 56,
+      "question": "When did Tim start playing the violin?",
+      "expected_answer": "August 2023",
+      "relevant_facts": [
+        "Tim recently started learning the violin, an instrument he always admired, finding it challenging but fun, and a way to chill and get creative. | Involving: Tim | He always admired musicians and finds it a great way to chill and get creative.",
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 57,
+      "question": "What instruments does Tim play?",
+      "expected_answer": "piano, violin",
+      "relevant_facts": [
+        "The movie Tim enjoys and whose theme he plays on piano is \"Harry Potter and the Philosopher's Stone\". It is special to him as it was the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family | It's the first movie in the series and associated with positive family memories.",
+        "Tim's favorite piano song to play is a theme from a movie that brings back many great memories. | Involving: Tim | The song evokes great memories.",
+        "Tim recently started learning the violin, an instrument he always admired, finding it challenging but fun, and a way to chill and get creative. | Involving: Tim | He always admired musicians and finds it a great way to chill and get creative.",
+        "Tim started learning to play the piano and is making satisfying progress. | When: Since the last conversation | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 58,
+      "question": "When did John attend the Harry Potter trivia?",
+      "expected_answer": "August 2023.",
+      "relevant_facts": [
+        "John attended a charity event that featured Harry Potter trivia last August. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 59,
+      "question": "Which career-high performances did John achieve in 2023?",
+      "expected_answer": "highest point score, highest assist",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Last Friday | Involving: John",
+        "John scored 40 points in a basketball game, which is his personal highest score ever. | When: Last week | Involving: John | It was a significant achievement, indicating his hard work is paying off."
+      ]
+    },
+    {
+      "q_idx": 60,
+      "question": "When did John achieve a career-high assist performance?",
+      "expected_answer": "December 11, 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 61,
+      "question": "What books has John read?",
+      "expected_answer": "inpsiring book on dreaming big, The Alchemist, fantasy series, non-fiction books on personal development, Dune",
+      "relevant_facts": [
+        "John enjoys reading fantasy books, which fuel his creativity, and non-fiction books on personal development and mindset, which help him understand himself better. | Involving: John",
+        "John read and loved \"The Alchemist\" because it made him think about life and the importance of following one's dreams. He highly recommends it. | Involving: John | The book's message resonated with him.",
+        "John is reading an inspiring book that reminds him to keep dreaming. | Involving: John",
+        "John is currently reading and highly recommends \"Dune\" by Frank Herbert, describing it as a great story about religion and human control over ecology. | Involving: John",
+        "John considers 'The Hobbit' and another popular fantasy series among his favorite books. | Involving: John",
+        "John recently finished an amazing fantasy series with many twists. | When: Recently, before November 11, 2023 | Involving: John",
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and search for personal legends, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John",
+        "John is a huge fan of Lord of the Rings, appreciating its adventure, world, and characters. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 62,
+      "question": "What does John do to share his knowledge?",
+      "expected_answer": "gives seminars, mentors younger players.",
+      "relevant_facts": [
+        "John's seminars went really well, and the aspiring professionals were eager and motivated. | When: Recently | Involving: John, aspiring professionals | John was happy to share his knowledge and help out.",
+        "John finds mentoring rewarding and fulfilling, enjoying sharing his skills, gaining experience, adapting, motivating, and encouraging players despite challenges, and seeing their development, growth, improvement, and confidence. | Involving: John, players",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing.",
+        "Some younger players see John as a mentor, and he enjoys being a positive role model, providing advice and support on and off the court. He feels great having their trust and admiration and hopes his experiences inspire their dreams. | Involving: John, younger players",
+        "John is mentoring younger players on his team, a role he took on to stay involved in the game during the off-season. | Involving: John, younger players | To stay involved in the game during the off-season.",
+        "John organized a week-long basketball camp for kids in his hometown last summer, which was an awesome experience that inspired the kids and fostered personal growth. | When: Last summer | Involving: John, kids | He wanted to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 63,
+      "question": "When did John organize a basketball camp for kids?",
+      "expected_answer": "summer 2023",
+      "relevant_facts": [
+        "John organized a week-long basketball camp for kids in his hometown last summer, which was an awesome experience that inspired the kids and fostered personal growth. | When: Last summer | Involving: John, kids | He wanted to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 64,
+      "question": "Which month was John in Italy?",
+      "expected_answer": "December, 2023",
+      "relevant_facts": [
+        "John visited Italy last month and had a blast. | When: December 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 65,
+      "question": "What fantasy movies does Tim like?",
+      "expected_answer": "Lord of the Rings, Harry Potter, and Star Wars.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "The movie Tim enjoys and whose theme he plays on piano is \"Harry Potter and the Philosopher's Stone\". It is special to him as it was the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family | It's the first movie in the series and associated with positive family memories.",
+        "Watching \"Harry Potter and the Philosopher's Stone\" with his family was a special memory for Tim, where they would get comfy with snacks and a blanket and be totally absorbed. | Involving: Tim, Tim's family | It was a magical and absorbing experience.",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 66,
+      "question": "What is a Star Wars book that Tim might enjoy?",
+      "expected_answer": "Star Wars: Jedi Apprentice by Judy Blundell and David Farland. It is a highly rated and immersive series about his favorite movies.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim loves fantasy. | Involving: Tim | This preference led him to seek out writing opportunities in the genre.",
+        "Tim's favorite book is Harry Potter because he finds it immersive. | Involving: Tim",
+        "Tim's favorite novels are fantasy novels, which he enjoys because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds, and his favorite is Lord of the Rings. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 67,
+      "question": "What would be a good hobby related to his travel dreams for Tim to pick up?",
+      "expected_answer": "Writing a travel blog.",
+      "relevant_facts": [
+        "Tim is hooked on Harry Potter and Game of Thrones and loves writing about these specific fantasy novels. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is going well, though he finds it nerve-wracking but exciting and joyful. | Involving: Tim",
+        "Tim's sources of inspiration for his writing include books, movies, real-life experiences, and certain authors. Reading about castles in the UK specifically gave him ideas. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | When: Recently | Involving: Tim | To plan his next dream trip, motivated by the story of the Himalayas trek.",
+        "Tim is researching visa requirements for countries he wants to visit, which he finds overwhelming but exciting, and he is proud of this initiative as a step towards his travel dreams. | Involving: Tim",
+        "Tim loves traveling. | Involving: Tim",
+        "Tim has been reading stories from travelers around the world to plan his next adventure, finding a book with many such stories. | Involving: Tim | To plan his next adventure.",
+        "Tim believes traveling is eye-opening. | Involving: Tim",
+        "Tim joined a group of globetrotters who share his interests. | Involving: Tim",
+        "Tim has always been interested in different cultures and countries. | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing stories. | Involving: Tim",
+        "Tim had a setback last week while trying to write a story based on his experiences in the UK, as it didn't go as he wanted. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 68,
+      "question": "What day did Tim get into his study abroad program?",
+      "expected_answer": "Januarty 5, 2024",
+      "relevant_facts": [
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 69,
+      "question": "When will Tim leave for Ireland?",
+      "expected_answer": "February, 2024",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim plans to stay in Galway, Ireland, which is known for its arts, Irish music, and vibrant atmosphere. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim will depart for Ireland next month for a semester-long study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim wants to visit The Cliffs of Moher, which offers amazing ocean views and cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 70,
+      "question": "Which Star Wars-related locations would Tim enjoy during his visit to Ireland?",
+      "expected_answer": "Skellig Michael, Malin Head, Loop Head, Ceann Sib\u00e9al, and Brow Head because they are Star Wars filming locations.",
+      "relevant_facts": [
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim is excited to explore nature in Ireland. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim plans to stay in Galway, Ireland, which is known for its arts, Irish music, and vibrant atmosphere. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim wants to visit The Cliffs of Moher, which offers amazing ocean views and cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim enjoys being in the mountains and finds that nature has a calming effect on him, acting as a \"reset for the soul.\" | Involving: Tim",
+        "Tim will depart for Ireland next month for a semester-long study abroad program. | When: Next month (February 2024) | Involving: Tim",
+        "Tim finds nature refreshing and considers it a good break from school. | Involving: Tim",
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 71,
+      "question": "Which team did John sign with on 21 May, 2023?",
+      "expected_answer": "The Minnesota Wolves",
+      "relevant_facts": [
+        "John signed with a new team, the Minnesota Wolves. | When: Recently, around May 21, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 72,
+      "question": "What is John's position on the team he signed with?",
+      "expected_answer": "shooting guard",
+      "relevant_facts": [
+        "John is a shooting guard for the Minnesota Wolves. | Involving: John",
+        "John signed with a new team, the Minnesota Wolves. | When: Recently, around May 21, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 73,
+      "question": "What challenge did John encounter during pre-season training?",
+      "expected_answer": "fitting into the new team's style of play",
+      "relevant_facts": [
+        "John found fitting into the Minnesota Wolves' style of play challenging during pre-season training. | When: During pre-season (before May 21, 2023) | Involving: John, Minnesota Wolves"
+      ]
+    },
+    {
+      "q_idx": 74,
+      "question": "What aspects of the Harry Potter universe will be discussed in John's fan project collaborations?",
+      "expected_answer": "characters, spells, magical creatures",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 75,
+      "question": "What forum did Tim join recently?",
+      "expected_answer": "fantasy literature forum",
+      "relevant_facts": [
+        "Tim joined a fantasy literature forum and had a great talk about his favorite books. | When: Last night | Involving: Tim | He found the discussion enriching."
+      ]
+    },
+    {
+      "q_idx": 76,
+      "question": "What kind of picture did Tim share as part of their Harry Potter book collection?",
+      "expected_answer": "MinaLima's creation from the Harry Potter films",
+      "relevant_facts": [
+        "Tim showed John his book collection, which included a picture. | Involving: Tim, John",
+        "Tim owns a picture from MinaLima, the company that created all the props for the Harry Potter films. | Involving: Tim, MinaLima | He loves their work and feels it's like having a piece of the wizarding world at home.",
+        "Tim reorganized his bookshelf and shared a photo of it with John. | Involving: Tim, John",
+        "Tim uses reminders of the wizarding world, such as the MinaLima picture, as a way to escape reality and the daily grind. | Involving: Tim | It helps him escape reality."
+      ]
+    },
+    {
+      "q_idx": 77,
+      "question": "What was the highest number of points John scored in a game recently?",
+      "expected_answer": "40 points",
+      "relevant_facts": [
+        "John scored 40 points in a basketball game, which is his personal highest score ever. | When: Last week | Involving: John | It was a significant achievement, indicating his hard work is paying off."
+      ]
+    },
+    {
+      "q_idx": 78,
+      "question": "What did John celebrate at a restaurant with teammates?",
+      "expected_answer": "a tough win",
+      "relevant_facts": [
+        "John and his teammates, feeling exhausted but happy, celebrated their tough win at a restaurant, laughing and reliving intense moments. | When: After the game last week | Involving: John, John's teammates | To celebrate their tough win."
+      ]
+    },
+    {
+      "q_idx": 79,
+      "question": "What kind of deals did John sign with Nike and Gatorade?",
+      "expected_answer": "basketball shoe and gear deal with Nike, potential sponsorship deal with Gatorade",
+      "relevant_facts": [
+        "John signed a deal with Nike for basketball shoes and gear. | When: Recently | Involving: John",
+        "John is in talks with Gatorade for a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 80,
+      "question": "Which city is John excited to have a game at?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "John loves Seattle for its energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John has a basketball game scheduled in Seattle next month. | When: Next month | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 81,
+      "question": "How long has John been surfing?",
+      "expected_answer": "five years",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with his friends, which he described as an unreal feeling. He loves the connection to nature that surfing provides, finding the waves and wind super exciting and free-feeling. | When: Started five years ago; had an awesome summer (past) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 82,
+      "question": "How does John feel while surfing?",
+      "expected_answer": "super exciting and free-feeling",
+      "relevant_facts": [
+        "John started surfing five years ago and had an awesome summer surfing with his friends, which he described as an unreal feeling. He loves the connection to nature that surfing provides, finding the waves and wind super exciting and free-feeling. | When: Started five years ago; had an awesome summer (past) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 83,
+      "question": "What kind of articles has Tim been writing about for the online magazine?",
+      "expected_answer": "different fantasy novels, characters, themes, and book recommendations",
+      "relevant_facts": [
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on character studies, themes, and book recommendations. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine and finds this work rewarding. | Involving: Tim",
+        "Tim is hooked on Harry Potter and Game of Thrones and loves writing about these specific fantasy novels. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 84,
+      "question": "Which two fantasy novels does Tim particularly enjoy writing about?",
+      "expected_answer": "Harry Potter and Game of Thrones",
+      "relevant_facts": [
+        "Tim is hooked on Harry Potter and Game of Thrones and loves writing about these specific fantasy novels. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 85,
+      "question": "What did Anthony and John end up playing during the charity event?",
+      "expected_answer": "an intense Harry Potter trivia contest",
+      "relevant_facts": [
+        "A \"super-nerd\" won a signed Harry Potter book as a prize at the Harry Potter trivia contest where John and Anthony participated. | Involving: super-nerd, John, Anthony",
+        "John and Anthony participated in an intense Harry Potter trivia contest. | Involving: John, Anthony",
+        "John attended a charity event that featured Harry Potter trivia last August. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 86,
+      "question": "What did John share with the person he skyped about?",
+      "expected_answer": "Characters from Harry Potter",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 87,
+      "question": "How did John describe the team bond?",
+      "expected_answer": "Awesome",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 88,
+      "question": "How did John get introduced to basketball?",
+      "expected_answer": "Dad signed him up for a local league",
+      "relevant_facts": [
+        "John's dad signed him up for a local basketball league when John was ten years old, marking the beginning of his playing career. | When: When John was ten years old | Involving: John, John's dad"
+      ]
+    },
+    {
+      "q_idx": 89,
+      "question": "What is John's number one goal in his basketball career?",
+      "expected_answer": "Winning a championship",
+      "relevant_facts": [
+        "John's number one goal for his basketball career is to win a championship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 90,
+      "question": "What organization is John teaming up with for his charity work?",
+      "expected_answer": "A local organization helping disadvantaged kids with sports and school",
+      "relevant_facts": [
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school, planning to use his platform to create a positive impact on the community and inspire others. | Involving: John, local organization | To have a positive impact on the community and inspire others."
+      ]
+    },
+    {
+      "q_idx": 91,
+      "question": "When did John meet back up with his teammates after his trip in August 2023?",
+      "expected_answer": "Aug 15th",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and lucky to be part of the team due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 92,
+      "question": "What did John's teammates give him when they met on Aug 15th?",
+      "expected_answer": "a basketball with autographs on it",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after his trip, feeling very welcome and lucky to be part of the team due to the electric atmosphere. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball on August 15th to show their friendship and appreciation, serving as a reminder of their bond. | When: August 15, 2023 | Involving: John, John's teammates | To show friendship and appreciation, and as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 93,
+      "question": "Why did John's teammates sign the basketball they gave him?",
+      "expected_answer": "to show their friendship and appreciation",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball on August 15th to show their friendship and appreciation, serving as a reminder of their bond. | When: August 15, 2023 | Involving: John, John's teammates | To show friendship and appreciation, and as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 94,
+      "question": "What is the main intention behind Tim wanting to attend the book conference?",
+      "expected_answer": "to learn more about literature and create a stronger bond to it",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month, which is a gathering of authors, publishers, and book lovers, to learn more about literature and strengthen his bond with it. | When: September 2023 | Involving: Tim | To learn more about literature and strengthen his bond with it."
+      ]
+    },
+    {
+      "q_idx": 95,
+      "question": "What new activity has Tim started learning in August 2023?",
+      "expected_answer": "play the piano",
+      "relevant_facts": [
+        "Tim started learning to play the piano and is making satisfying progress. | When: Since the last conversation | Involving: Tim",
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 96,
+      "question": "Which movie's theme is Tim's favorite to play on the piano?",
+      "expected_answer": "\"Harry Potter and the Philosopher's Stone\"",
+      "relevant_facts": [
+        "The movie Tim enjoys and whose theme he plays on piano is \"Harry Potter and the Philosopher's Stone\". It is special to him as it was the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family | It's the first movie in the series and associated with positive family memories."
+      ]
+    },
+    {
+      "q_idx": 97,
+      "question": "What special memory does \"Harry Potter and the Philosopher's Stone\" bring to Tim?",
+      "expected_answer": "Watching it with his family",
+      "relevant_facts": [
+        "Watching \"Harry Potter and the Philosopher's Stone\" with his family was a special memory for Tim, where they would get comfy with snacks and a blanket and be totally absorbed. | Involving: Tim, Tim's family | It was a magical and absorbing experience.",
+        "The movie Tim enjoys and whose theme he plays on piano is \"Harry Potter and the Philosopher's Stone\". It is special to him as it was the first movie in the series and brings back magical memories of watching it with his family. | Involving: Tim, Tim's family | It's the first movie in the series and associated with positive family memories."
+      ]
+    },
+    {
+      "q_idx": 98,
+      "question": "Which movie does Tim mention they enjoy watching during Thanksgiving?",
+      "expected_answer": "\"Home Alone\"",
+      "relevant_facts": [
+        "Tim's family enjoys watching \"Home Alone\", \"Elf\", and \"The Santa Clause\" during Thanksgiving and the holidays, finding them funny, festive, and heartwarming. | Involving: Tim, Tim's family"
+      ]
+    },
+    {
+      "q_idx": 99,
+      "question": "What tradition does Tim mention they love during Thanksgiving?",
+      "expected_answer": "Prepping the feast and talking about what they're thankful for",
+      "relevant_facts": [
+        "Thanksgiving is a special holiday for Tim's family, who enjoy prepping the feast, discussing what they are thankful for, and watching movies afterward. | Involving: Tim, Tim's family"
+      ]
+    },
+    {
+      "q_idx": 100,
+      "question": "How long did John and his high school basketball teammates play together?",
+      "expected_answer": "Four years",
+      "relevant_facts": [
+        "John and the friends in his picture were teammates on a sports team for four years in high school. | Involving: John, John's friends (teammates)"
+      ]
+    },
+    {
+      "q_idx": 101,
+      "question": "How was John's experience in New York City?",
+      "expected_answer": "Amazing",
+      "relevant_facts": [
+        "John loves discovering new cities and had an amazing trip to New York City, where he enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John",
+        "John initially had trouble figuring out the subway during his NYC trip but found it easy after someone helped explain it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 102,
+      "question": "What did John say about NYC, enticing Tim to visit?",
+      "expected_answer": "It's got so much to check out - the culture, food - you won't regret it.",
+      "relevant_facts": [
+        "John loves discovering new cities and had an amazing trip to New York City, where he enjoyed exploring the city and trying all the restaurants, recommending it as a must-visit. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 103,
+      "question": "What kind of soup did John make recently?",
+      "expected_answer": "tasty soup with sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty soup. | Involving: John",
+        "John made up the tasty soup recipe on the spot and used sage for flavor. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 104,
+      "question": "What spice did John add to the soup for flavor?",
+      "expected_answer": "sage",
+      "relevant_facts": [
+        "John made up the tasty soup recipe on the spot and used sage for flavor. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 105,
+      "question": "What is Tim excited to see at Universal Studios?",
+      "expected_answer": "The Harry Potter stuff",
+      "relevant_facts": [
+        "Tim is planning his first trip to Universal Studios next month and is excited for the Harry Potter attractions. | When: Next month | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 106,
+      "question": "Where are John and his teammates planning to explore on a team trip?",
+      "expected_answer": "a new city",
+      "relevant_facts": [
+        "John and his new teammates are planning a team trip next month to explore a new city and have some fun. | When: Next month (October 2023) | Involving: John, John's new teammates | To explore a new city and have some fun"
+      ]
+    },
+    {
+      "q_idx": 107,
+      "question": "What city did Tim suggest to John for the team trip next month?",
+      "expected_answer": "Edinburgh, Scotland",
+      "relevant_facts": [
+        "John asked Tim for suggestions for their team trip destination. | Involving: John, Tim",
+        "John and his new teammates are planning a team trip next month to explore a new city and have some fun. | When: Next month (October 2023) | Involving: John, John's new teammates | To explore a new city and have some fun",
+        "Tim suggested Edinburgh, Scotland, as a trip destination, noting its magical vibe, history, architecture, beauty, and connection to Harry Potter. | Involving: Tim, John | As a suggestion for John's team trip",
+        "John considers Edinburgh, Scotland, a great idea and a place worth considering for their team trip, and he has not been there before. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 108,
+      "question": "What does John want to do after his basketball career?",
+      "expected_answer": "positively influence and inspire others, potentially start a foundation and engage in charity work",
+      "relevant_facts": [
+        "John wants to use his platform after basketball to make a positive difference, inspire others, potentially start a foundation, and do charity work, aiming to leave a meaningful legacy. He considers thinking about life after basketball important. | Involving: John",
+        "John aims to make a difference off the court through charity work or by inspiring people, motivated by his desire to give back to the community because of basketball's positive influence on his life. | Involving: John | He wants to give back to the community because basketball has been great to him."
+      ]
+    },
+    {
+      "q_idx": 109,
+      "question": "What advice did Tim give John about picking endorsements?",
+      "expected_answer": "Ensure they align with values and brand, look for companies that share the desire to make a change and help others, make sure the endorsement feels authentic",
+      "relevant_facts": [
+        "Tim advised John to choose endorsements that align with his values and brand, partner with companies that share his desire to make a positive change, and ensure authenticity for his followers. | Involving: Tim, John | Provided in response to John's request for advice."
+      ]
+    },
+    {
+      "q_idx": 110,
+      "question": "What book recommendation did Tim give to John for the trip?",
+      "expected_answer": "A fantasy novel by Patrick Rothfuss",
+      "relevant_facts": [
+        "Tim recommended \"The Name of the Wind,\" a fantasy novel by Patrick Rothfuss, for John's trip. | Involving: Tim, John, Patrick Rothfuss | In response to John's request for book recommendations.",
+        "John asked Tim for book recommendations for his trip. | Involving: John, Tim",
+        "John plans to check out the book recommended by Tim. | Involving: John, Tim",
+        "John plans to add \"The Name of the Wind\" to his reading list. | Involving: John | Tim recommended the book.",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, strong world-building, and character development. | Involving: Tim",
+        "John likes fantasy novels with strong characters and good world-building, and he added \"The Name of the Wind\" to his reading list based on Tim's recommendation. | Involving: John",
+        "Tim recommended a book by Patrick Rothfuss, praising its \"awesome\" world-building and characters. | Involving: Tim, Patrick Rothfuss",
+        "John intends to check out \"The Name of the Wind\" for his trip and shared a photo of his bookshelf, indicating he enjoys reading. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 111,
+      "question": "What type of venue did John and his girlfriend choose for their wedding ceremony?",
+      "expected_answer": "Greenhouse",
+      "relevant_facts": [
+        "John and his wife held their wedding ceremony in a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week (relative to October 2, 2023) | Involving: John, John's wife | To ensure everyone felt safe and to celebrate with loved ones."
+      ]
+    },
+    {
+      "q_idx": 112,
+      "question": "What was the setting for John and his wife's first dance?",
+      "expected_answer": "Cozy restaurant",
+      "relevant_facts": [
+        "John and his wife had their first dance at a cozy restaurant, which was described as dreamy with music and candlelight. | When: Last week (relative to October 2, 2023) | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 113,
+      "question": "Which basketball team does Tim support?",
+      "expected_answer": "The Wolves",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 114,
+      "question": "What passion does Tim mention connects him with people from all over the world?",
+      "expected_answer": "passion for fantasy stuff",
+      "relevant_facts": [
+        "Tim loves how his passion for fantasy stuff connects him with people from all over the world. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 115,
+      "question": "How does John describe the game season for his team?",
+      "expected_answer": "intense with tough losses and great wins",
+      "relevant_facts": [
+        "John's team had an intense season with both tough losses and great wins, but overall performed pretty well. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 116,
+      "question": "How does John say his team handles tough opponents?",
+      "expected_answer": "by backing each other up and not quitting",
+      "relevant_facts": [
+        "John's team is driven to improve by tough opponents, and they support each other and won't quit. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 117,
+      "question": "What motivates John's team to get better, according to John?",
+      "expected_answer": "facing tough opponents",
+      "relevant_facts": [
+        "John's team is driven to improve by tough opponents, and they support each other and won't quit. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 118,
+      "question": "What did John's team win at the end of the season?",
+      "expected_answer": "a trophy",
+      "relevant_facts": [
+        "John's team won a trophy, making all their hard work and effort feel worthwhile. | Involving: John (and his team)",
+        "John was elated about winning the trophy and appreciates Tim's support, stating he will keep working hard. | Involving: John, Tim",
+        "John won a trophy, likely a basketball trophy, after putting in significant time and energy. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 119,
+      "question": "Where did Tim capture the photography of the sunset over the mountain range?",
+      "expected_answer": "Smoky Mountains",
+      "relevant_facts": [
+        "Tim took a stunning picture during a trip to the Smoky Mountains. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 120,
+      "question": "How does John feel about being seen as a mentor by some of the younger players?",
+      "expected_answer": "It feels great",
+      "relevant_facts": [
+        "Some younger players see John as a mentor, and he enjoys being a positive role model, providing advice and support on and off the court. He feels great having their trust and admiration and hopes his experiences inspire their dreams. | Involving: John, younger players",
+        "John finds mentoring rewarding and fulfilling, enjoying sharing his skills, gaining experience, adapting, motivating, and encouraging players despite challenges, and seeing their development, growth, improvement, and confidence. | Involving: John, players"
+      ]
+    },
+    {
+      "q_idx": 121,
+      "question": "What does John find rewarding about mentoring the younger players?",
+      "expected_answer": "Seeing their growth, improvement, and confidence",
+      "relevant_facts": [
+        "John finds mentoring rewarding and fulfilling, enjoying sharing his skills, gaining experience, adapting, motivating, and encouraging players despite challenges, and seeing their development, growth, improvement, and confidence. | Involving: John, players"
+      ]
+    },
+    {
+      "q_idx": 122,
+      "question": "What has John been able to help the younger players achieve?",
+      "expected_answer": "reach their goals",
+      "relevant_facts": [
+        "Some younger players see John as a mentor, and he enjoys being a positive role model, providing advice and support on and off the court. He feels great having their trust and admiration and hopes his experiences inspire their dreams. | Involving: John, younger players",
+        "John is mentoring younger players on his team, a role he took on to stay involved in the game during the off-season. | Involving: John, younger players | To stay involved in the game during the off-season.",
+        "John finds mentoring rewarding and fulfilling, enjoying sharing his skills, gaining experience, adapting, motivating, and encouraging players despite challenges, and seeing their development, growth, improvement, and confidence. | Involving: John, players",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school, planning to use his platform to create a positive impact on the community and inspire others. | Involving: John, local organization | To have a positive impact on the community and inspire others.",
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and sees the positive difference sports make.",
+        "John organized a week-long basketball camp for kids in his hometown last summer, which was an awesome experience that inspired the kids and fostered personal growth. | When: Last summer | Involving: John, kids | He wanted to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 123,
+      "question": "What genre is the novel that Tim is writing?",
+      "expected_answer": "Fantasy",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which is going well, though he finds it nerve-wracking but exciting and joyful. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 124,
+      "question": "Who is one of Tim's sources of inspiration for writing?",
+      "expected_answer": "J.K. Rowling",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, whose books are captivating due to their detail and creative storytelling. Tim takes notes on her style for his own writing. | Involving: Tim, J.K. Rowling",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 125,
+      "question": "What J.K. Rowling quote does Tim resonate with?",
+      "expected_answer": "\"Turn on the light - happiness hides in the darkest of times.\"",
+      "relevant_facts": [
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to keep hope alive during tough times. | Involving: Tim | It helps him maintain hope during difficult periods."
+      ]
+    },
+    {
+      "q_idx": 126,
+      "question": "What does John write on the whiteboard to help him stay motivated?",
+      "expected_answer": "motivational quotes and strategies",
+      "relevant_facts": [
+        "John uses a whiteboard to write down motivational quotes and strategies, which helps him stay focused and motivated during tough workouts and keep improving. | Involving: John | To stay focused, motivated, and improve during tough workouts."
+      ]
+    },
+    {
+      "q_idx": 127,
+      "question": "What hobby is a therapy for John when away from the court?",
+      "expected_answer": "Cooking",
+      "relevant_facts": [
+        "John enjoys cuddling up with a book for chill time and finds cooking therapeutic, creative, and a way to experiment with flavors and take a break when he's away from the court. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 128,
+      "question": "What type of meal does John often cook using a slow cooker?",
+      "expected_answer": "honey garlic chicken with roasted veg",
+      "relevant_facts": [
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables, and John agreed to write it down and mail it to him. Tim is eager to try it. | Involving: Tim, John",
+        "John frequently makes honey garlic chicken with roasted vegetables, which is one of his favorite recipes, and he enjoys trying out new recipes. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 129,
+      "question": "How will John share the honey garlic chicken recipe with the other person?",
+      "expected_answer": "write it down and mail it",
+      "relevant_facts": [
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables, and John agreed to write it down and mail it to him. Tim is eager to try it. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 130,
+      "question": "What was Tim's huge writing issue last week,as mentioned on November 6, 2023?",
+      "expected_answer": "He got stuck on a plot twist",
+      "relevant_facts": [
+        "Tim experienced a frustrating writing issue last week, getting stuck on a plot twist, but he persevered and got his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 131,
+      "question": "What does Tim have that serves as a reminder of hard work and is his prized possession?",
+      "expected_answer": "a basketball signed by his favorite player",
+      "relevant_facts": [
+        "Tim owns a basketball signed by his favorite player, LeBron James, which is his prized possession and serves as a reminder of hard work. | Involving: Tim, LeBron James | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 132,
+      "question": "Why do Tim and John find LeBron inspiring?",
+      "expected_answer": "LeBron's determination and the epic block in Game 7 of the '16 Finals",
+      "relevant_facts": [
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John | Inspired by LeBron's moments of determination and heart.",
+        "Tim was inspired by LeBron James' epic block in a Finals game a few years back, which changed the game and led to a win, reinforcing the lesson to never give up. | When: A few years back | Involving: Tim, LeBron James | It was an inspiration to never give up.",
+        "John's favorite basketball team is The Wolves, and his favorite player is LeBron, whose skills, leadership, work ethic, and dedication he admires as an inspiration. | Involving: John, LeBron, The Wolves",
+        "John remembers LeBron James' epic block in Game 7 of the 2016 Finals against Iguodala, where he chased down Iguodala and pinned the ball against the backboard. This act of determination and heart is why John loves basketball. | When: 2016 Finals, Game 7 | Involving: John, LeBron James, Iguodala | It exemplifies the determination and heart John loves in basketball."
+      ]
+    },
+    {
+      "q_idx": 133,
+      "question": "How did John describe the views during their road trip out on the European coastline?",
+      "expected_answer": "Spectacular",
+      "relevant_facts": [
+        "John and his wife went on a road trip on the European coastline, which they found amazing with spectacular views, and it was a nice change from his regular life. | When: Recently, before November 11, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 134,
+      "question": "What is one of Tim's favorite fantasy TV shows, as mentioned on November 11, 2023?",
+      "expected_answer": "\"That\"",
+      "relevant_facts": [
+        "\"That\" is one of Tim's favorite fantasy shows. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 135,
+      "question": "How does Tim stay motivated during difficult study sessions?",
+      "expected_answer": "Visualizing goals and success",
+      "relevant_facts": [
+        "Tim's study trick is breaking up studying into smaller parts, specifically 25 minutes on and 5 minutes off for something fun, to make it less overwhelming and stay on track. | Involving: Tim | To make studying less overwhelming and stay on track.",
+        "Tim's love for writing and reading helps him stay motivated and push himself to get better during tough times. | Involving: Tim",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to keep hope alive during tough times. | Involving: Tim | It helps him maintain hope during difficult periods.",
+        "Tim owns a basketball signed by his favorite player, LeBron James, which is his prized possession and serves as a reminder of hard work. | Involving: Tim, LeBron James | It reminds him of hard work.",
+        "Tim had a tough exam last week that caused him to doubt himself, but he turned it into a learning experience, studied hard, and demonstrated resilience and determination. | When: Last week | Involving: Tim (user) | It was a significant personal challenge and a moment of self-discovery regarding his resilience.",
+        "Tim was inspired by LeBron James' epic block in a Finals game a few years back, which changed the game and led to a win, reinforcing the lesson to never give up. | When: A few years back | Involving: Tim, LeBron James | It was an inspiration to never give up."
+      ]
+    },
+    {
+      "q_idx": 136,
+      "question": "What did Tim say about his injury on 16 November, 2023?",
+      "expected_answer": "The doctor said it's not too serious",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 137,
+      "question": "What was the setback Tim faced in his writing project on 21 November, 2023?",
+      "expected_answer": "Story based on experiences in the UK didn't go as planned",
+      "relevant_facts": [
+        "Tim had a setback last week while trying to write a story based on his experiences in the UK, as it didn't go as he wanted. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 138,
+      "question": "How did John overcome his ankle injury from last season?",
+      "expected_answer": "stayed focused on recovery and worked hard to strengthen his body",
+      "relevant_facts": [
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism, all crucial for basketball. | Involving: John | To improve his physical capabilities for professional basketball.",
+        "Incorporating strength training has improved John's shooting accuracy, agility, and speed, giving him an advantage over opponents and boosting his confidence in basketball. | Involving: John | These improvements are crucial for his performance in professional basketball.",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. He found it frustrating because he couldn't play or help his team, but he stayed focused on recovery and worked hard, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John developed a workout schedule that incorporates both basketball training and strength training. | Involving: John | To balance his training and stay on track, and to overcome the hurdle of adapting his routine.",
+        "John's injury recovery has been tough, but he is staying positive and taking it slow. | Involving: John",
+        "John has an injury that has made his week tough, but he is staying positive. | When: This week (leading up to November 16, 2023) | Involving: John",
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John is currently undergoing daily physical therapy exercises as part of his rehabilitation efforts to stay active following his injury. | When: Every day | Involving: John",
+        "John plans to keep pushing and staying positive regarding his fitness journey. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John uses a whiteboard to write down motivational quotes and strategies, which helps him stay focused and motivated during tough workouts and keep improving. | Involving: John | To stay focused, motivated, and improve during tough workouts.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as he loves how these poses challenge his body and mind. | Involving: John",
+        "John achieved a milestone at the gym by jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John | It was a significant step in his recovery/fitness journey after being out for a long time.",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 139,
+      "question": "What motivated Tim to keep pushing himself to get better in writing and reading?",
+      "expected_answer": "Love for writing and reading",
+      "relevant_facts": [
+        "Tim's love for writing and reading helps him stay motivated and push himself to get better during tough times. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 140,
+      "question": "How did John overcome a mistake he made during a big game in basketball?",
+      "expected_answer": "Worked hard to get better and focused on growth",
+      "relevant_facts": [
+        "John messed up during a big basketball game, which was hard to accept. Instead of getting stuck, he worked hard to improve, learning that resilience is key and owning up to mistakes is important for growth as a player and teammate. | Involving: John",
+        "Tim observed that John admits mistakes and uses them for improvement, showing his commitment to getting better. | Involving: Tim (observer), John (subject)",
+        "John advises Tim to reflect on what went wrong and find ways to improve with his storytelling, drawing a parallel to how he handles challenges on the basketball court. | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 141,
+      "question": "What book did John recently finish rereading that left him feeling inspired and hopeful about following dreams?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and search for personal legends, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John",
+        "John read and loved \"The Alchemist\" because it made him think about life and the importance of following one's dreams. He highly recommends it. | Involving: John | The book's message resonated with him."
+      ]
+    },
+    {
+      "q_idx": 142,
+      "question": "How did \"The Alchemist\" impact John's perspective on following dreams?",
+      "expected_answer": "made him think again about following dreams and searching for personal legends",
+      "relevant_facts": [
+        "John read and loved \"The Alchemist\" because it made him think about life and the importance of following one's dreams. He highly recommends it. | Involving: John | The book's message resonated with him.",
+        "John recently reread \"The Alchemist,\" which he found inspiring and motivating to follow dreams and search for personal legends, leaving him feeling hopeful. | When: Recently (before November 21, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 143,
+      "question": "What is John trying out to improve his strength and flexibility after recovery from ankle injury?",
+      "expected_answer": "yoga",
+      "relevant_facts": [
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "Yoga has helped John improve his strength, flexibility, focus, and balance during his workouts. | Involving: John",
+        "John's injury recovery has been tough, but he is staying positive and taking it slow. | Involving: John",
+        "Last season, John hurt his ankle, which was a major challenge requiring time off and physical therapy. He found it frustrating because he couldn't play or help his team, but he stayed focused on recovery and worked hard, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability. | Involving: John",
+        "John recently sustained an injury, which prevented him from playing in basketball games and assisting his team. | When: Not too long ago | Involving: John (and his team)",
+        "John and his wife hosted a small get-together with friends and family to celebrate John's jogging milestone. | When: Last Friday or Saturday | Involving: John, John's wife, friends, family | To celebrate John's milestone of jogging without pain.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability, as he loves how these poses challenge his body and mind. | Involving: John",
+        "Tim plans to try the Warrior II yoga pose. | Involving: Tim (user) | John shared the pose and its benefits.",
+        "John achieved a milestone at the gym by jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John | It was a significant step in his recovery/fitness journey after being out for a long time."
+      ]
+    },
+    {
+      "q_idx": 144,
+      "question": "How long does John usually hold the yoga pose he shared with Tim?",
+      "expected_answer": "30-60 seconds",
+      "relevant_facts": [
+        "Tim plans to try the Warrior II yoga pose. | Involving: Tim (user) | John shared the pose and its benefits.",
+        "John typically holds the Warrior II pose for 30-60 seconds, finding it helpful for building strength and stability. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 145,
+      "question": "Where was the forest picture shared by John on December 1,2023 taken?",
+      "expected_answer": "near his hometown",
+      "relevant_facts": [
+        "John shared a photo of a tranquil forest located near his hometown. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 146,
+      "question": "What did Tim recently start learning in addition to being part of a travel club and working on studies?",
+      "expected_answer": "an instrument",
+      "relevant_facts": [
+        "Tim joined a travel club. | Involving: Tim | He is interested in different cultures and countries, excited to meet new people and learn about them.",
+        "Tim recently started learning the violin, an instrument he always admired, finding it challenging but fun, and a way to chill and get creative. | Involving: Tim | He always admired musicians and finds it a great way to chill and get creative.",
+        "Tim is working on his studies. | Involving: Tim",
+        "Tim started learning to play the piano and is making satisfying progress. | When: Since the last conversation | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 147,
+      "question": "What instrument is Tim learning to play in December 2023?",
+      "expected_answer": "violin",
+      "relevant_facts": [
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)",
+        "Tim recently started learning the violin, an instrument he always admired, finding it challenging but fun, and a way to chill and get creative. | Involving: Tim | He always admired musicians and finds it a great way to chill and get creative."
+      ]
+    },
+    {
+      "q_idx": 148,
+      "question": "How long has Tim been playing the piano for, as of December 2023?",
+      "expected_answer": "about four months",
+      "relevant_facts": [
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 149,
+      "question": "What book did Tim just finish reading on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 150,
+      "question": "Which book did Tim recommend to John as a good story on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim is currently reading an inspiring fantasy novel series that focuses on the themes of friendship and loyalty. | When: Currently, as of December 8, 2023 | Involving: Tim",
+        "Tim just finished reading \"A Dance with Dragons\" and highly recommends it. | Involving: Tim",
+        "John plans to check out the \"Game of Thrones\" series. | Involving: John",
+        "Tim recently attended a Harry Potter party where he met many like-minded people and had a lot of fun. | When: Recently, around December 7, 2023 | Involving: Tim",
+        "Tim has only read the \"Game of Thrones\" (GoT) series by George R. R. Martin. | Involving: Tim",
+        "Tim and John both share an interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim wore his Gryffindor scarf to the Harry Potter party and received a chocolate frog as a treat. | When: Around December 7, 2023 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 151,
+      "question": "What is the topic of discussion between John and Tim on 11 December, 2023?",
+      "expected_answer": "Academic achievements and sports successes",
+      "relevant_facts": [
+        "Tim asked John for tips on motivating others on his team. | Involving: Tim (user), John | Tim is looking for advice on team motivation.",
+        "John was elated about winning the trophy and appreciates Tim's support, stating he will keep working hard. | Involving: John, Tim",
+        "John is trying to figure out how to pick the right endorsements and asked Tim for advice. | Involving: John, Tim",
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023 | Involving: Tim (user)",
+        "Tim advised John to choose endorsements that align with his values and brand, partner with companies that share his desire to make a positive change, and ensure authenticity for his followers. | Involving: Tim, John | Provided in response to John's request for advice.",
+        "John's basketball team recently played a tough game against a top team and secured a win. | When: Lately, prior to December 8, 2023 | Involving: John (and his basketball team)",
+        "Tim is currently overwhelmed with assignments and exams but is trying to find a way to balance studying with his fantasy reading hobby. | When: This week | Involving: Tim",
+        "John's tips for motivating teammates include showing care, celebrating achievements, providing constructive feedback, reminding them of the bigger goal, creating a positive environment, and giving pep talks before a game. | Involving: John | In response to Tim's request for advice.",
+        "John's team won an intense basketball game by a tight score, with John scoring the last basket, which he found awesome. | When: Last week | Involving: John, John's team, crowd",
+        "Tim gave a presentation in class yesterday, feeling nervous but successfully completing it. | When: Yesterday | Involving: Tim",
+        "John and his teammates won a tough basketball game, which was an incredible experience with an electric atmosphere. | When: Last week | Involving: John, John's teammates | It was a tough win and an incredible experience.",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He was very excited about it.",
+        "Tim had a tough exam last week that caused him to doubt himself, but he turned it into a learning experience, studied hard, and demonstrated resilience and determination. | When: Last week | Involving: Tim (user) | It was a significant personal challenge and a moment of self-discovery regarding his resilience."
+      ]
+    },
+    {
+      "q_idx": 152,
+      "question": "What kind of game did John have a career-high in assists in?",
+      "expected_answer": "basketball",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Last Friday | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 153,
+      "question": "What was John's way of dealing with doubts and stress when he was younger?",
+      "expected_answer": "practicing basketball outside for hours",
+      "relevant_facts": [
+        "When John was younger, he practiced basketball outside for hours, dreaming of playing in big games. | When: When John was younger | Involving: John | It was his way of dealing with doubts and stress."
+      ]
+    },
+    {
+      "q_idx": 154,
+      "question": "How did John feel about the atmosphere during the big game against the rival team?",
+      "expected_answer": "electric and intense",
+      "relevant_facts": [
+        "John felt great making plays for his team, loves seeing his teammates succeed from the opportunities he creates, and found the arena atmosphere electric and intense due to playing rivals. | When: Last Friday | Involving: John, his teammates, rivals"
+      ]
+    },
+    {
+      "q_idx": 155,
+      "question": "How did John feel after being able to jog without pain?",
+      "expected_answer": "It was a huge success.",
+      "relevant_facts": [
+        "John and his wife hosted a small get-together with friends and family to celebrate John's jogging milestone. | When: Last Friday or Saturday | Involving: John, John's wife, friends, family | To celebrate John's milestone of jogging without pain.",
+        "John enjoyed seeing everyone and had a ton of fun at the get-together. | Involving: John, friends, family",
+        "John achieved a milestone at the gym by jogging a bit with no pain, which was a huge success and a relief after being out for so long. | When: Last Friday | Involving: John | It was a significant step in his recovery/fitness journey after being out for a long time."
+      ]
+    },
+    {
+      "q_idx": 156,
+      "question": "What kind of deal did John get in December?",
+      "expected_answer": "Deal with a renowned outdoor gear company",
+      "relevant_facts": [
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John | He was very excited about it."
+      ]
+    },
+    {
+      "q_idx": 157,
+      "question": "Where was the photoshoot done for John's gear deal?",
+      "expected_answer": "In a gorgeous forest",
+      "relevant_facts": [
+        "The photoshoot for John's outdoor gear endorsement deal went very well, taking place in a gorgeous forest where the photographer captured epic shots of him. | Involving: John, photographer"
+      ]
+    },
+    {
+      "q_idx": 158,
+      "question": "In which area has John's team seen the most growth during training?",
+      "expected_answer": "Communication and bonding",
+      "relevant_facts": [
+        "John's team has experienced significant growth in communication and bonding, which has improved their performances by allowing them to understand each other's strengths and weaknesses. | Involving: John's team"
+      ]
+    },
+    {
+      "q_idx": 159,
+      "question": "What type of seminars is John conducting?",
+      "expected_answer": "Sports and marketing seminars",
+      "relevant_facts": [
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing."
+      ]
+    },
+    {
+      "q_idx": 160,
+      "question": "What activity did Tim do after reading the stories about the Himalayan trek?",
+      "expected_answer": "visited a travel agency",
+      "relevant_facts": [
+        "Tim read a story about two hikers who trekked through the Himalayas. | Involving: Tim, two hikers",
+        "Tim visited a travel agency to inquire about the requirements for his next dream trip. | When: Recently | Involving: Tim | To plan his next dream trip, motivated by the story of the Himalayas trek.",
+        "The book described the Himalayas trek as tough but worth it, involving challenging terrain, altitude sickness, and bad weather, but the hikers saw amazing sights. This motivated Tim. | Involving: Tim, hikers | The amazing sights and overcoming challenges motivated Tim."
+      ]
+    },
+    {
+      "q_idx": 161,
+      "question": "What is one cause that John supports with his influence and resources?",
+      "expected_answer": "youth sports and fair chances in sports",
+      "relevant_facts": [
+        "John supports youth sports and advocates for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John | He believes every kid should have access to good sports programs and sees the positive difference sports make.",
+        "John is teaming up with a local organization that helps disadvantaged kids with sports and school, planning to use his platform to create a positive impact on the community and inspire others. | Involving: John, local organization | To have a positive impact on the community and inspire others.",
+        "John organized a week-long basketball camp for kids in his hometown last summer, which was an awesome experience that inspired the kids and fostered personal growth. | When: Last summer | Involving: John, kids | He wanted to inspire the kids and show them their potential."
+      ]
+    },
+    {
+      "q_idx": 162,
+      "question": "What new fantasy TV series is Tim excited about?",
+      "expected_answer": "\"The Wheel of Time\"",
+      "relevant_facts": [
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" coming out next month, which is based on a book series he loves. | When: next month | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 163,
+      "question": "Which language is Tim learning?",
+      "expected_answer": "German",
+      "relevant_facts": [
+        "Tim has been using a language learning app for German. | Involving: Tim",
+        "Tim is currently learning German, finding it tough but fun. | Involving: Tim",
+        "Tim finds learning German tough but worth it, likes its structure, and found it easier than French which he took in high school. | Involving: Tim",
+        "Tim plans to continue with his German lessons. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 164,
+      "question": "What language does Tim know besides German?",
+      "expected_answer": "Spanish",
+      "relevant_facts": [
+        "Tim finds learning German tough but worth it, likes its structure, and found it easier than French which he took in high school. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 165,
+      "question": "What book did Tim get in Italy that inspired him to cook?",
+      "expected_answer": "a cooking book",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 166,
+      "question": "What is John's favorite book series?",
+      "expected_answer": "Harry Potter",
+      "relevant_facts": [
+        "John is a fan of Harry Potter. | Involving: John",
+        "John loves the first Harry Potter movie and owns the entire Harry Potter collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 167,
+      "question": "According to John, who is his favorite character from Lord of the Rings?",
+      "expected_answer": "Aragorn",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, perseverance, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 168,
+      "question": "Why does John like Aragorn from Lord of the Rings?",
+      "expected_answer": "brave, selfless, down-to-earth attitude",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, bravery, down-to-earth attitude, perseverance, and commitment to justice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 169,
+      "question": "What kind of painting does John have in his room as a reminder?",
+      "expected_answer": "a painting of Aragorn",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room to remind him to stay true and be a leader in everything he does. | Involving: John | To remind him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 170,
+      "question": "What is the painting of Aragorn a reminder for John to be in everything he does?",
+      "expected_answer": "be a leader",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room to remind him to stay true and be a leader in everything he does. | Involving: John | To remind him to stay true and be a leader."
+      ]
+    },
+    {
+      "q_idx": 171,
+      "question": "What map does Tim show to his friend John?",
+      "expected_answer": "a map of Middle-earth from LOTR",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 172,
+      "question": "Where will Tim be going for a semester abroad?",
+      "expected_answer": "Ireland",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim plans to stay in Galway, Ireland, which is known for its arts, Irish music, and vibrant atmosphere. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim will depart for Ireland next month for a semester-long study abroad program. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 173,
+      "question": "Which city in Ireland will Tim be staying in during his semester abroad?",
+      "expected_answer": "Galway",
+      "relevant_facts": [
+        "Tim plans to stay in Galway, Ireland, which is known for its arts, Irish music, and vibrant atmosphere. | When: During his semester abroad (starting February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 174,
+      "question": "What charity event did John organize recently in 2024?",
+      "expected_answer": "benefit basketball game",
+      "relevant_facts": [
+        "John's benefit basketball game was a success, attracting many people and raising money for charity. | When: Last week (between January 1 and January 6, 2024) | Involving: John | To raise money for charity",
+        "John held a benefit basketball game. | When: Last week (between January 1 and January 6, 2024) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 175,
+      "question": "What achievement did John share with Tim in January 2024?",
+      "expected_answer": "endorsement with a popular beverage company",
+      "relevant_facts": [
+        "John plans to keep Tim updated on which brands he chooses for endorsement. | Involving: John, Tim",
+        "Tim advised John to choose endorsements that align with his values and brand, partner with companies that share his desire to make a positive change, and ensure authenticity for his followers. | Involving: Tim, John | Provided in response to John's request for advice.",
+        "John is trying to figure out how to pick the right endorsements and asked Tim for advice. | Involving: John, Tim",
+        "John secured an endorsement with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and incredible for him."
+      ]
+    },
+    {
+      "q_idx": 176,
+      "question": "What was Johns's reaction to sealing the deal with the beverage company?",
+      "expected_answer": "crazy feeling, sense of accomplishment",
+      "relevant_facts": [
+        "John felt a sense of accomplishment and that his hard work and training hours paid off after securing the endorsement deal. | Involving: John | It validated his efforts.",
+        "John secured an endorsement with a popular beverage company. | When: Last week | Involving: John | It's a dream come true and incredible for him."
+      ]
+    },
+    {
+      "q_idx": 177,
+      "question": "Which city did John recommend to Tim in January 2024?",
+      "expected_answer": "Barcelona",
+      "relevant_facts": [
+        "John recommended Barcelona to Tim as a must-visit city, citing its culture, architecture, food, and beaches. | Involving: John, Tim | John believes Tim would enjoy these aspects.",
+        "Tim asked John for travel recommendations. | Involving: Tim, John",
+        "Tim will add Barcelona to his travel list, having heard many great things about the city. | Involving: Tim | Based on John's recommendation and prior positive impressions."
+      ]
+    }
+  ],
+  "embedding_id": "cohere-embed-english-v3.0",
+  "bank_id": "emb_cohere-embed-english-v3-0_1772638161"
+}

--- a/benchmark-runner/datasets/locomo_embeddings_gt_text-embedding-3-small.json
+++ b/benchmark-runner/datasets/locomo_embeddings_gt_text-embedding-3-small.json
@@ -1,0 +1,1850 @@
+{
+  "annotations": [
+    {
+      "q_idx": 0,
+      "question": "what are John's goals with regards to his basketball career?",
+      "expected_answer": "improve shooting percentage, win a championship",
+      "relevant_facts": [
+        "John's primary goal in his basketball career is to win a championship. | Involving: John | This is John's number one professional aspiration.",
+        "John is focusing on improving his basketball skills, aiming for better shooting, more impact on the court, and consistent performance to help his team. Off the court, he is looking into more endorsements and building his brand, as he considers his life after basketball. | Involving: John | To be a consistent performer, help his team, and prepare for life after basketball.",
+        "John's goal is to improve his shooting percentage, and he is practicing hard to achieve it. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 1,
+      "question": "What are John's goals for his career that are not related to his basketball skills?",
+      "expected_answer": "get endorsements, build his brand, do charity work",
+      "relevant_facts": [
+        "John is focusing on improving his basketball skills, aiming for better shooting, more impact on the court, and consistent performance to help his team. Off the court, he is looking into more endorsements and building his brand, as he considers his life after basketball. | Involving: John | To be a consistent performer, help his team, and prepare for life after basketball.",
+        "John also aims to make a positive difference off the court through charity work or inspiring people, as a way to give back to the sport that has been good to him. | Involving: John | This reflects John's desire for social impact beyond his athletic career.",
+        "John uses his contacts in the basketball industry and his marketing skills for networking to secure endorsements. | Involving: John",
+        "John plans to initiate his charity work by collaborating with a local organization that supports disadvantaged children with sports and school, aiming to use his platform for community impact and inspiration. | Involving: John | This outlines the specific steps John intends to take to achieve his off-court goals.",
+        "John recently signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing.",
+        "John is exploring endorsement opportunities with brands, which he finds exciting and rewarding as his hard work is paying off. | Involving: John",
+        "John plans to use his platform after basketball to make a positive difference and inspire others, potentially by starting a foundation and engaging in charity work. | Involving: John | It is important for John to make the most of his opportunities and leave a meaningful legacy.",
+        "John is making progress with exploring endorsements and has talked to some promising big-name companies. | Involving: John",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John is improving his overall basketball game on the court, has secured endorsement deals, and is learning how to market himself and boost his brand. | Involving: John",
+        "John will keep Tim updated on which brands he chooses for endorsement. | Involving: John, Tim",
+        "John felt crazy and accomplished after sealing the endorsement deal, believing his hard work and training hours had paid off. | Involving: John | It validated his efforts and hard work.",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John is currently in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John's seminars went really well, and the aspiring professionals who attended were eager and motivated, making him happy to share his knowledge. | When: Recently | Involving: John, aspiring professionals",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John",
+        "John likes Under Armour and would find it cool to work with them. | Involving: John",
+        "John believes in making a difference and uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John",
+        "John received an endorsement with a popular beverage company. | When: Last week (approx. January 5, 2024) | Involving: John | It was a dream come true and a significant achievement.",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "Tim advised John to choose endorsements that align with his values and brand, to seek companies that share his desire to make a change and help others, and to ensure the endorsement feels authentic to his followers. | Involving: Tim, John | To help John select suitable endorsements.",
+        "John asked Tim for advice on how to pick the right endorsements. | Involving: John, Tim | John is trying to figure out how to choose endorsements effectively.",
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book. | Involving: John, Anthony",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John previously attended a Harry Potter trivia charity event in August and had a fun time. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 2,
+      "question": "What items does John collect?",
+      "expected_answer": "sneakers, fantasy movie DVDs, jerseys",
+      "relevant_facts": [
+        "John likes to collect basketball jerseys. | Involving: John",
+        "John loves talking to people about his sneaker collection. | Involving: John",
+        "John loves \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter movie collection. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 3,
+      "question": "Would Tim enjoy reading books by C. S. Lewis or John Greene?",
+      "expected_answer": "C. S.Lewis",
+      "relevant_facts": [
+        "John shares Tim's enjoyment of getting lost in another world through fantasy stories and finds exploring different lands and regions fun. He specifically loves the map of Middle-earth from Lord of the Rings for its ability to immerse him. | Involving: John, Tim | He enjoys the immersive experience of exploring different worlds and cultures.",
+        "Tim and John share an interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim recommended a book by Patrick Rothfuss to John, praising its world-building and characters as amazing. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim loves going on road trips with friends and family, exploring, hiking, or playing board games. In his free time, he enjoys curling up with a good book to escape reality and get lost in different worlds. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim (user)",
+        "John knows that Tim finds peace in reading fantasy books. | Involving: John, Tim",
+        "Tim loves escaping to the world of books and has a collection of books that allow him to do so. | Involving: Tim",
+        "Tim recommended 'The Name of the Wind', a fantasy novel by Patrick Rothfuss, as a good book for John to read while traveling. | Involving: Tim, John, Patrick Rothfuss | To provide John with a book recommendation for his trip.",
+        "Tim enjoys fantasy novels because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim loves to get lost in good books in his downtime. | Involving: Tim (user)",
+        "Tim particularly loves writing about Harry Potter and Game of Thrones, as he is very hooked on them. | Involving: Tim",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim (user)",
+        "Tim enjoys getting lost in fantasy stories and also discovering new ways to better himself through books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim enjoys fantasy books, specifically Lord of the Rings, because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim | He appreciates the immersive experience and the ability to explore different worlds and cultures.",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim has never been on a sports team; he prefers reading fantasy novels and traveling to new places to experience different kinds of 'magic'. | Involving: Tim",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and allowing his imagination to soar. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | When: Recently | Involving: Tim",
+        "Tim does not surf but finds escape and freedom by reading great fantasy books, especially in a comfy spot. | Involving: Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim, George R. R. Martin",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim",
+        "Tim is currently reading an inspiring fantasy novel series about the power of friendship and loyalty. | When: Currently (as of December 8, 2023) | Involving: Tim",
+        "Tim reads a lot of fantasy books as a way to take a break from stress. | Involving: Tim",
+        "The new TV series \"The Wheel of Time\" is based on a book series that Tim loves. | Involving: Tim (user)",
+        "Tim is writing articles about fantasy novels for an online magazine, which he finds very rewarding. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is going well and he finds it exciting and joyful, though a bit nerve-wracking. He believes his hard work is paying off. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones because they transport him to other places. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling that transports readers. Tim studies her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him due to a special quality in her writing. | Involving: Tim, J.K. Rowling",
+        "Tim recently reorganized his bookshelf and shared a photo of it, which contains some of his favorite books including Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, world-building, and character development. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim",
+        "Tim loves getting lost in fantasy realms and finds them to be an escape. | Involving: Tim",
+        "Tim loves fantasy books because they provide a break from reality and an awesome, magical adventure, transporting readers to different worlds. | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on studying characters, themes, and making book recommendations. | Involving: Tim",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim uses his Harry Potter-related items as reminders, which serve as a way for him to escape reality. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds. | Involving: Tim (user)",
+        "Tim is currently overwhelmed by assignments and exams and is trying to find a way to juggle studying with his fantasy reading hobby. | When: This week (around August 21-27, 2023) | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum and secured it by sharing his ideas, which the magazine liked. | Involving: Tim",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, and he loves their work, considering it a piece of the wizarding world at home. | Involving: Tim, MinaLima",
+        "Tim recently attended a Harry Potter party where he met many like-minded people and had a lot of fun. He wore his Gryffindor scarf and received a chocolate frog as a treat. | When: Recently, around December 8, 2023 | Involving: Tim, people at the party",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" which is coming out next month. | When: Next month | Involving: Tim (user)",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and feeling inspired, which gave him a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim had a nice and magical chat with a Harry Potter fan. | When: Last week (prior to July 16, 2023) | Involving: Tim, Harry Potter fan",
+        "Tim is planning his first trip to Universal Studios next month and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 4,
+      "question": "What books has Tim read?",
+      "expected_answer": "Harry Potter, Game of Thrones, the Name of the Wind, The Alchemist, The Hobbit, A Dance with Dragons, and the Wheel of Time.",
+      "relevant_facts": [
+        "John plans to add \"The Name of the Wind\" to his reading list based on Tim's recommendation. | Involving: John, Tim | Tim recommended the book.",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim (user)",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones because they transport him to other places. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss to John, praising its world-building and characters as amazing. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: a while back | Involving: Tim | The book had a significant impact on his perspective regarding his goals.",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim (user)",
+        "Tim particularly loves writing about Harry Potter and Game of Thrones, as he is very hooked on them. | Involving: Tim",
+        "Tim recommended 'The Name of the Wind', a fantasy novel by Patrick Rothfuss, as a good book for John to read while traveling. | Involving: Tim, John, Patrick Rothfuss | To provide John with a book recommendation for his trip.",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "The new TV series \"The Wheel of Time\" is based on a book series that Tim loves. | Involving: Tim (user)",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him due to a special quality in her writing. | Involving: Tim, J.K. Rowling",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling that transports readers. Tim studies her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim, George R. R. Martin",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | When: Recently | Involving: Tim",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, world-building, and character development. | Involving: Tim",
+        "Tim recently reorganized his bookshelf and shared a photo of it, which contains some of his favorite books including Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 5,
+      "question": "Based on Tim's collections, what is a shop that he would enjoy visiting in New York city?",
+      "expected_answer": "House of MinaLima",
+      "relevant_facts": [
+        "Tim wants to visit New York City. | Involving: Tim",
+        "Tim is adding New York City to his travel list and is looking forward to visiting it. | Involving: Tim",
+        "Tim recently reorganized his bookshelf and shared a photo of it, which contains some of his favorite books including Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim wants to explore more real Harry Potter places someday. | When: Future | Involving: Tim",
+        "Tim plans to visit more Harry Potter spots in the future, which makes him feel like he's stepping into the books. | Involving: Tim",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim uses his Harry Potter-related items as reminders, which serve as a way for him to escape reality. | Involving: Tim",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim (user)",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, and he loves their work, considering it a piece of the wizarding world at home. | Involving: Tim, MinaLima",
+        "Tim is planning his first trip to Universal Studios next month and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 6,
+      "question": "In which month's game did John achieve a career-high score in points?",
+      "expected_answer": "June 2023",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 7,
+      "question": "Which geographical locations has Tim been to?",
+      "expected_answer": "California, London, the Smoky Mountains",
+      "relevant_facts": [
+        "Tim skyped with a Harry Potter fan he met in California, discussing characters and potential collaboration. | Involving: Tim, Harry Potter fan (Tim met in CA) | Tim enjoyed talking to someone who understands his interest.",
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "Tim took a stunning picture on a trip to the Smoky Mountains in Summer 2022. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 8,
+      "question": "Which outdoor gear company likely signed up John for an endorsement deal?",
+      "expected_answer": "Under Armour",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John likes Under Armour and would find it cool to work with them. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 9,
+      "question": "Which endorsement deals has John been offered?",
+      "expected_answer": "basketball shoes and gear deal with Nike, potential sponsorship with Gatorade, Moxie a popular beverage company, outdoor gear company",
+      "relevant_facts": [
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John recently signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is currently in talks with Gatorade for a potential sponsorship. | Involving: John",
+        "John received an endorsement with a popular beverage company. | When: Last week (approx. January 5, 2024) | Involving: John | It was a dream come true and a significant achievement."
+      ]
+    },
+    {
+      "q_idx": 10,
+      "question": "When was John in Seattle for a game?",
+      "expected_answer": "early August, 2023",
+      "relevant_facts": [
+        "John has a game scheduled in Seattle next month. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 11,
+      "question": "What sports does John like besides basketball?",
+      "expected_answer": "surfing",
+      "relevant_facts": [
+        "John had an awesome summer surfing and riding waves with his friends, which he described as an unreal feeling. He started surfing five years ago and loves the connection to nature it provides. | When: Started five years ago (around 2018) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 12,
+      "question": "What year did John start surfing?",
+      "expected_answer": "2018",
+      "relevant_facts": [
+        "John had an awesome summer surfing and riding waves with his friends, which he described as an unreal feeling. He started surfing five years ago and loves the connection to nature it provides. | When: Started five years ago (around 2018) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 13,
+      "question": "What does Tim do to escape reality?",
+      "expected_answer": "Read fantasy books.",
+      "relevant_facts": [
+        "John knows that Tim finds peace in reading fantasy books. | Involving: John, Tim",
+        "Tim enjoys fantasy novels because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim loves going on road trips with friends and family, exploring, hiking, or playing board games. In his free time, he enjoys curling up with a good book to escape reality and get lost in different worlds. | Involving: Tim, Tim's friends, Tim's family",
+        "Tim loves getting lost in fantasy realms and finds them to be an escape. | Involving: Tim",
+        "Tim loves escaping to the world of books and has a collection of books that allow him to do so. | Involving: Tim",
+        "Tim does not surf but finds escape and freedom by reading great fantasy books, especially in a comfy spot. | Involving: Tim",
+        "Tim loves fantasy books because they provide a break from reality and an awesome, magical adventure, transporting readers to different worlds. | Involving: Tim",
+        "Tim loves to get lost in good books in his downtime. | Involving: Tim (user)",
+        "Tim enjoys fantasy books, specifically Lord of the Rings, because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim | He appreciates the immersive experience and the ability to explore different worlds and cultures.",
+        "Tim enjoys getting lost in fantasy stories and also discovering new ways to better himself through books on growth, psychology, and self-improvement. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones because they transport him to other places. | Involving: Tim",
+        "John shares Tim's enjoyment of getting lost in another world through fantasy stories and finds exploring different lands and regions fun. He specifically loves the map of Middle-earth from Lord of the Rings for its ability to immerse him. | Involving: John, Tim | He enjoys the immersive experience of exploring different worlds and cultures.",
+        "Tim is currently reading a captivating fantasy book that transports him to another world, keeping him on the edge of his seat and allowing his imagination to soar. | Involving: Tim",
+        "Tim reads a lot of fantasy books as a way to take a break from stress. | Involving: Tim",
+        "Tim has never been on a sports team; he prefers reading fantasy novels and traveling to new places to experience different kinds of 'magic'. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 14,
+      "question": "What kind of writing does Tim do?",
+      "expected_answer": "comments on favorite books in a fantasy literature forum, articles on fantasy novels, studying characters, themes, and making book recommendations, writing a fantasy novel",
+      "relevant_facts": [
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing stories. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine, which he finds very rewarding. | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum and secured it by sharing his ideas, which the magazine liked. | Involving: Tim",
+        "Tim particularly loves writing about Harry Potter and Game of Thrones, as he is very hooked on them. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is going well and he finds it exciting and joyful, though a bit nerve-wracking. He believes his hard work is paying off. | Involving: Tim",
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim",
+        "John plans to add \"The Name of the Wind\" to his reading list based on Tim's recommendation. | Involving: John, Tim | Tim recommended the book.",
+        "Tim had a setback last week when he tried writing a story based on his experiences in the UK, but it didn't go as he wanted. | When: Last week | Involving: Tim",
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on studying characters, themes, and making book recommendations. | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, world-building, and character development. | Involving: Tim",
+        "John plans to check out and read the book recommended by Tim. | Involving: John, Tim",
+        "Tim experienced a significant and frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | When: Recently | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss to John, praising its world-building and characters as amazing. | Involving: Tim, John, Patrick Rothfuss",
+        "Tim recommended 'The Name of the Wind', a fantasy novel by Patrick Rothfuss, as a good book for John to read while traveling. | Involving: Tim, John, Patrick Rothfuss | To provide John with a book recommendation for his trip.",
+        "John asked Tim for book recommendations for his upcoming trip. | Involving: John, Tim | John is planning a trip and wants reading material."
+      ]
+    },
+    {
+      "q_idx": 15,
+      "question": "Who is Anthony?",
+      "expected_answer": "likely John's friend, colleague or family",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book. | Involving: John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 16,
+      "question": "After how many weeks did Tim reconnect with the fellow Harry Potter fan from California?",
+      "expected_answer": "three weeks",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 17,
+      "question": "How many games has John mentioned winning?",
+      "expected_answer": "6",
+      "relevant_facts": [
+        "John's favorite game in his career was when he hit a buzzer-beater shot to win after his team was down by 10 points in the 4th quarter. | Involving: John | It was a thrilling experience with an incredible atmosphere.",
+        "John's basketball team recently played a tough top team and secured a win. | When: Recently | Involving: John, John's basketball team",
+        "John's team won a trophy, which made all their hard work and effort feel worthwhile. | Involving: John (and his team)",
+        "John's team won an intense basketball game by a tight score, with John scoring the last basket. | When: Last week (relative to August 9, 2023) | Involving: John, John's team",
+        "John and his teammates pulled off a tough win in a basketball game, which was an incredible experience with an electric atmosphere. | When: Last week (prior to July 16, 2023) | Involving: John, John's teammates",
+        "Last year, John's basketball team was trailing significantly in the 4th quarter of a game but managed to overcome the deficit and win, which was an amazing and unforgettable feeling. | When: Last year | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 18,
+      "question": "What authors has Tim read books from?",
+      "expected_answer": "J.K. Rowling, R.R. Martin, Patrick Rothfuss, Paulo Coelho, and J. R. R. Tolkien.",
+      "relevant_facts": [
+        "Tim enjoys fantasy books, specifically Lord of the Rings, because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim | He appreciates the immersive experience and the ability to explore different worlds and cultures.",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim (user)",
+        "Tim recently reorganized his bookshelf and shared a photo of it, which contains some of his favorite books including Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim recommended a book by Patrick Rothfuss to John, praising its world-building and characters as amazing. | Involving: Tim, John, Patrick Rothfuss",
+        "The Harry Potter series is one of Tim's favorite book series. | Involving: Tim (user)",
+        "Tim read \"The Alchemist\" a while back, and it changed his perspective on his goals. | When: a while back | Involving: Tim | The book had a significant impact on his perspective regarding his goals.",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling that transports readers. Tim studies her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim recommended 'The Name of the Wind', a fantasy novel by Patrick Rothfuss, as a good book for John to read while traveling. | Involving: Tim, John, Patrick Rothfuss | To provide John with a book recommendation for his trip.",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him due to a special quality in her writing. | Involving: Tim, J.K. Rowling",
+        "Tim is currently reading and enjoying the fantasy novel \"The Name of the Wind\" by Patrick Rothfuss. | Involving: Tim",
+        "Tim has only read the Game of Thrones (GoT) series by George R. R. Martin. | Involving: Tim, George R. R. Martin",
+        "Tim considers \"The Alchemist\" to be one of his favorite books. | Involving: Tim",
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | When: Recently | Involving: Tim",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, world-building, and character development. | Involving: Tim",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim's favorite fantasy books are Harry Potter and Game of Thrones because they transport him to other places. | Involving: Tim",
+        "Tim is also a fan of Lord of the Rings. | Involving: Tim",
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 19,
+      "question": "What is a prominent charity organization that John might want to work with and why?",
+      "expected_answer": "Good Sports, because they work with Nike, Gatorade, and Under Armour and they aim toprovide youth sports opportunities for kids ages 3-18 in high-need communities.",
+      "relevant_facts": [
+        "John plans to initiate his charity work by collaborating with a local organization that supports disadvantaged children with sports and school, aiming to use his platform for community impact and inspiration. | Involving: John | This outlines the specific steps John intends to take to achieve his off-court goals.",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John",
+        "John likes Under Armour and would find it cool to work with them. | Involving: John",
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids",
+        "John is considering sports brands such as Nike and Under Armour for endorsement opportunities, but is also open to exploring other brands that align with his values and interests. | Involving: John",
+        "John recently signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, and stay involved in the game during the off-season. | Involving: John, younger players (on his team) | To share skills, stay involved in the game, and for personal reward.",
+        "John is currently in talks with Gatorade for a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 20,
+      "question": "Which city was John in before traveling to Chicago?",
+      "expected_answer": "Seattle",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 21,
+      "question": "Which US cities does John mention visiting to Tim?",
+      "expected_answer": "Seattle, Chicago, New York",
+      "relevant_facts": [
+        "John loves discovering new cities and has visited New York City. | Involving: John",
+        "John loves Seattle's energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John had an amazing experience in New York City, finding it new and exciting, enjoying exploring and trying restaurants, and considers it a must-visit. | Involving: John",
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John",
+        "John had a trip to NYC where he initially struggled with the subway system but found it easy after someone helped him. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 22,
+      "question": "When did John meet with his teammates after returning from Chicago?",
+      "expected_answer": "August 15, 2023",
+      "relevant_facts": [
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John",
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, serving as a reminder of their bond.",
+        "John reunited with his teammates on August 15th after a trip, feeling very welcome and appreciating the electric atmosphere and team bond. | When: August 15, 2023 | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 23,
+      "question": "When is Tim attending a book conference?",
+      "expected_answer": "September 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: Next month (September 2023) | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 24,
+      "question": "Where was John between August 11 and August 15 2023?",
+      "expected_answer": "Chicago",
+      "relevant_facts": [
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 25,
+      "question": "What similar sports collectible do Tim and John own?",
+      "expected_answer": "signed basketball",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It reminds him of hard work.",
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, serving as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 26,
+      "question": "Which TV series does Tim mention watching?",
+      "expected_answer": "That, Wheel of Time",
+      "relevant_facts": [
+        "The new TV series \"The Wheel of Time\" is based on a book series that Tim loves. | Involving: Tim (user)",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" which is coming out next month. | When: Next month | Involving: Tim (user)",
+        "Tim's favorite fantasy show is \"That\". | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 27,
+      "question": "Which popular time management technique does Tim use to prepare for exams?",
+      "expected_answer": "Pomodoro technique",
+      "relevant_facts": [
+        "Tim breaks up his studying into 25-minute sessions followed by 5-minute breaks for fun, which he finds less overwhelming and helps him stay on track. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 28,
+      "question": "Which popular music composer's tunes does Tim enjoy playing on the piano?",
+      "expected_answer": "John Williams",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim",
+        "Tim started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "Tim is learning to play the violin, is mostly into classical music, and is keen to try out jazz and film scores, finding it a great way to chill and get creative. | Involving: Tim",
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023. | Involving: Tim (user)",
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie in the series and brings back great memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 29,
+      "question": "What schools did John play basketball in and how many years was he with his team during high school?",
+      "expected_answer": "Middle school, high school, and college and he was with his high school team for 4 years.",
+      "relevant_facts": [
+        "John continued playing basketball through middle and high school, earning a college scholarship, and was later drafted by a team after college, fulfilling his childhood dream. | When: Through middle and high school, and after college | Involving: John | These are major achievements in John's basketball career, culminating in his dream of playing professionally.",
+        "John and his friends were teammates in high school for four years. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 30,
+      "question": "Which cities has John been to?",
+      "expected_answer": "Seattle, Chicago, New York, and Paris.",
+      "relevant_facts": [
+        "John loves discovering new cities and has visited New York City. | Involving: John",
+        "John had an amazing experience in New York City, finding it new and exciting, enjoying exploring and trying restaurants, and considers it a must-visit. | Involving: John",
+        "Seattle is one of John's favorite cities to explore, and he finds it super vibrant. | Involving: John",
+        "John had a trip to NYC where he initially struggled with the subway system but found it easy after someone helped him. | Involving: John",
+        "John has been to Paris and loved it, finding the view from there incredible. | Involving: John",
+        "John's recent trip was to Chicago, where he experienced awesome energy and friendly locals. | Involving: John",
+        "John loves Seattle's energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 31,
+      "question": "What month did Tim plan on going to Universal Studios?",
+      "expected_answer": "September, 2023",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: Next month (September 2023) | Involving: Tim | To learn more about literature and create a stronger bond to it.",
+        "Tim is planning his first trip to Universal Studios next month and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 32,
+      "question": "Which US states might Tim be in during September 2023 based on his plans of visiting Universal Studios?",
+      "expected_answer": "California or Florida",
+      "relevant_facts": [
+        "Tim is planning his first trip to Universal Studios next month and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 33,
+      "question": "When does John plan on traveling with his team on a team trip?",
+      "expected_answer": "October, 2023",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip to explore a new city. | When: next month | Involving: John, John's teammates | To have some fun."
+      ]
+    },
+    {
+      "q_idx": 34,
+      "question": "What could John do after his basketball career?",
+      "expected_answer": "become a basketball coach since he likes giving back and leadership",
+      "relevant_facts": [
+        "John also aims to make a positive difference off the court through charity work or inspiring people, as a way to give back to the sport that has been good to him. | Involving: John | This reflects John's desire for social impact beyond his athletic career.",
+        "John plans to use his platform after basketball to make a positive difference and inspire others, potentially by starting a foundation and engaging in charity work. | Involving: John | It is important for John to make the most of his opportunities and leave a meaningful legacy.",
+        "John plans to initiate his charity work by collaborating with a local organization that supports disadvantaged children with sports and school, aiming to use his platform for community impact and inspiration. | Involving: John | This outlines the specific steps John intends to take to achieve his off-court goals.",
+        "John finds it fulfilling to see the players' growth, improvement, and confidence, believing he makes a positive impact on their lives. Some players see him as a mentor, and he enjoys being a positive role model by providing advice and support on and off the court. He feels great having their trust and admiration, hoping his experiences inspire them. | Involving: John, younger players",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing.",
+        "John believes in making a difference and uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, and stay involved in the game during the off-season. | Involving: John, younger players (on his team) | To share skills, stay involved in the game, and for personal reward.",
+        "John's seminars went really well, and the aspiring professionals who attended were eager and motivated, making him happy to share his knowledge. | When: Recently | Involving: John, aspiring professionals",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John",
+        "John faces challenges mentoring due to individual differences but enjoys gaining experience in adapting, motivating, and encouraging. He finds it rewarding to watch players develop and reach their goals. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids",
+        "John advised that motivating others involves showing care, celebrating achievements, providing constructive feedback, reminding them of goals, creating a positive environment, and giving pep talks before a game. | When: Wednesday, December 6, 2023 | Involving: John, Tim (user) | In response to Tim's request for advice."
+      ]
+    },
+    {
+      "q_idx": 35,
+      "question": "What outdoor activities does John enjoy?",
+      "expected_answer": "Hiking, surfing",
+      "relevant_facts": [
+        "John had an awesome summer surfing and riding waves with his friends, which he described as an unreal feeling. He started surfing five years ago and loves the connection to nature it provides. | When: Started five years ago (around 2018) | Involving: John, John's friends",
+        "John received top-notch hiking and outdoor gear as part of his endorsement deal. | Involving: John",
+        "John went camping in the mountains, found the experience stunning with refreshing air, and loved chilling and taking in nature's beauty, which he found peaceful and refreshing. | Involving: John",
+        "John found a peaceful spot while hiking, characterized by a soothing river sound and surrounding rocks, which made him feel at peace. | Involving: John",
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John",
+        "John experienced immense love and happiness on his wedding day, and some friends from his hiking club attended, despite him having recently joined the club. | When: Last week (wedding day) | Involving: John, John's hiking club friends",
+        "John took a stunning trip to the Rocky Mountains last year, appreciating the fresh air. He believes nature is great for clearing the mind, calming the soul, and makes one realize how incredible the world is, also humbling and comforting. | When: 2022 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 36,
+      "question": "Who is Tim and John's favorite basketball player?",
+      "expected_answer": "LeBron James",
+      "relevant_facts": [
+        "John's favorite basketball team is \"The Wolves\" and his favorite player is LeBron, whose skills and leadership he admires. | Involving: John, LeBron",
+        "Tim's favorite basketball player is LeBron James, and he was inspired by LeBron's epic block in Game 7 of the 2016 Finals, which changed the game and led to a win, reinforcing the \"never give up\" mentality. | When: 2016 Finals, Game 7 (June 19, 2016) | Involving: Tim, LeBron James | It was an inspiration to never give up."
+      ]
+    },
+    {
+      "q_idx": 37,
+      "question": "Which week did Tim visit the UK for the Harry Potter Conference?",
+      "expected_answer": "The week before October 13th, 2023.",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and feeling inspired, which gave him a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 38,
+      "question": "which country has Tim visited most frequently in his travels?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and feeling inspired, which gave him a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim had a setback last week when he tried writing a story based on his experiences in the UK, but it didn't go as he wanted. | When: Last week | Involving: Tim",
+        "Tim took a stunning picture on a trip to the Smoky Mountains in Summer 2022. | When: Summer 2022 | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 39,
+      "question": "What year did Tim go to the Smoky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "Tim took a stunning picture on a trip to the Smoky Mountains in Summer 2022. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 40,
+      "question": "Has Tim been to North Carolina and/or Tennesee states in the US?",
+      "expected_answer": "Yes",
+      "relevant_facts": [
+        "Tim took a stunning picture on a trip to the Smoky Mountains in Summer 2022. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 41,
+      "question": "What kind of fiction stories does Tim write?",
+      "expected_answer": "Fantasy stories with plot twists",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which is going well and he finds it exciting and joyful, though a bit nerve-wracking. He believes his hard work is paying off. | Involving: Tim",
+        "Tim experienced a significant and frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 42,
+      "question": "What has John cooked?",
+      "expected_answer": "Soup, a slow cooker meal, and honey garlic chicken with roasted veg.",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty, improvised soup using sage. | Involving: John",
+        "John's favorite recipe is honey garlic chicken with roasted vegetables, which he makes frequently. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 43,
+      "question": "What does John like about Lebron James?",
+      "expected_answer": "His heart, determination, skills, and leadership.",
+      "relevant_facts": [
+        "John's favorite basketball team is \"The Wolves\" and his favorite player is LeBron, whose skills and leadership he admires. | Involving: John, LeBron",
+        "John admires LeBron's work ethic and dedication to the game, finding him an inspiration. | Involving: John, LeBron",
+        "John loves basketball due to the determination and heart exemplified by moments like LeBron James' epic block in Game 7 of the 2016 Finals, where he chased down Iguodala and pinned the ball against the backboard. | When: 2016 Finals, Game 7 (June 19, 2016) | Involving: John, LeBron James, Iguodala | It exemplifies determination and heart, which is why John loves basketball.",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 44,
+      "question": "When did John and his wife go on a European vacation?",
+      "expected_answer": "November, 2023.",
+      "relevant_facts": [
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 45,
+      "question": "Which country was Tim visiting in the second week of November?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and feeling inspired, which gave him a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 46,
+      "question": "Where was Tim in the week before 16 November 2023?",
+      "expected_answer": "UK",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and feeling inspired, which gave him a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim",
+        "Tim visited a castle in the UK last Friday and found its architecture and history amazing. | When: Last Friday | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 47,
+      "question": "When did John get married at a greenhouse?",
+      "expected_answer": "last week of September 2023",
+      "relevant_facts": [
+        "John and his girlfriend held their wedding ceremony at a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week | Involving: John, John's girlfriend | To ensure safety and intimacy during the ceremony."
+      ]
+    },
+    {
+      "q_idx": 48,
+      "question": "When did John get an ankle injury in 2023?",
+      "expected_answer": "around November 16, 2023",
+      "relevant_facts": [
+        "John achieved a milestone at the gym by jogging without any pain, which was a huge relief and success after being unable to do so for a long time. | When: Last Friday (December 15, 2023) | Involving: John | It marked a significant personal achievement in his recovery/fitness journey.",
+        "John and his wife just left for a short European vacation. | When: Monday, November 06, 2023 | Involving: John, John's wife",
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Friday, December 8, 2023 | Involving: John",
+        "John felt great making plays for his team, loves seeing teammates succeed due to his opportunities, and found the arena atmosphere electric and the game against rivals intense, making it a memorable night. | When: Friday, December 8, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 49,
+      "question": "How many times has John injured his ankle?",
+      "expected_answer": "two times",
+      "relevant_facts": [
+        "John and his wife hosted a small get-together with friends and family to celebrate John's milestone of jogging without pain. They had a ton of fun and enjoyed seeing everyone again. | When: After last Friday's milestone | Involving: John, John's wife, friends, family | To celebrate John's significant achievement in his fitness journey.",
+        "John found it frustrating not being able to play or help his team due to his ankle injury, but he focused on recovery and strengthening his body, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "Last season, John hurt his ankle, which required some time off and physical therapy. | When: Last season | Involving: John",
+        "John achieved a milestone at the gym by jogging without any pain, which was a huge relief and success after being unable to do so for a long time. | When: Last Friday (December 15, 2023) | Involving: John | It marked a significant personal achievement in his recovery/fitness journey."
+      ]
+    },
+    {
+      "q_idx": 50,
+      "question": "Which book was John reading during his recovery from an ankle injury?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John found it frustrating not being able to play or help his team due to his ankle injury, but he focused on recovery and strengthening his body, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John injured himself recently, which caused him to miss basketball games and be unable to help his team. | When: Not too long ago | Involving: John, John's team",
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow dreams and search for personal legends, leaving him feeling motivated and hopeful. | When: recently | Involving: John | The book inspired him to pursue his dreams and personal legends.",
+        "Last season, John hurt his ankle, which required some time off and physical therapy. | When: Last season | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 51,
+      "question": "What kind of yoga for building core strength might John benefit from?",
+      "expected_answer": "Hatha Yoga",
+      "relevant_facts": [
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps build strength and stability and works out legs and core. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to his yoga practice. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 52,
+      "question": "What does John do to supplement his basketball training?",
+      "expected_answer": "Yoga, strength training",
+      "relevant_facts": [
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism for basketball. | Involving: John | These are the direct benefits for his basketball performance.",
+        "John created a workout schedule that balances basketball activities and strength training. | Involving: John | To effectively train for professional basketball and stay on track.",
+        "John had to adapt and tweak his routine at the new gym, finding the right balance was tricky but he eventually got the hang of it. | Involving: John | To effectively train and balance his basketball and strength training.",
+        "Strength training has significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, leading to increased confidence and an upper hand over opponents. | Involving: John | These are the observed positive impacts of strength training on his game.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps build strength and stability and works out legs and core. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to his yoga practice. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 53,
+      "question": "What other exercises can help John with his basketball performance?",
+      "expected_answer": "Sprinting, long-distance running, and boxing.",
+      "relevant_facts": [
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism for basketball. | Involving: John | These are the direct benefits for his basketball performance.",
+        "Strength training has significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, leading to increased confidence and an upper hand over opponents. | Involving: John | These are the observed positive impacts of strength training on his game.",
+        "John created a workout schedule that balances basketball activities and strength training. | Involving: John | To effectively train for professional basketball and stay on track.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "John had an awesome summer surfing and riding waves with his friends, which he described as an unreal feeling. He started surfing five years ago and loves the connection to nature it provides. | When: Started five years ago (around 2018) | Involving: John, John's friends",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps build strength and stability and works out legs and core. | Involving: John",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to his yoga practice. | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John achieved a milestone at the gym by jogging without any pain, which was a huge relief and success after being unable to do so for a long time. | When: Last Friday (December 15, 2023) | Involving: John | It marked a significant personal achievement in his recovery/fitness journey.",
+        "John found a peaceful spot while hiking, characterized by a soothing river sound and surrounding rocks, which made him feel at peace. | Involving: John",
+        "John went camping in the mountains, found the experience stunning with refreshing air, and loved chilling and taking in nature's beauty, which he found peaceful and refreshing. | Involving: John",
+        "John took a stunning trip to the Rocky Mountains last year, appreciating the fresh air. He believes nature is great for clearing the mind, calming the soul, and makes one realize how incredible the world is, also humbling and comforting. | When: 2022 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 54,
+      "question": "When did John take a trip to the Rocky Mountains?",
+      "expected_answer": "2022",
+      "relevant_facts": [
+        "John took a stunning trip to the Rocky Mountains last year, appreciating the fresh air. He believes nature is great for clearing the mind, calming the soul, and makes one realize how incredible the world is, also humbling and comforting. | When: 2022 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 55,
+      "question": "When did John start playing professionally?",
+      "expected_answer": "May, 2023",
+      "relevant_facts": [
+        "John has been playing professional basketball for just under a year. | Involving: John",
+        "John signed with the Minnesota Wolves. | When: Recently | Involving: John",
+        "John signed with a new team. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 56,
+      "question": "When did Tim start playing the violin?",
+      "expected_answer": "August 2023",
+      "relevant_facts": [
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 57,
+      "question": "What instruments does Tim play?",
+      "expected_answer": "piano, violin",
+      "relevant_facts": [
+        "Tim is learning to play the violin, is mostly into classical music, and is keen to try out jazz and film scores, finding it a great way to chill and get creative. | Involving: Tim",
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim",
+        "Tim started learning to play the piano and finds the progress satisfying. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 58,
+      "question": "When did John attend the Harry Potter trivia?",
+      "expected_answer": "August 2023.",
+      "relevant_facts": [
+        "John previously attended a Harry Potter trivia charity event in August and had a fun time. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 59,
+      "question": "Which career-high performances did John achieve in 2023?",
+      "expected_answer": "highest point score, highest assist",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Friday, December 8, 2023 | Involving: John",
+        "John scored 40 points in a basketball game, which was his highest score ever, indicating his hard work is paying off. | When: Last week (prior to July 16, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 60,
+      "question": "When did John achieve a career-high assist performance?",
+      "expected_answer": "December 11, 2023",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Friday, December 8, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 61,
+      "question": "What books has John read?",
+      "expected_answer": "inpsiring book on dreaming big, The Alchemist, fantasy series, non-fiction books on personal development, Dune",
+      "relevant_facts": [
+        "John thinks Tim's bookshelf is awesome, and The Hobbit is one of John's favorite books. John has also read another popular fantasy series which is one of his favorites. | Involving: John, Tim",
+        "John is currently reading an inspiring book that reminds him to keep dreaming. | Involving: John",
+        "The book \"The Alchemist\" made John think about life and the importance of following one's dreams. | Involving: John",
+        "John enjoys reading non-fiction books about personal development and mindset, as they help him know himself better. | Involving: John",
+        "John read and loved the book \"The Alchemist\". | Involving: John",
+        "John highly recommends \"The Alchemist\". | Involving: John",
+        "John is currently reading \"Dune\" by Frank Herbert, which he enjoys and highly recommends as a great story about religion and human control over ecology. | When: Currently | Involving: John, Frank Herbert",
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow dreams and search for personal legends, leaving him feeling motivated and hopeful. | When: recently | Involving: John | The book inspired him to pursue his dreams and personal legends.",
+        "John recently finished an amazing fantasy series that had many twists. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 62,
+      "question": "What does John do to share his knowledge?",
+      "expected_answer": "gives seminars, mentors younger players.",
+      "relevant_facts": [
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, and stay involved in the game during the off-season. | Involving: John, younger players (on his team) | To share skills, stay involved in the game, and for personal reward.",
+        "John's seminars went really well, and the aspiring professionals who attended were eager and motivated, making him happy to share his knowledge. | When: Recently | Involving: John, aspiring professionals",
+        "John faces challenges mentoring due to individual differences but enjoys gaining experience in adapting, motivating, and encouraging. He finds it rewarding to watch players develop and reach their goals. | Involving: John, younger players",
+        "John finds it fulfilling to see the players' growth, improvement, and confidence, believing he makes a positive impact on their lives. Some players see him as a mentor, and he enjoys being a positive role model by providing advice and support on and off the court. He feels great having their trust and admiration, hoping his experiences inspire them. | Involving: John, younger players",
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing.",
+        "John advised that motivating others involves showing care, celebrating achievements, providing constructive feedback, reminding them of goals, creating a positive environment, and giving pep talks before a game. | When: Wednesday, December 6, 2023 | Involving: John, Tim (user) | In response to Tim's request for advice.",
+        "Tim asked John for tips on motivating others on his team. | When: Wednesday, December 6, 2023 | Involving: Tim (user), John",
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids"
+      ]
+    },
+    {
+      "q_idx": 63,
+      "question": "When did John organize a basketball camp for kids?",
+      "expected_answer": "summer 2023",
+      "relevant_facts": [
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids"
+      ]
+    },
+    {
+      "q_idx": 64,
+      "question": "Which month was John in Italy?",
+      "expected_answer": "December, 2023",
+      "relevant_facts": [
+        "John found Italy amazing, specifically its food, history, and architecture. | When: During his trip last month (December 2023) | Involving: John | This describes why John had a blast during his trip to Italy.",
+        "John bought a book in Italy that has been inspiring his cooking. | When: During his trip last month (December 2023) | Involving: John",
+        "John visited Italy last month and had a blast. | When: Last month (December 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 65,
+      "question": "What fantasy movies does Tim like?",
+      "expected_answer": "Lord of the Rings, Harry Potter, and Star Wars.",
+      "relevant_facts": [
+        "Tim visited a Harry Potter-related place in London a few years ago, which he described as like walking into a movie and an amazing tour. | When: A few years ago | Involving: Tim",
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie in the series and brings back great memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family",
+        "Tim's favorite fantasy movie is Lord of the Rings. | Involving: Tim (user)",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim has seen all the Harry Potter movies and enjoys comparing them to the books. | Involving: Tim (user)",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, and he loves their work, considering it a piece of the wizarding world at home. | Involving: Tim, MinaLima",
+        "Tim is planning his first trip to Universal Studios next month and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 66,
+      "question": "What is a Star Wars book that Tim might enjoy?",
+      "expected_answer": "Star Wars: Jedi Apprentice by Judy Blundell and David Farland. It is a highly rated and immersive series about his favorite movies.",
+      "relevant_facts": [
+        "Tim and John share an interest in fantasy books and movies. | Involving: Tim, John",
+        "Tim enjoys fantasy novels because they fire up his imagination, take him to alternate realities, and serve as an escape from reality. | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim enjoys fantasy books, specifically Lord of the Rings, because they allow him to get lost in another world, appreciate intricate details, and explore other cultures and landscapes from home. | Involving: Tim | He appreciates the immersive experience and the ability to explore different worlds and cultures.",
+        "Tim's favorite book is Harry Potter, which he finds very immersive. | Involving: Tim",
+        "Tim is a huge fan of the fantasy genre, especially epic adventures and magical worlds. | Involving: Tim (user)",
+        "Tim recommends the fantasy novel \"The Name of the Wind,\" highlighting its great magician and musician protagonist, world-building, and character development. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 67,
+      "question": "What would be a good hobby related to his travel dreams for Tim to pick up?",
+      "expected_answer": "Writing a travel blog.",
+      "relevant_facts": [
+        "Tim is proud of researching visa requirements, viewing it as taking initiative towards his travel dreams. | Involving: Tim | It feels like a step towards making his travel dreams a reality.",
+        "Tim loves traveling. | Involving: Tim",
+        "Tim visited a travel agency to check the requirements for his next dream trip. | When: Recently | Involving: Tim | To understand the requirements for his next dream trip.",
+        "Tim is researching visa requirements for places he wants to visit, finding the process overwhelming but exciting. | Involving: Tim | He is taking a step towards making his travel dreams a reality.",
+        "Tim's motivation comes from writing and reading, which helps him stay motivated and push himself to get better. | Involving: Tim",
+        "Tim is reading stories from travelers around the world from a book to plan his next adventure. | When: Recently | Involving: Tim | To plan his next adventure.",
+        "Tim joined a travel club and is interested in different cultures and countries, looking forward to meeting new people and learning about what makes them unique. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is going well and he finds it exciting and joyful, though a bit nerve-wracking. He believes his hard work is paying off. | Involving: Tim",
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling that transports readers. Tim studies her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim has never been on a sports team; he prefers reading fantasy novels and traveling to new places to experience different kinds of 'magic'. | Involving: Tim",
+        "Tim joined a group of globetrotters who share his interests. | When: Since their last conversation (before January 2, 2024) | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing stories. | Involving: Tim",
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim's creativity for writing is inspired by books, movies, real-life experiences (such as reading about UK castles), and specific authors. He finds writing more enjoyable when connected to things he loves. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine, which he finds very rewarding. | Involving: Tim",
+        "Tim had a setback last week when he tried writing a story based on his experiences in the UK, but it didn't go as he wanted. | When: Last week | Involving: Tim",
+        "Tim found the opportunity to write for the online magazine on a fantasy literature forum and secured it by sharing his ideas, which the magazine liked. | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) for a semester | Involving: Tim",
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 68,
+      "question": "What day did Tim get into his study abroad program?",
+      "expected_answer": "Januarty 5, 2024",
+      "relevant_facts": [
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 69,
+      "question": "When will Tim leave for Ireland?",
+      "expected_answer": "February, 2024",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) for a semester | Involving: Tim",
+        "Tim will stay in Galway, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 70,
+      "question": "Which Star Wars-related locations would Tim enjoy during his visit to Ireland?",
+      "expected_answer": "Skellig Michael, Malin Head, Loop Head, Ceann Sib\u00e9al, and Brow Head because they are Star Wars filming locations.",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim's favorite fantasy movie is Star Wars, which he feels never gets old. | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) for a semester | Involving: Tim",
+        "Tim will stay in Galway, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim",
+        "Tim was accepted into a study abroad program. | When: Friday, January 5, 2024 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 71,
+      "question": "Which team did John sign with on 21 May, 2023?",
+      "expected_answer": "The Minnesota Wolves",
+      "relevant_facts": [
+        "John signed with the Minnesota Wolves. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 72,
+      "question": "What is John's position on the team he signed with?",
+      "expected_answer": "shooting guard",
+      "relevant_facts": [
+        "John is a shooting guard for the Minnesota Wolves. | Involving: John",
+        "John signed with the Minnesota Wolves. | When: Recently | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 73,
+      "question": "What challenge did John encounter during pre-season training?",
+      "expected_answer": "fitting into the new team's style of play",
+      "relevant_facts": [
+        "John encountered challenges fitting into the Minnesota Wolves' style of play during pre-season training. | When: During pre-season | Involving: John, Minnesota Wolves"
+      ]
+    },
+    {
+      "q_idx": 74,
+      "question": "What aspects of the Harry Potter universe will be discussed in John's fan project collaborations?",
+      "expected_answer": "characters, spells, magical creatures",
+      "relevant_facts": [
+        "Tim and John are discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "Tim is working on a Harry Potter fan project and has been discussing collaborations for it. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 75,
+      "question": "What forum did Tim join recently?",
+      "expected_answer": "fantasy literature forum",
+      "relevant_facts": [
+        "Tim joined a fantasy literature forum and had an enriching talk about his favorite books. | When: Last night | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 76,
+      "question": "What kind of picture did Tim share as part of their Harry Potter book collection?",
+      "expected_answer": "MinaLima's creation from the Harry Potter films",
+      "relevant_facts": [
+        "Tim recently reorganized his bookshelf and shared a photo of it, which contains some of his favorite books including Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim",
+        "Tim has a picture from MinaLima, the creators of props for the Harry Potter films, and he loves their work, considering it a piece of the wizarding world at home. | Involving: Tim, MinaLima"
+      ]
+    },
+    {
+      "q_idx": 77,
+      "question": "What was the highest number of points John scored in a game recently?",
+      "expected_answer": "40 points",
+      "relevant_facts": [
+        "John scored 40 points in a basketball game, which was his highest score ever, indicating his hard work is paying off. | When: Last week (prior to July 16, 2023) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 78,
+      "question": "What did John celebrate at a restaurant with teammates?",
+      "expected_answer": "a tough win",
+      "relevant_facts": [
+        "John and his teammates celebrated their tough win at a restaurant, laughing and reliving the intense moments. | When: After the game last week | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 79,
+      "question": "What kind of deals did John sign with Nike and Gatorade?",
+      "expected_answer": "basketball shoe and gear deal with Nike, potential sponsorship deal with Gatorade",
+      "relevant_facts": [
+        "John recently signed a basketball shoe and gear deal with Nike. | Involving: John",
+        "John is currently in talks with Gatorade for a potential sponsorship. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 80,
+      "question": "Which city is John excited to have a game at?",
+      "expected_answer": "Seattle",
+      "relevant_facts": [
+        "John loves Seattle's energy, diversity, awesome food (especially local seafood), and the incredible support from fans at games. | Involving: John",
+        "John has a game scheduled in Seattle next month. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 81,
+      "question": "How long has John been surfing?",
+      "expected_answer": "five years",
+      "relevant_facts": [
+        "John had an awesome summer surfing and riding waves with his friends, which he described as an unreal feeling. He started surfing five years ago and loves the connection to nature it provides. | When: Started five years ago (around 2018) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 82,
+      "question": "How does John feel while surfing?",
+      "expected_answer": "super exciting and free-feeling",
+      "relevant_facts": [
+        "John had an awesome summer surfing and riding waves with his friends, which he described as an unreal feeling. He started surfing five years ago and loves the connection to nature it provides. | When: Started five years ago (around 2018) | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 83,
+      "question": "What kind of articles has Tim been writing about for the online magazine?",
+      "expected_answer": "different fantasy novels, characters, themes, and book recommendations",
+      "relevant_facts": [
+        "Tim's articles for the online magazine cover different fantasy novels, focusing on studying characters, themes, and making book recommendations. | Involving: Tim",
+        "Tim is writing articles about fantasy novels for an online magazine, which he finds very rewarding. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 84,
+      "question": "Which two fantasy novels does Tim particularly enjoy writing about?",
+      "expected_answer": "Harry Potter and Game of Thrones",
+      "relevant_facts": [
+        "Tim particularly loves writing about Harry Potter and Game of Thrones, as he is very hooked on them. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 85,
+      "question": "What did Anthony and John end up playing during the charity event?",
+      "expected_answer": "an intense Harry Potter trivia contest",
+      "relevant_facts": [
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book. | Involving: John, Anthony"
+      ]
+    },
+    {
+      "q_idx": 86,
+      "question": "What did John share with the person he skyped about?",
+      "expected_answer": "Characters from Harry Potter",
+      "relevant_facts": [
+        "Tim and John are discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John"
+      ]
+    },
+    {
+      "q_idx": 87,
+      "question": "How did John describe the team bond?",
+      "expected_answer": "Awesome",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after a trip, feeling very welcome and appreciating the electric atmosphere and team bond. | When: August 15, 2023 | Involving: John, John's teammates"
+      ]
+    },
+    {
+      "q_idx": 88,
+      "question": "How did John get introduced to basketball?",
+      "expected_answer": "Dad signed him up for a local league",
+      "relevant_facts": [
+        "John's dad signed him up for a local basketball league when John was ten years old, marking the beginning of his active participation in the sport. | When: When he was ten years old | Involving: John, John's dad | This was a significant step in John's basketball journey."
+      ]
+    },
+    {
+      "q_idx": 89,
+      "question": "What is John's number one goal in his basketball career?",
+      "expected_answer": "Winning a championship",
+      "relevant_facts": [
+        "John's primary goal in his basketball career is to win a championship. | Involving: John | This is John's number one professional aspiration."
+      ]
+    },
+    {
+      "q_idx": 90,
+      "question": "What organization is John teaming up with for his charity work?",
+      "expected_answer": "A local organization helping disadvantaged kids with sports and school",
+      "relevant_facts": [
+        "John plans to initiate his charity work by collaborating with a local organization that supports disadvantaged children with sports and school, aiming to use his platform for community impact and inspiration. | Involving: John | This outlines the specific steps John intends to take to achieve his off-court goals."
+      ]
+    },
+    {
+      "q_idx": 91,
+      "question": "When did John meet back up with his teammates after his trip in August 2023?",
+      "expected_answer": "Aug 15th",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after a trip, feeling very welcome and appreciating the electric atmosphere and team bond. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, serving as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 92,
+      "question": "What did John's teammates give him when they met on Aug 15th?",
+      "expected_answer": "a basketball with autographs on it",
+      "relevant_facts": [
+        "John reunited with his teammates on August 15th after a trip, feeling very welcome and appreciating the electric atmosphere and team bond. | When: August 15, 2023 | Involving: John, John's teammates",
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, serving as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 93,
+      "question": "Why did John's teammates sign the basketball they gave him?",
+      "expected_answer": "to show their friendship and appreciation",
+      "relevant_facts": [
+        "John's teammates gave him a signed basketball as a sign of their friendship and appreciation when they reunited. | When: August 15, 2023 | Involving: John, John's teammates | To show their friendship and appreciation, serving as a reminder of their bond."
+      ]
+    },
+    {
+      "q_idx": 94,
+      "question": "What is the main intention behind Tim wanting to attend the book conference?",
+      "expected_answer": "to learn more about literature and create a stronger bond to it",
+      "relevant_facts": [
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: Next month (September 2023) | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 95,
+      "question": "What new activity has Tim started learning in August 2023?",
+      "expected_answer": "play the piano",
+      "relevant_facts": [
+        "Tim is working on studies, recently started learning an instrument, and finds it challenging but fun, having always admired musicians. | Involving: Tim",
+        "Tim started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023. | Involving: Tim (user)",
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 96,
+      "question": "Which movie's theme is Tim's favorite to play on the piano?",
+      "expected_answer": "\"Harry Potter and the Philosopher's Stone\"",
+      "relevant_facts": [
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim",
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie in the series and brings back great memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family"
+      ]
+    },
+    {
+      "q_idx": 97,
+      "question": "What special memory does \"Harry Potter and the Philosopher's Stone\" bring to Tim?",
+      "expected_answer": "Watching it with his family",
+      "relevant_facts": [
+        "The movie \"Harry Potter and the Philosopher's Stone\" is special to Tim because it was the first movie in the series and brings back great memories of watching it with his family, getting comfy with snacks and a blanket. | Involving: Tim, Tim's family"
+      ]
+    },
+    {
+      "q_idx": 98,
+      "question": "Which movie does Tim mention they enjoy watching during Thanksgiving?",
+      "expected_answer": "\"Home Alone\"",
+      "relevant_facts": [
+        "Tim's family enjoys watching \"Home Alone\" during Thanksgiving because it brings lots of laughs. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 99,
+      "question": "What tradition does Tim mention they love during Thanksgiving?",
+      "expected_answer": "Prepping the feast and talking about what they're thankful for",
+      "relevant_facts": [
+        "Tim's family traditions for Thanksgiving include preparing a feast, discussing gratitude, and watching movies. | Involving: Tim (and his family)"
+      ]
+    },
+    {
+      "q_idx": 100,
+      "question": "How long did John and his high school basketball teammates play together?",
+      "expected_answer": "Four years",
+      "relevant_facts": [
+        "John and his friends were teammates in high school for four years. | Involving: John, John's friends"
+      ]
+    },
+    {
+      "q_idx": 101,
+      "question": "How was John's experience in New York City?",
+      "expected_answer": "Amazing",
+      "relevant_facts": [
+        "John had an amazing experience in New York City, finding it new and exciting, enjoying exploring and trying restaurants, and considers it a must-visit. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 102,
+      "question": "What did John say about NYC, enticing Tim to visit?",
+      "expected_answer": "It's got so much to check out - the culture, food - you won't regret it.",
+      "relevant_facts": [
+        "John had an amazing experience in New York City, finding it new and exciting, enjoying exploring and trying restaurants, and considers it a must-visit. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 103,
+      "question": "What kind of soup did John make recently?",
+      "expected_answer": "tasty soup with sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty, improvised soup using sage. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 104,
+      "question": "What spice did John add to the soup for flavor?",
+      "expected_answer": "sage",
+      "relevant_facts": [
+        "John has been trying out cooking recipes and recently made a tasty, improvised soup using sage. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 105,
+      "question": "What is Tim excited to see at Universal Studios?",
+      "expected_answer": "The Harry Potter stuff",
+      "relevant_facts": [
+        "Tim is planning his first trip to Universal Studios next month and is particularly excited about the Harry Potter attractions. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 106,
+      "question": "Where are John and his teammates planning to explore on a team trip?",
+      "expected_answer": "a new city",
+      "relevant_facts": [
+        "John and his teammates are planning a team trip to explore a new city. | When: next month | Involving: John, John's teammates | To have some fun."
+      ]
+    },
+    {
+      "q_idx": 107,
+      "question": "What city did Tim suggest to John for the team trip next month?",
+      "expected_answer": "Edinburgh, Scotland",
+      "relevant_facts": [
+        "Tim suggested Edinburgh, Scotland, as a potential destination for John's team trip, highlighting its magical vibe, history, architecture, beauty, and its status as the birthplace of Harry Potter. | Involving: Tim, John | As a suggestion for John's team trip."
+      ]
+    },
+    {
+      "q_idx": 108,
+      "question": "What does John want to do after his basketball career?",
+      "expected_answer": "positively influence and inspire others, potentially start a foundation and engage in charity work",
+      "relevant_facts": [
+        "John also aims to make a positive difference off the court through charity work or inspiring people, as a way to give back to the sport that has been good to him. | Involving: John | This reflects John's desire for social impact beyond his athletic career.",
+        "John plans to use his platform after basketball to make a positive difference and inspire others, potentially by starting a foundation and engaging in charity work. | Involving: John | It is important for John to make the most of his opportunities and leave a meaningful legacy.",
+        "John finds it fulfilling to see the players' growth, improvement, and confidence, believing he makes a positive impact on their lives. Some players see him as a mentor, and he enjoys being a positive role model by providing advice and support on and off the court. He feels great having their trust and admiration, hoping his experiences inspire them. | Involving: John, younger players",
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John plans to initiate his charity work by collaborating with a local organization that supports disadvantaged children with sports and school, aiming to use his platform for community impact and inspiration. | Involving: John | This outlines the specific steps John intends to take to achieve his off-court goals.",
+        "John believes in making a difference and uses his influence and resources to help causes he believes in. He has spoken at a charity event. | Involving: John",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John",
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids"
+      ]
+    },
+    {
+      "q_idx": 109,
+      "question": "What advice did Tim give John about picking endorsements?",
+      "expected_answer": "Ensure they align with values and brand, look for companies that share the desire to make a change and help others, make sure the endorsement feels authentic",
+      "relevant_facts": [
+        "John asked Tim for advice on how to pick the right endorsements. | Involving: John, Tim | John is trying to figure out how to choose endorsements effectively.",
+        "Tim advised John to choose endorsements that align with his values and brand, to seek companies that share his desire to make a change and help others, and to ensure the endorsement feels authentic to his followers. | Involving: Tim, John | To help John select suitable endorsements."
+      ]
+    },
+    {
+      "q_idx": 110,
+      "question": "What book recommendation did Tim give to John for the trip?",
+      "expected_answer": "A fantasy novel by Patrick Rothfuss",
+      "relevant_facts": [
+        "Tim recommended 'The Name of the Wind', a fantasy novel by Patrick Rothfuss, as a good book for John to read while traveling. | Involving: Tim, John, Patrick Rothfuss | To provide John with a book recommendation for his trip."
+      ]
+    },
+    {
+      "q_idx": 111,
+      "question": "What type of venue did John and his girlfriend choose for their wedding ceremony?",
+      "expected_answer": "Greenhouse",
+      "relevant_facts": [
+        "John and his girlfriend held their wedding ceremony at a lovely greenhouse venue, opting for a smaller, more intimate gathering while following necessary safety protocols. | When: Last week | Involving: John, John's girlfriend | To ensure safety and intimacy during the ceremony."
+      ]
+    },
+    {
+      "q_idx": 112,
+      "question": "What was the setting for John and his wife's first dance?",
+      "expected_answer": "Cozy restaurant",
+      "relevant_facts": [
+        "John and his wife had their first dance at a cozy restaurant, which was described as dreamy with music and candlelight. | When: Last week (wedding day) | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 113,
+      "question": "Which basketball team does Tim support?",
+      "expected_answer": "The Wolves",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 114,
+      "question": "What passion does Tim mention connects him with people from all over the world?",
+      "expected_answer": "passion for fantasy stuff",
+      "relevant_facts": [
+        "Tim attended a Harry Potter conference in the UK last week, finding it incredible and feeling inspired, which gave him a new lease of life. He loves how his passion for fantasy connects him with people globally. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 115,
+      "question": "How does John describe the game season for his team?",
+      "expected_answer": "intense with tough losses and great wins",
+      "relevant_facts": [
+        "John's team had an intense season with both tough losses and great wins, but overall performed pretty well. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 116,
+      "question": "How does John say his team handles tough opponents?",
+      "expected_answer": "by backing each other up and not quitting",
+      "relevant_facts": [
+        "John's team is driven to get better by facing tough opponents, and they support each other, demonstrating a resilient attitude. | Involving: John (and his team)",
+        "John considers his team to be like a family away from home, providing strong support, pushing each other to improve, and encouraging him in sports and other aspects of life. They also hang out a lot, and he is thankful for them. | Involving: John, John's team",
+        "John's teammates provide strong support and encouragement, even when he makes mistakes, which helps him keep going. | Involving: John's teammates, John",
+        "John finds comfort and motivation from a ball that reminds him of the bond and support from his teammates, which also serves as a reminder of why he started playing basketball and his journey. | Involving: John, John's teammates | It helps him stay strong and give his all."
+      ]
+    },
+    {
+      "q_idx": 117,
+      "question": "What motivates John's team to get better, according to John?",
+      "expected_answer": "facing tough opponents",
+      "relevant_facts": [
+        "John's team is driven to get better by facing tough opponents, and they support each other, demonstrating a resilient attitude. | Involving: John (and his team)"
+      ]
+    },
+    {
+      "q_idx": 118,
+      "question": "What did John's team win at the end of the season?",
+      "expected_answer": "a trophy",
+      "relevant_facts": [
+        "John was elated about winning the trophy and appreciates Tim's support, stating he will continue to work hard. | Involving: John, Tim",
+        "John's team won a trophy, which made all their hard work and effort feel worthwhile. | Involving: John (and his team)",
+        "John won a trophy, likely a basketball trophy, which felt great after putting in significant effort. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 119,
+      "question": "Where did Tim capture the photography of the sunset over the mountain range?",
+      "expected_answer": "Smoky Mountains",
+      "relevant_facts": [
+        "Tim took a stunning picture on a trip to the Smoky Mountains in Summer 2022. | When: Summer 2022 | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 120,
+      "question": "How does John feel about being seen as a mentor by some of the younger players?",
+      "expected_answer": "It feels great",
+      "relevant_facts": [
+        "John finds it fulfilling to see the players' growth, improvement, and confidence, believing he makes a positive impact on their lives. Some players see him as a mentor, and he enjoys being a positive role model by providing advice and support on and off the court. He feels great having their trust and admiration, hoping his experiences inspire them. | Involving: John, younger players",
+        "John is mentoring younger players on his team, which he finds super rewarding and a way to share his skills and knowledge, and stay involved in the game during the off-season. | Involving: John, younger players (on his team) | To share skills, stay involved in the game, and for personal reward.",
+        "John faces challenges mentoring due to individual differences but enjoys gaining experience in adapting, motivating, and encouraging. He finds it rewarding to watch players develop and reach their goals. | Involving: John, younger players",
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids"
+      ]
+    },
+    {
+      "q_idx": 121,
+      "question": "What does John find rewarding about mentoring the younger players?",
+      "expected_answer": "Seeing their growth, improvement, and confidence",
+      "relevant_facts": [
+        "John finds it fulfilling to see the players' growth, improvement, and confidence, believing he makes a positive impact on their lives. Some players see him as a mentor, and he enjoys being a positive role model by providing advice and support on and off the court. He feels great having their trust and admiration, hoping his experiences inspire them. | Involving: John, younger players",
+        "John faces challenges mentoring due to individual differences but enjoys gaining experience in adapting, motivating, and encouraging. He finds it rewarding to watch players develop and reach their goals. | Involving: John, younger players"
+      ]
+    },
+    {
+      "q_idx": 122,
+      "question": "What has John been able to help the younger players achieve?",
+      "expected_answer": "reach their goals",
+      "relevant_facts": [
+        "John finds it fulfilling to see the players' growth, improvement, and confidence, believing he makes a positive impact on their lives. Some players see him as a mentor, and he enjoys being a positive role model by providing advice and support on and off the court. He feels great having their trust and admiration, hoping his experiences inspire them. | Involving: John, younger players",
+        "John faces challenges mentoring due to individual differences but enjoys gaining experience in adapting, motivating, and encouraging. He finds it rewarding to watch players develop and reach their goals. | Involving: John, younger players"
+      ]
+    },
+    {
+      "q_idx": 123,
+      "question": "What genre is the novel that Tim is writing?",
+      "expected_answer": "Fantasy",
+      "relevant_facts": [
+        "Tim is currently writing a fantasy novel, which is going well and he finds it exciting and joyful, though a bit nerve-wracking. He believes his hard work is paying off. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 124,
+      "question": "Who is one of Tim's sources of inspiration for writing?",
+      "expected_answer": "J.K. Rowling",
+      "relevant_facts": [
+        "J.K. Rowling is an inspiring writer for Tim, who admires her captivating detail and creative storytelling that transports readers. Tim studies her writing style for his own work. | Involving: Tim, J.K. Rowling",
+        "Tim has been reading J.K. Rowling's works for a long time, and her stories continue to inspire him due to a special quality in her writing. | Involving: Tim, J.K. Rowling"
+      ]
+    },
+    {
+      "q_idx": 125,
+      "question": "What J.K. Rowling quote does Tim resonate with?",
+      "expected_answer": "\"Turn on the light - happiness hides in the darkest of times.\"",
+      "relevant_facts": [
+        "Tim likes the J.K. Rowling quote \"Turn on the light - happiness hides in the darkest of times\" and uses it to maintain hope during difficult periods. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 126,
+      "question": "What does John write on the whiteboard to help him stay motivated?",
+      "expected_answer": "motivational quotes and strategies",
+      "relevant_facts": [
+        "John uses a whiteboard to write down motivational quotes and strategies, which helps him stay focused and motivated during tough workouts and keep improving. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 127,
+      "question": "What hobby is a therapy for John when away from the court?",
+      "expected_answer": "Cooking",
+      "relevant_facts": [
+        "John considers cuddling up with a book his chill time. He also finds cooking therapeutic, a good way to be creative, and to experiment with flavors when he's away from the court. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 128,
+      "question": "What type of meal does John often cook using a slow cooker?",
+      "expected_answer": "honey garlic chicken with roasted veg",
+      "relevant_facts": [
+        "John's favorite recipe is honey garlic chicken with roasted vegetables, which he makes frequently. | Involving: John",
+        "Tim is eager to try John's honey garlic chicken with roasted vegetables recipe. | Involving: Tim, John",
+        "Tim requested the recipe for John's honey garlic chicken with roasted vegetables. | When: Saturday, October 21, 2023 | Involving: Tim, John",
+        "John plans to write down and mail the honey garlic chicken with roasted vegetables recipe to Tim. | When: Saturday, October 21, 2023 | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 129,
+      "question": "How will John share the honey garlic chicken recipe with the other person?",
+      "expected_answer": "write it down and mail it",
+      "relevant_facts": [
+        "John plans to write down and mail the honey garlic chicken with roasted vegetables recipe to Tim. | When: Saturday, October 21, 2023 | Involving: John, Tim"
+      ]
+    },
+    {
+      "q_idx": 130,
+      "question": "What was Tim's huge writing issue last week,as mentioned on November 6, 2023?",
+      "expected_answer": "He got stuck on a plot twist",
+      "relevant_facts": [
+        "Tim experienced a significant and frustrating writing issue last week, getting stuck on a plot twist, but he persevered and eventually got his ideas flowing again. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 131,
+      "question": "What does Tim have that serves as a reminder of hard work and is his prized possession?",
+      "expected_answer": "a basketball signed by his favorite player",
+      "relevant_facts": [
+        "Tim's prized possession is a basketball signed by his favorite player, which serves as a reminder of hard work. | Involving: Tim | It reminds him of hard work."
+      ]
+    },
+    {
+      "q_idx": 132,
+      "question": "Why do Tim and John find LeBron inspiring?",
+      "expected_answer": "LeBron's determination and the epic block in Game 7 of the '16 Finals",
+      "relevant_facts": [
+        "John admires LeBron's work ethic and dedication to the game, finding him an inspiration. | Involving: John, LeBron",
+        "Tim's favorite basketball player is LeBron James, and he was inspired by LeBron's epic block in Game 7 of the 2016 Finals, which changed the game and led to a win, reinforcing the \"never give up\" mentality. | When: 2016 Finals, Game 7 (June 19, 2016) | Involving: Tim, LeBron James | It was an inspiration to never give up.",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John",
+        "John loves basketball due to the determination and heart exemplified by moments like LeBron James' epic block in Game 7 of the 2016 Finals, where he chased down Iguodala and pinned the ball against the backboard. | When: 2016 Finals, Game 7 (June 19, 2016) | Involving: John, LeBron James, Iguodala | It exemplifies determination and heart, which is why John loves basketball."
+      ]
+    },
+    {
+      "q_idx": 133,
+      "question": "How did John describe the views during their road trip out on the European coastline?",
+      "expected_answer": "Spectacular",
+      "relevant_facts": [
+        "John and his wife went on a road trip along the European coastline, enjoying spectacular views, bonding, and creating memories. It was a refreshing change from his regular life. | Involving: John, John's wife"
+      ]
+    },
+    {
+      "q_idx": 134,
+      "question": "What is one of Tim's favorite fantasy TV shows, as mentioned on November 11, 2023?",
+      "expected_answer": "\"That\"",
+      "relevant_facts": [
+        "Tim's favorite fantasy show is \"That\". | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 135,
+      "question": "How does Tim stay motivated during difficult study sessions?",
+      "expected_answer": "Visualizing goals and success",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 136,
+      "question": "What did Tim say about his injury on 16 November, 2023?",
+      "expected_answer": "The doctor said it's not too serious",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 137,
+      "question": "What was the setback Tim faced in his writing project on 21 November, 2023?",
+      "expected_answer": "Story based on experiences in the UK didn't go as planned",
+      "relevant_facts": [
+        "Tim had a setback last week when he tried writing a story based on his experiences in the UK, but it didn't go as he wanted. | When: Last week | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 138,
+      "question": "How did John overcome his ankle injury from last season?",
+      "expected_answer": "stayed focused on recovery and worked hard to strengthen his body",
+      "relevant_facts": [
+        "John found it frustrating not being able to play or help his team due to his ankle injury, but he focused on recovery and strengthening his body, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John includes strength training in his routine because it builds muscle, increases power, prevents injuries, enhances explosiveness, and boosts overall athleticism for basketball. | Involving: John | These are the direct benefits for his basketball performance.",
+        "Last season, John hurt his ankle, which required some time off and physical therapy. | When: Last season | Involving: John",
+        "John is actively undergoing daily physical therapy exercises as part of his rehabilitation to stay active. | When: Every day | Involving: John | To recover from his injury and stay active.",
+        "John plans to keep pushing and staying positive in his ongoing fitness and recovery efforts. | Involving: John",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to his yoga practice. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps build strength and stability and works out legs and core. | Involving: John",
+        "John prioritizes listening to his body and getting enough rest to aid his practice and self-care. | Involving: John | To push himself during practice while also looking after himself.",
+        "John believes taking time for oneself is crucial for staying sharp, focused, gaining new perspectives, and tackling challenges with more energy. He intends to keep finding the right balance in his journey. | Involving: John",
+        "John uses a whiteboard to write down motivational quotes and strategies, which helps him stay focused and motivated during tough workouts and keep improving. | Involving: John",
+        "John keeps a plaque on his desk as a constant physical reminder to believe in himself, trust his abilities, and stay motivated when facing obstacles. | Involving: John",
+        "John created a workout schedule that balances basketball activities and strength training. | Involving: John | To effectively train for professional basketball and stay on track.",
+        "John enjoys playing and pushing himself, inspired by LeBron's determination and heart. | Involving: John",
+        "Strength training has significantly improved John's basketball performance, specifically his shooting accuracy, agility, and speed, leading to increased confidence and an upper hand over opponents. | Involving: John | These are the observed positive impacts of strength training on his game.",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "John had to adapt and tweak his routine at the new gym, finding the right balance was tricky but he eventually got the hang of it. | Involving: John | To effectively train and balance his basketball and strength training.",
+        "John admires LeBron's work ethic and dedication to the game, finding him an inspiration. | Involving: John, LeBron",
+        "John confirmed he will stay motivated and keep chasing his dreams. | Involving: John",
+        "John achieved a milestone at the gym by jogging without any pain, which was a huge relief and success after being unable to do so for a long time. | When: Last Friday (December 15, 2023) | Involving: John | It marked a significant personal achievement in his recovery/fitness journey.",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John feels motivated and ready to keep pushing for his goals, expressing appreciation for Tim's encouragement. | Involving: John, Tim",
+        "John appreciates Tim's support and states he will keep pushing forward. | Involving: John, Tim",
+        "John visualizes his goals and success for focus and motivation, which helps him during tough study sessions. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 139,
+      "question": "What motivated Tim to keep pushing himself to get better in writing and reading?",
+      "expected_answer": "Love for writing and reading",
+      "relevant_facts": [
+        "Tim's motivation comes from writing and reading, which helps him stay motivated and push himself to get better. | Involving: Tim",
+        "Tim has been writing more articles, which he enjoys as it combines his love for reading and sharing stories. | Involving: Tim",
+        "Tim is currently writing a fantasy novel, which is going well and he finds it exciting and joyful, though a bit nerve-wracking. He believes his hard work is paying off. | Involving: Tim",
+        "Tim loves reading. | Involving: Tim",
+        "Tim considers reading very important to him, comparing its loss to John's current inability to be on the court due to injury. | Involving: Tim",
+        "Tim plans to attend a book conference next month (September 2023) to learn more about literature and strengthen his bond to it. | When: Next month (September 2023) | Involving: Tim | To learn more about literature and create a stronger bond to it."
+      ]
+    },
+    {
+      "q_idx": 140,
+      "question": "How did John overcome a mistake he made during a big game in basketball?",
+      "expected_answer": "Worked hard to get better and focused on growth",
+      "relevant_facts": [
+        "After messing up in a big basketball game, John worked hard to improve, learning that resilience is key and owning up to mistakes is important for growth as a player and teammate. | Involving: John",
+        "John cares about improving by admitting mistakes and using them to get better. | Involving: John",
+        "When John faces challenges on the court, he reflects on what went wrong and finds ways to improve. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 141,
+      "question": "What book did John recently finish rereading that left him feeling inspired and hopeful about following dreams?",
+      "expected_answer": "The Alchemist",
+      "relevant_facts": [
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow dreams and search for personal legends, leaving him feeling motivated and hopeful. | When: recently | Involving: John | The book inspired him to pursue his dreams and personal legends."
+      ]
+    },
+    {
+      "q_idx": 142,
+      "question": "How did \"The Alchemist\" impact John's perspective on following dreams?",
+      "expected_answer": "made him think again about following dreams and searching for personal legends",
+      "relevant_facts": [
+        "John recently finished rereading \"The Alchemist,\" finding it inspiring and motivating him to follow dreams and search for personal legends, leaving him feeling motivated and hopeful. | When: recently | Involving: John | The book inspired him to pursue his dreams and personal legends.",
+        "The book \"The Alchemist\" made John think about life and the importance of following one's dreams. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 143,
+      "question": "What is John trying out to improve his strength and flexibility after recovery from ankle injury?",
+      "expected_answer": "yoga",
+      "relevant_facts": [
+        "John found it frustrating not being able to play or help his team due to his ankle injury, but he focused on recovery and strengthening his body, realizing the importance of patience and perseverance. | When: Last season | Involving: John",
+        "John is trying out yoga to gain extra strength and flexibility, finding it challenging but worthwhile. | Involving: John",
+        "John has noticed improvements in strength, flexibility, focus, and balance during his workouts due to his yoga practice. | Involving: John",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps build strength and stability and works out legs and core. | Involving: John",
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "Last season, John hurt his ankle, which required some time off and physical therapy. | When: Last season | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 144,
+      "question": "How long does John usually hold the yoga pose he shared with Tim?",
+      "expected_answer": "30-60 seconds",
+      "relevant_facts": [
+        "John enjoys practicing Warrior II pose, which makes him feel strong, and another pose that helps with balance and stability. He loves how these poses challenge his body and mind. | Involving: John",
+        "Tim plans to try the Warrior II yoga pose. | Involving: Tim",
+        "John typically holds the Warrior II pose for 30-60 seconds, which helps build strength and stability and works out legs and core. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 145,
+      "question": "Where was the forest picture shared by John on December 1,2023 taken?",
+      "expected_answer": "near his hometown",
+      "relevant_facts": [
+        "John shared a photo of a tranquil forest near his hometown. | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 146,
+      "question": "What did Tim recently start learning in addition to being part of a travel club and working on studies?",
+      "expected_answer": "an instrument",
+      "relevant_facts": [
+        "Tim is working on studies, recently started learning an instrument, and finds it challenging but fun, having always admired musicians. | Involving: Tim",
+        "Tim joined a travel club and is interested in different cultures and countries, looking forward to meeting new people and learning about what makes them unique. | Involving: Tim",
+        "Tim joined a group of globetrotters who share his interests. | When: Since their last conversation (before January 2, 2024) | Involving: Tim",
+        "Tim started learning to play the piano and finds the progress satisfying. | Involving: Tim",
+        "Tim is learning to play the violin, is mostly into classical music, and is keen to try out jazz and film scores, finding it a great way to chill and get creative. | Involving: Tim",
+        "Tim's favorite song to play on the piano is a movie theme that brings back great memories. | Involving: Tim",
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 147,
+      "question": "What instrument is Tim learning to play in December 2023?",
+      "expected_answer": "violin",
+      "relevant_facts": [
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023. | Involving: Tim (user)",
+        "Tim is learning to play the violin, is mostly into classical music, and is keen to try out jazz and film scores, finding it a great way to chill and get creative. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 148,
+      "question": "How long has Tim been playing the piano for, as of December 2023?",
+      "expected_answer": "about four months",
+      "relevant_facts": [
+        "Tim has been playing for about four months and is enjoying the progress he's making. | When: For about four months, as of December 6, 2023. | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 149,
+      "question": "What book did Tim just finish reading on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | When: Recently | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 150,
+      "question": "Which book did Tim recommend to John as a good story on 8th December, 2023?",
+      "expected_answer": "\"A Dance with Dragons\"",
+      "relevant_facts": [
+        "Tim recently finished reading \"A Dance with Dragons\" and highly recommends it. | When: Recently | Involving: Tim",
+        "John asked Tim for book recommendations for his upcoming trip. | Involving: John, Tim | John is planning a trip and wants reading material."
+      ]
+    },
+    {
+      "q_idx": 151,
+      "question": "What is the topic of discussion between John and Tim on 11 December, 2023?",
+      "expected_answer": "Academic achievements and sports successes",
+      "relevant_facts": [
+        "John feels motivated and ready to keep pushing for his goals, expressing appreciation for Tim's encouragement. | Involving: John, Tim",
+        "Tim observed that John looked very \"into it\" in the basketball game picture, suggesting John plays at an \"awesome level.\" | Involving: Tim, John",
+        "Tim appreciates John's support and encouragement, stating it has made his journey better. | Involving: Tim, John",
+        "John was elated about winning the trophy and appreciates Tim's support, stating he will continue to work hard. | Involving: John, Tim",
+        "John shared a picture from a recent basketball game he played in. | When: Recent | Involving: John, Tim (recipient)",
+        "Tim encourages John to follow his dreams and believes they both have potential. They agree to keep supporting and motivating each other on their journey towards their dreams. | Involving: Tim, John",
+        "Tim has been swamped with exams this week. | When: This week | Involving: Tim",
+        "John felt great making plays for his team, loves seeing teammates succeed due to his opportunities, and found the arena atmosphere electric and the game against rivals intense, making it a memorable night. | When: Friday, December 8, 2023 | Involving: John",
+        "John has an injury that has made his week tough, but he is staying positive. | When: This week | Involving: John",
+        "Tim gave a presentation in class, feeling nervous but successfully completing it. | When: Yesterday | Involving: Tim (user)",
+        "Tim had a tough exam last week that made him doubt himself, but he turned it into a learning experience, studied hard, and demonstrated resilience and determination. | When: Last week | Involving: Tim",
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Friday, December 8, 2023 | Involving: John",
+        "John achieved a milestone at the gym by jogging without any pain, which was a huge relief and success after being unable to do so for a long time. | When: Last Friday (December 15, 2023) | Involving: John | It marked a significant personal achievement in his recovery/fitness journey."
+      ]
+    },
+    {
+      "q_idx": 152,
+      "question": "What kind of game did John have a career-high in assists in?",
+      "expected_answer": "basketball",
+      "relevant_facts": [
+        "John achieved a career-high in assists during a basketball game against their rival. | When: Friday, December 8, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 153,
+      "question": "What was John's way of dealing with doubts and stress when he was younger?",
+      "expected_answer": "practicing basketball outside for hours",
+      "relevant_facts": [
+        "Practicing basketball was John's way of dealing with doubts and stress when he was younger. | When: When John was younger | Involving: John",
+        "The picture John sent Tim reminds John of when he was younger, practicing basketball outside for hours and dreaming of playing in big games. | When: When John was younger | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 154,
+      "question": "How did John feel about the atmosphere during the big game against the rival team?",
+      "expected_answer": "electric and intense",
+      "relevant_facts": [
+        "John felt great making plays for his team, loves seeing teammates succeed due to his opportunities, and found the arena atmosphere electric and the game against rivals intense, making it a memorable night. | When: Friday, December 8, 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 155,
+      "question": "How did John feel after being able to jog without pain?",
+      "expected_answer": "It was a huge success.",
+      "relevant_facts": [
+        "John and his wife hosted a small get-together with friends and family to celebrate John's milestone of jogging without pain. They had a ton of fun and enjoyed seeing everyone again. | When: After last Friday's milestone | Involving: John, John's wife, friends, family | To celebrate John's significant achievement in his fitness journey.",
+        "John achieved a milestone at the gym by jogging without any pain, which was a huge relief and success after being unable to do so for a long time. | When: Last Friday (December 15, 2023) | Involving: John | It marked a significant personal achievement in his recovery/fitness journey."
+      ]
+    },
+    {
+      "q_idx": 156,
+      "question": "What kind of deal did John get in December?",
+      "expected_answer": "Deal with a renowned outdoor gear company",
+      "relevant_facts": [
+        "John secured an endorsement deal with a renowned outdoor gear company. | When: Last week | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 157,
+      "question": "Where was the photoshoot done for John's gear deal?",
+      "expected_answer": "In a gorgeous forest",
+      "relevant_facts": [
+        "John had a photoshoot in a gorgeous forest, where the photographer took epic shots of him. | Involving: John, photographer"
+      ]
+    },
+    {
+      "q_idx": 158,
+      "question": "In which area has John's team seen the most growth during training?",
+      "expected_answer": "Communication and bonding",
+      "relevant_facts": [
+        "John's team has experienced significant growth in communication and bonding, which has improved their performances by allowing them to understand each other's strengths and weaknesses. | Involving: John, John's team | The growth has helped their performances."
+      ]
+    },
+    {
+      "q_idx": 159,
+      "question": "What type of seminars is John conducting?",
+      "expected_answer": "Sports and marketing seminars",
+      "relevant_facts": [
+        "John started doing seminars to help people with their sports and marketing. | When: This week | Involving: John | To help people with sports and marketing."
+      ]
+    },
+    {
+      "q_idx": 160,
+      "question": "What activity did Tim do after reading the stories about the Himalayan trek?",
+      "expected_answer": "visited a travel agency",
+      "relevant_facts": [
+        "The book described the Himalayas trek as tough due to challenging terrain, altitude sickness, and bad weather, but it was worth it for the amazing sights, which motivated Tim. | Involving: Tim (motivated), two hikers (from the story) | The challenging yet rewarding nature of the trek motivated Tim.",
+        "Tim read a story about two hikers who trekked through the Himalayas. | When: Recently | Involving: Tim, two hikers",
+        "Tim visited a travel agency to check the requirements for his next dream trip. | When: Recently | Involving: Tim | To understand the requirements for his next dream trip."
+      ]
+    },
+    {
+      "q_idx": 161,
+      "question": "What is one cause that John supports with his influence and resources?",
+      "expected_answer": "youth sports and fair chances in sports",
+      "relevant_facts": [
+        "John plans to initiate his charity work by collaborating with a local organization that supports disadvantaged children with sports and school, aiming to use his platform for community impact and inspiration. | Involving: John | This outlines the specific steps John intends to take to achieve his off-court goals.",
+        "John supports youth sports and fights for fair chances in sports for underserved communities, collaborating with organizations to create opportunities for young athletes. | Involving: John",
+        "John organized a basketball camp for kids in his hometown, which was an awesome and inspiring experience. | When: Summer 2023 | Involving: John, kids"
+      ]
+    },
+    {
+      "q_idx": 162,
+      "question": "What new fantasy TV series is Tim excited about?",
+      "expected_answer": "\"The Wheel of Time\"",
+      "relevant_facts": [
+        "The new TV series \"The Wheel of Time\" is based on a book series that Tim loves. | Involving: Tim (user)",
+        "Tim is excited about a new fantasy TV series called \"The Wheel of Time\" which is coming out next month. | When: Next month | Involving: Tim (user)"
+      ]
+    },
+    {
+      "q_idx": 163,
+      "question": "Which language is Tim learning?",
+      "expected_answer": "German",
+      "relevant_facts": [
+        "Tim is currently learning German, finding it tough but fun. | Involving: Tim",
+        "Tim finds learning German tough but worth it, and likes its structure, noting it's easier than French which he took in high school. | Involving: Tim",
+        "Tim plans to continue with his German lessons. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 164,
+      "question": "What language does Tim know besides German?",
+      "expected_answer": "Spanish",
+      "relevant_facts": [
+        "Tim finds learning German tough but worth it, and likes its structure, noting it's easier than French which he took in high school. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 165,
+      "question": "What book did Tim get in Italy that inspired him to cook?",
+      "expected_answer": "a cooking book",
+      "relevant_facts": []
+    },
+    {
+      "q_idx": 166,
+      "question": "What is John's favorite book series?",
+      "expected_answer": "Harry Potter",
+      "relevant_facts": [
+        "Tim and John are discussing various aspects of the Harry Potter universe, including characters, spells, and magical creatures. | Involving: Tim, John",
+        "John and Anthony participated in an intense Harry Potter trivia contest at a charity event, where a \"super-nerd\" won a signed Harry Potter book. | Involving: John, Anthony",
+        "Tim offered to provide John with tips for visiting Harry Potter places. | Involving: Tim, John",
+        "John plans to visit Harry Potter-related places in the future, as it is on his to-do list. | When: Future | Involving: John",
+        "John enjoys being with people who are passionate about Harry Potter. | Involving: John",
+        "John loves \"Harry Potter and the Philosopher's Stone\" and owns the entire Harry Potter movie collection. | Involving: John",
+        "John is a fan of Harry Potter movies. | Involving: John",
+        "John complimented Tim's Harry Potter themed Christmas tree, stating it looked amazing and that Tim knows how to get the vibes just right. | Involving: John, Tim",
+        "John was asking about the main actress in Harry Potter, indicating he did not know her name. | Involving: John",
+        "John previously attended a Harry Potter trivia charity event in August and had a fun time. | When: August 2023 | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 167,
+      "question": "According to John, who is his favorite character from Lord of the Rings?",
+      "expected_answer": "Aragorn",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, down-to-earth attitude, perseverance, and commitment to justice. John admires Aragorn for putting others first, which leads to him becoming king. | Involving: John | Aragorn's character traits and journey inspire John."
+      ]
+    },
+    {
+      "q_idx": 168,
+      "question": "Why does John like Aragorn from Lord of the Rings?",
+      "expected_answer": "brave, selfless, down-to-earth attitude",
+      "relevant_facts": [
+        "John's favorite character is Aragorn, whom he finds inspiring due to his growth, leadership, selflessness, down-to-earth attitude, perseverance, and commitment to justice. John admires Aragorn for putting others first, which leads to him becoming king. | Involving: John | Aragorn's character traits and journey inspire John."
+      ]
+    },
+    {
+      "q_idx": 169,
+      "question": "What kind of painting does John have in his room as a reminder?",
+      "expected_answer": "a painting of Aragorn",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room. | Involving: John | The painting serves as a reminder for him to stay true and be a leader in everything he does."
+      ]
+    },
+    {
+      "q_idx": 170,
+      "question": "What is the painting of Aragorn a reminder for John to be in everything he does?",
+      "expected_answer": "be a leader",
+      "relevant_facts": [
+        "John has a painting of Aragorn in his room. | Involving: John | The painting serves as a reminder for him to stay true and be a leader in everything he does."
+      ]
+    },
+    {
+      "q_idx": 171,
+      "question": "What map does Tim show to his friend John?",
+      "expected_answer": "a map of Middle-earth from LOTR",
+      "relevant_facts": [
+        "John shares Tim's enjoyment of getting lost in another world through fantasy stories and finds exploring different lands and regions fun. He specifically loves the map of Middle-earth from Lord of the Rings for its ability to immerse him. | Involving: John, Tim | He enjoys the immersive experience of exploring different worlds and cultures.",
+        "Tim showed John his book collection. | Involving: Tim, John",
+        "Tim recently reorganized his bookshelf and shared a photo of it, which contains some of his favorite books including Harry Potter, Game of Thrones, and Lord of the Rings. | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 172,
+      "question": "Where will Tim be going for a semester abroad?",
+      "expected_answer": "Ireland",
+      "relevant_facts": [
+        "Tim is excited to explore nature in Ireland and specifically wants to visit The Cliffs of Moher for its amazing ocean views and cliffs. | When: During his semester abroad (starting February 2024) | Involving: Tim",
+        "Tim will go to Ireland for a semester as part of his study abroad program. | When: Next month (February 2024) for a semester | Involving: Tim",
+        "Tim will stay in Galway, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 173,
+      "question": "Which city in Ireland will Tim be staying in during his semester abroad?",
+      "expected_answer": "Galway",
+      "relevant_facts": [
+        "Tim will stay in Galway, which he notes is great for its arts and Irish music and has a vibrant atmosphere. | When: Next month (February 2024) | Involving: Tim"
+      ]
+    },
+    {
+      "q_idx": 174,
+      "question": "What charity event did John organize recently in 2024?",
+      "expected_answer": "benefit basketball game",
+      "relevant_facts": [
+        "John's benefit basketball game was a total success, with many people attending and money raised for charity. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John",
+        "John held a benefit basketball game. | When: Last week (between December 31, 2023, and January 6, 2024) | Involving: John"
+      ]
+    },
+    {
+      "q_idx": 175,
+      "question": "What achievement did John share with Tim in January 2024?",
+      "expected_answer": "endorsement with a popular beverage company",
+      "relevant_facts": [
+        "Tim advised John to choose endorsements that align with his values and brand, to seek companies that share his desire to make a change and help others, and to ensure the endorsement feels authentic to his followers. | Involving: Tim, John | To help John select suitable endorsements.",
+        "John will keep Tim updated on which brands he chooses for endorsement. | Involving: John, Tim",
+        "John asked Tim for advice on how to pick the right endorsements. | Involving: John, Tim | John is trying to figure out how to choose endorsements effectively.",
+        "John received an endorsement with a popular beverage company. | When: Last week (approx. January 5, 2024) | Involving: John | It was a dream come true and a significant achievement."
+      ]
+    },
+    {
+      "q_idx": 176,
+      "question": "What was Johns's reaction to sealing the deal with the beverage company?",
+      "expected_answer": "crazy feeling, sense of accomplishment",
+      "relevant_facts": [
+        "John felt crazy and accomplished after sealing the endorsement deal, believing his hard work and training hours had paid off. | Involving: John | It validated his efforts and hard work.",
+        "John received an endorsement with a popular beverage company. | When: Last week (approx. January 5, 2024) | Involving: John | It was a dream come true and a significant achievement."
+      ]
+    },
+    {
+      "q_idx": 177,
+      "question": "Which city did John recommend to Tim in January 2024?",
+      "expected_answer": "Barcelona",
+      "relevant_facts": [
+        "John recommends Barcelona to Tim as a must-visit city, highlighting its culture, architecture, food, and nearby beaches. | Involving: John (recommender), Tim (recipient)",
+        "Tim will add Barcelona to his travel list. | Involving: Tim | He found John's recommendation appealing and has heard great things about the city."
+      ]
+    }
+  ],
+  "embedding_id": "text-embedding-3-small",
+  "bank_id": "emb_text-embedding-3-small_1772627279"
+}

--- a/benchmark-runner/embedding_models.json
+++ b/benchmark-runner/embedding_models.json
@@ -8,7 +8,7 @@
       "provider_name": "Local CPU",
       "provider_icon": "/huggingface.png",
       "pricing_type": "free",
-      "price_per_query": 0.0,
+      "price_per_1m_tokens": 0.0,
       "model": "BAAI/bge-small-en-v1.5",
       "dimensions": 384,
       "notes": "BAAI/bge-small-en-v1.5 via sentence-transformers. 384-dim."
@@ -20,7 +20,7 @@
       "provider_name": "Local CPU",
       "provider_icon": "/huggingface.png",
       "pricing_type": "free",
-      "price_per_query": 0.0,
+      "price_per_1m_tokens": 0.0,
       "model": "sentence-transformers/all-MiniLM-L6-v2",
       "dimensions": 384,
       "notes": "sentence-transformers/all-MiniLM-L6-v2. General-purpose 384-dim bi-encoder."
@@ -32,7 +32,7 @@
       "provider_name": "Local CPU",
       "provider_icon": "/huggingface.png",
       "pricing_type": "free",
-      "price_per_query": 0.0,
+      "price_per_1m_tokens": 0.0,
       "model": "BAAI/bge-base-en-v1.5",
       "dimensions": 768,
       "notes": "BAAI/bge-base-en-v1.5. 768-dim. Stronger than bge-small."
@@ -44,7 +44,7 @@
       "provider_name": "Local CPU",
       "provider_icon": "/huggingface.png",
       "pricing_type": "free",
-      "price_per_query": 0.0,
+      "price_per_1m_tokens": 0.0,
       "model": "BAAI/bge-large-en-v1.5",
       "dimensions": 1024,
       "notes": "BAAI/bge-large-en-v1.5. 1024-dim. Largest local BGE model."
@@ -56,10 +56,10 @@
       "provider_name": "OpenAI",
       "provider_icon": "/openai.png",
       "pricing_type": "pay-per-use",
-      "price_per_query": 0.000001,
+      "price_per_1m_tokens": 0.02,
       "model": "text-embedding-3-small",
       "dimensions": 1536,
-      "notes": "OpenAI text-embedding-3-small. 1536-dim. $0.02/1M tokens (~$0.000001/query at 50 tok)."
+      "notes": "OpenAI text-embedding-3-small. 1536-dim. $0.02/1M tokens."
     },
     {
       "embedding_id": "cohere-embed-english-light-v3.0",
@@ -68,10 +68,10 @@
       "provider_name": "Cohere",
       "provider_icon": "/cohere.png",
       "pricing_type": "pay-per-use",
-      "price_per_query": 0.000005,
+      "price_per_1m_tokens": 0.10,
       "model": "embed-english-light-v3.0",
       "dimensions": 384,
-      "notes": "Cohere embed-english-light-v3.0. 384-dim. $0.10/1M tokens (~$0.000005/query at 50 tok)."
+      "notes": "Cohere embed-english-light-v3.0. 384-dim. $0.10/1M tokens."
     },
     {
       "embedding_id": "cohere-embed-english-v3.0",
@@ -80,10 +80,10 @@
       "provider_name": "Cohere",
       "provider_icon": "/cohere.png",
       "pricing_type": "pay-per-use",
-      "price_per_query": 0.000005,
+      "price_per_1m_tokens": 0.10,
       "model": "embed-english-v3.0",
       "dimensions": 1024,
-      "notes": "Cohere embed-english-v3.0. 1024-dim. $0.10/1M tokens (~$0.000005/query at 50 tok)."
+      "notes": "Cohere embed-english-v3.0. 1024-dim. $0.10/1M tokens."
     }
   ]
 }

--- a/benchmark-runner/embedding_models.json
+++ b/benchmark-runner/embedding_models.json
@@ -11,7 +11,7 @@
       "price_per_query": 0.0,
       "model": "BAAI/bge-small-en-v1.5",
       "dimensions": 384,
-      "notes": "BAAI/bge-small-en-v1.5 via sentence-transformers. 384-dim. Runs on CPU in Docker."
+      "notes": "BAAI/bge-small-en-v1.5 via sentence-transformers. 384-dim."
     },
     {
       "embedding_id": "all-minilm-l6-v2",
@@ -23,7 +23,67 @@
       "price_per_query": 0.0,
       "model": "sentence-transformers/all-MiniLM-L6-v2",
       "dimensions": 384,
-      "notes": "sentence-transformers/all-MiniLM-L6-v2. General-purpose 384-dim bi-encoder. Runs on CPU in Docker."
+      "notes": "sentence-transformers/all-MiniLM-L6-v2. General-purpose 384-dim bi-encoder."
+    },
+    {
+      "embedding_id": "bge-base-en-v1.5",
+      "display_name": "BGE Base EN v1.5",
+      "provider": "local",
+      "provider_name": "Local CPU",
+      "provider_icon": "/huggingface.png",
+      "pricing_type": "free",
+      "price_per_query": 0.0,
+      "model": "BAAI/bge-base-en-v1.5",
+      "dimensions": 768,
+      "notes": "BAAI/bge-base-en-v1.5. 768-dim. Stronger than bge-small."
+    },
+    {
+      "embedding_id": "bge-large-en-v1.5",
+      "display_name": "BGE Large EN v1.5",
+      "provider": "local",
+      "provider_name": "Local CPU",
+      "provider_icon": "/huggingface.png",
+      "pricing_type": "free",
+      "price_per_query": 0.0,
+      "model": "BAAI/bge-large-en-v1.5",
+      "dimensions": 1024,
+      "notes": "BAAI/bge-large-en-v1.5. 1024-dim. Largest local BGE model."
+    },
+    {
+      "embedding_id": "text-embedding-3-small",
+      "display_name": "text-embedding-3-small",
+      "provider": "openai",
+      "provider_name": "OpenAI",
+      "provider_icon": "/openai.png",
+      "pricing_type": "pay-per-use",
+      "price_per_query": 0.000001,
+      "model": "text-embedding-3-small",
+      "dimensions": 1536,
+      "notes": "OpenAI text-embedding-3-small. 1536-dim. $0.02/1M tokens (~$0.000001/query at 50 tok)."
+    },
+    {
+      "embedding_id": "cohere-embed-english-light-v3.0",
+      "display_name": "embed-english-light-v3.0",
+      "provider": "cohere",
+      "provider_name": "Cohere",
+      "provider_icon": "/cohere.png",
+      "pricing_type": "pay-per-use",
+      "price_per_query": 0.000005,
+      "model": "embed-english-light-v3.0",
+      "dimensions": 384,
+      "notes": "Cohere embed-english-light-v3.0. 384-dim. $0.10/1M tokens (~$0.000005/query at 50 tok)."
+    },
+    {
+      "embedding_id": "cohere-embed-english-v3.0",
+      "display_name": "embed-english-v3.0",
+      "provider": "cohere",
+      "provider_name": "Cohere",
+      "provider_icon": "/cohere.png",
+      "pricing_type": "pay-per-use",
+      "price_per_query": 0.000005,
+      "model": "embed-english-v3.0",
+      "dimensions": 1024,
+      "notes": "Cohere embed-english-v3.0. 1024-dim. $0.10/1M tokens (~$0.000005/query at 50 tok)."
     }
   ]
 }

--- a/benchmark-runner/embedding_models.json
+++ b/benchmark-runner/embedding_models.json
@@ -1,0 +1,29 @@
+{
+  "fixed_reranker": "local-minilm-l6",
+  "embeddings": [
+    {
+      "embedding_id": "bge-small-en-v1.5",
+      "display_name": "BGE Small EN v1.5",
+      "provider": "local",
+      "provider_name": "Local CPU",
+      "provider_icon": "/huggingface.png",
+      "pricing_type": "free",
+      "price_per_query": 0.0,
+      "model": "BAAI/bge-small-en-v1.5",
+      "dimensions": 384,
+      "notes": "BAAI/bge-small-en-v1.5 via sentence-transformers. 384-dim. Runs on CPU in Docker."
+    },
+    {
+      "embedding_id": "all-minilm-l6-v2",
+      "display_name": "all-MiniLM-L6-v2",
+      "provider": "local",
+      "provider_name": "Local CPU",
+      "provider_icon": "/huggingface.png",
+      "pricing_type": "free",
+      "price_per_query": 0.0,
+      "model": "sentence-transformers/all-MiniLM-L6-v2",
+      "dimensions": 384,
+      "notes": "sentence-transformers/all-MiniLM-L6-v2. General-purpose 384-dim bi-encoder. Runs on CPU in Docker."
+    }
+  ]
+}

--- a/benchmark-runner/run_all_embeddings.py
+++ b/benchmark-runner/run_all_embeddings.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Embeddings benchmark orchestrator — Docker-based, one persistent volume per embedding model.
+
+Each embedding model gets its own Docker volume because the Hindsight DB schema bakes in
+vector dimensions — models with different dimensions cannot share a bank.
+
+Each model also gets its own ground truth annotation file (datasets/locomo_embeddings_gt_{id}.json)
+because the retain LLM is non-deterministic: fact texts differ per ingest, so a cross-bank GT
+would produce false "not found" results on exact string matching.
+
+Architecture per embedding model:
+  Phase 1 (ingest + annotate, once — skipped if metadata + GT already exist):
+    - Start a Hindsight container with the target embedding model + RRF reranker
+    - Ingest conv-43 into a persistent bank
+    - Annotate ground truth: recall(budget="high") + LLM relevance labelling per question
+    - Save data_dir + bank_id to datasets/embedding_banks.json
+    - Save GT to datasets/locomo_embeddings_gt_{embedding_id}.json
+
+  Phase 2 (benchmark):
+    - Start container with same embedding model + fixed MiniLM-L6 reranker
+    - Run recall(budget="mid") on all annotated questions
+    - Compute MRR and Recall@K metrics against per-model GT
+    - Save results to results/leaderboard/embeddings/{embedding_id}.json
+
+Run all embedding models:
+  PYTHONUNBUFFERED=1 uv run python3 -u run_all_embeddings.py > /tmp/embeddings_run.log 2>&1 &
+
+Run a single embedding model (substring match on embedding_id):
+  uv run python3 -u run_all_embeddings.py bge-small-en-v1.5
+"""
+
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import requests
+from testcontainers.core.container import DockerContainer
+
+from hindsight_benchmark.embeddings import (
+    EmbeddingsBenchmark, gt_path_for_model,
+    FIXED_RERANKER_PROVIDER, FIXED_RERANKER_MODEL,
+)
+
+BENCHMARK_RUNNER_DIR = Path(__file__).parent
+RESULTS_DIR = BENCHMARK_RUNNER_DIR.parent / "results" / "leaderboard" / "embeddings"
+
+HINDSIGHT_IMAGE = "ghcr.io/vectorize-io/hindsight:latest"
+HINDSIGHT_PORT = 8888
+
+GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+COHERE_API_KEY = os.environ.get("COHERE_API_KEY", "")
+
+RETAIN_PROVIDER = "gemini"
+RETAIN_MODEL = "gemini-2.5-flash"
+RETAIN_API_KEY = GEMINI_API_KEY
+
+# Embedding models to benchmark: (embedding_id, provider, model)
+# All models must produce exactly 384-dimensional vectors (Hindsight DB constraint).
+EMBEDDING_MODELS = [
+    # Local models (no API key required, run on CPU in Docker)
+    ("bge-small-en-v1.5",  "local", "BAAI/bge-small-en-v1.5"),
+    ("all-minilm-l6-v2",   "local", "sentence-transformers/all-MiniLM-L6-v2"),
+]
+
+
+def _base_env(embedding_provider: str, embedding_model: str) -> dict:
+    """Build environment variables for a Hindsight container with the given embedding model."""
+    env = {
+        "HOME": "/app/data",
+        "HINDSIGHT_ENABLE_CP": "false",
+        "HINDSIGHT_API_HOST": "0.0.0.0",
+        "HINDSIGHT_API_PORT": str(HINDSIGHT_PORT),
+        "HINDSIGHT_API_EMBEDDINGS_PROVIDER": embedding_provider,
+        "HINDSIGHT_API_RERANKER_PROVIDER": "rrf",
+        "HINDSIGHT_API_ENABLE_OBSERVATIONS": "false",
+        "HINDSIGHT_API_EXTRACT_CAUSAL_LINKS": "false",
+        "HINDSIGHT_API_LLM_TIMEOUT": "45",
+        "HINDSIGHT_API_DB_POOL_MIN_SIZE": "20",
+        "HINDSIGHT_API_RERANKER_MAX_CANDIDATES": "300",
+        "HINDSIGHT_API_DB_COMMAND_TIMEOUT": "15",
+        "HINDSIGHT_API_RETAIN_LLM_PROVIDER": RETAIN_PROVIDER,
+        "HINDSIGHT_API_RETAIN_LLM_MODEL": RETAIN_MODEL,
+        "HINDSIGHT_API_RETAIN_LLM_API_KEY": RETAIN_API_KEY,
+        "HINDSIGHT_API_RETAIN_LLM_TIMEOUT": "120",
+        "HINDSIGHT_API_LLM_PROVIDER": RETAIN_PROVIDER,
+        "HINDSIGHT_API_LLM_MODEL": RETAIN_MODEL,
+        "HINDSIGHT_API_LLM_API_KEY": RETAIN_API_KEY,
+    }
+    if embedding_provider == "local" and embedding_model:
+        env["HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"] = embedding_model
+    elif embedding_provider == "openai" and embedding_model:
+        env["HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"] = embedding_model
+        env["HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"] = OPENAI_API_KEY
+    elif embedding_provider == "cohere" and embedding_model:
+        env["HINDSIGHT_API_EMBEDDINGS_COHERE_MODEL"] = embedding_model
+        env["HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY"] = COHERE_API_KEY
+    return env
+
+
+def _benchmark_env(embedding_provider: str, embedding_model: str) -> dict:
+    """Build env for a benchmark run: same embedding model + fixed MiniLM-L6 reranker."""
+    env = _base_env(embedding_provider, embedding_model)
+    env["HINDSIGHT_API_RERANKER_PROVIDER"] = FIXED_RERANKER_PROVIDER
+    env["HINDSIGHT_API_RERANKER_LOCAL_MODEL"] = FIXED_RERANKER_MODEL
+    env["HINDSIGHT_API_LAZY_RERANKER"] = "true"
+    return env
+
+
+def _start_hindsight(data_dir: str, env: dict) -> tuple[DockerContainer, str]:
+    c = DockerContainer(HINDSIGHT_IMAGE)
+    c.with_volume_mapping(data_dir, "/app/data", "rw")
+    c.with_exposed_ports(HINDSIGHT_PORT)
+    for k, v in env.items():
+        c.with_env(k, v)
+    c.start()
+    port = c.get_exposed_port(HINDSIGHT_PORT)
+    api_url = f"http://localhost:{port}"
+    print(f"  Container started on {api_url}, waiting for health...")
+    _wait_health(api_url)
+    return c, api_url
+
+
+def _wait_health(api_url: str, timeout: int = 300):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            r = requests.get(f"{api_url}/health", timeout=5)
+            if r.status_code == 200:
+                print(f"  ✓ Hindsight healthy at {api_url}")
+                return
+        except Exception:
+            pass
+        time.sleep(3)
+    raise TimeoutError(f"Hindsight did not become healthy at {api_url} within {timeout}s")
+
+
+def main():
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    filter_model = sys.argv[1] if len(sys.argv) > 1 else None
+    models_to_run = EMBEDDING_MODELS
+    if filter_model:
+        models_to_run = [m for m in EMBEDDING_MODELS if filter_model in m[0]]
+        print(f"Filtered to models matching '{filter_model}': {[m[0] for m in models_to_run]}")
+
+    if not GEMINI_API_KEY:
+        print("ERROR: GEMINI_API_KEY is required (used for retain LLM and GT annotation)")
+        sys.exit(1)
+
+    benchmark = EmbeddingsBenchmark(gemini_api_key=GEMINI_API_KEY)
+    run_ts = int(time.time())
+
+    total = len(models_to_run)
+    for i, (embedding_id, provider, model) in enumerate(models_to_run, 1):
+        print(f"\n{'='*60}")
+        print(f"[{i}/{total}] {embedding_id}")
+        print(f"  Provider: {provider}, Model: {model}")
+        print(f"  Fixed reranker: {FIXED_RERANKER_MODEL}")
+        print(f"{'='*60}")
+
+        if provider == "openai" and not OPENAI_API_KEY:
+            print("  SKIP: OPENAI_API_KEY not set")
+            continue
+        if provider == "cohere" and not COHERE_API_KEY:
+            print("  SKIP: COHERE_API_KEY not set")
+            continue
+
+        # Check if we already have an ingested bank AND annotated GT for this model
+        saved_data_dir, saved_bank_id = benchmark.get_bank_for_model(embedding_id)
+        gt_path = gt_path_for_model(embedding_id)
+
+        if saved_data_dir and saved_bank_id and gt_path.exists():
+            data_dir = saved_data_dir
+            bank_id = saved_bank_id
+            print(f"  Reusing existing bank: {bank_id} (data_dir: {data_dir})")
+            print(f"  GT already exists at {gt_path}")
+        else:
+            # Fresh ingest + annotate for this embedding model
+            data_dir = tempfile.mkdtemp(prefix=f"hindsight-emb-{embedding_id[:20]}-")
+            print(f"\n  Phase 1: Ingesting + annotating, volume: {data_dir}")
+
+            ingest_env = _base_env(provider, model)
+            ingest_container = None
+            bank_id = None
+            try:
+                ingest_container, ingest_url = _start_hindsight(data_dir, ingest_env)
+                bank_id = benchmark.ingest_bank(ingest_url, embedding_id, run_ts)
+                benchmark.save_bank_for_model(embedding_id, data_dir, bank_id)
+                print(f"  Bank {bank_id} saved. Starting GT annotation...")
+                benchmark.create_annotations(ingest_url, bank_id, embedding_id)
+                print(f"  Annotation complete.")
+            except Exception as e:
+                print(f"  ERROR during ingest/annotate: {e}")
+                import traceback; traceback.print_exc()
+                if ingest_container:
+                    ingest_container.stop()
+                continue
+            finally:
+                if ingest_container:
+                    print("  Stopping ingest container...")
+                    ingest_container.stop()
+
+        # Phase 2: run benchmark with fixed MiniLM-L6 reranker
+        print(f"\n  Phase 2: Running benchmark (bank={bank_id})")
+        bench_container = None
+        try:
+            bench_env = _benchmark_env(provider, model)
+            bench_container, bench_url = _start_hindsight(data_dir, bench_env)
+            print(f"  Container ready at {bench_url}. Running embeddings benchmark...")
+            result = benchmark.run_with_bank(
+                embedding_id=embedding_id,
+                provider=provider,
+                model=model,
+                api_url=bench_url,
+                bank_id=bank_id,
+            )
+            print(
+                f"\n  Result: MRR={result.get('mrr')}, "
+                f"R@1={result.get('recall_at_1')}, "
+                f"R@3={result.get('recall_at_3')}, "
+                f"R@5={result.get('recall_at_5')}, "
+                f"avg_latency={result.get('avg_latency_s')}s"
+            )
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            import traceback; traceback.print_exc()
+        finally:
+            if bench_container is not None:
+                print("  Stopping benchmark container...")
+                bench_container.stop()
+
+    print(f"\n{'='*60}")
+    print("All embedding benchmarks complete!")
+    print(f"Results saved to: {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark-runner/run_all_embeddings.py
+++ b/benchmark-runner/run_all_embeddings.py
@@ -59,11 +59,21 @@ RETAIN_MODEL = "gemini-2.5-flash"
 RETAIN_API_KEY = GEMINI_API_KEY
 
 # Embedding models to benchmark: (embedding_id, provider, model)
-# All models must produce exactly 384-dimensional vectors (Hindsight DB constraint).
+# Hindsight auto-detects the embedding dimension at startup — any dimension is supported.
+# Each model gets its own Docker volume (separate bank) because the schema is fixed at
+# schema-creation time per bank (different dims require different banks).
 EMBEDDING_MODELS = [
     # Local models (no API key required, run on CPU in Docker)
-    ("bge-small-en-v1.5",  "local", "BAAI/bge-small-en-v1.5"),
-    ("all-minilm-l6-v2",   "local", "sentence-transformers/all-MiniLM-L6-v2"),
+    ("bge-small-en-v1.5",       "local",  "BAAI/bge-small-en-v1.5"),
+    ("all-minilm-l6-v2",        "local",  "sentence-transformers/all-MiniLM-L6-v2"),
+    ("bge-base-en-v1.5",        "local",  "BAAI/bge-base-en-v1.5"),
+    ("bge-large-en-v1.5",       "local",  "BAAI/bge-large-en-v1.5"),
+    # OpenAI embedding API
+    ("text-embedding-3-small",  "openai", "text-embedding-3-small"),
+    # text-embedding-3-large (3072-dim) exceeds pgvector HNSW 2000-dim limit — excluded
+    # Cohere embedding API
+    ("cohere-embed-english-light-v3.0", "cohere", "embed-english-light-v3.0"),
+    ("cohere-embed-english-v3.0",       "cohere", "embed-english-v3.0"),
 ]
 
 
@@ -92,6 +102,7 @@ def _base_env(embedding_provider: str, embedding_model: str) -> dict:
     }
     if embedding_provider == "local" and embedding_model:
         env["HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"] = embedding_model
+        env["HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE"] = "true"
     elif embedding_provider == "openai" and embedding_model:
         env["HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"] = embedding_model
         env["HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"] = OPENAI_API_KEY
@@ -110,9 +121,23 @@ def _benchmark_env(embedding_provider: str, embedding_model: str) -> dict:
     return env
 
 
+HF_HUB_CACHE_DIR = Path.home() / ".cache" / "huggingface" / "hub"
+
+
 def _start_hindsight(data_dir: str, env: dict) -> tuple[DockerContainer, str]:
     c = DockerContainer(HINDSIGHT_IMAGE)
     c.with_volume_mapping(data_dir, "/app/data", "rw")
+    # Mount host HF cache so models aren't re-downloaded on each container start.
+    # HOME is /app/data in the container, so we must set HF_HOME explicitly to override
+    # the default HOME-based path. Mount 'hub' and 'modules' separately to avoid
+    # token file permission issues with the parent directory.
+    hf_base = Path.home() / ".cache" / "huggingface"
+    (hf_base / "hub").mkdir(parents=True, exist_ok=True)
+    (hf_base / "modules").mkdir(parents=True, exist_ok=True)
+    c.with_volume_mapping(str(hf_base / "hub"), "/hf_cache/hub", "rw")
+    c.with_volume_mapping(str(hf_base / "modules"), "/hf_cache/modules", "rw")
+    c.with_env("HF_HOME", "/hf_cache")
+    c.with_env("HF_HUB_OFFLINE", "1")  # use only cached models, no network calls
     c.with_exposed_ports(HINDSIGHT_PORT)
     for k, v in env.items():
         c.with_env(k, v)

--- a/benchmark-runner/src/hindsight_benchmark/embeddings.py
+++ b/benchmark-runner/src/hindsight_benchmark/embeddings.py
@@ -1,0 +1,392 @@
+"""
+Embeddings benchmark — measures retrieval quality of different embedding models via Hindsight recall() on LoComo conv-43.
+
+Architecture:
+  Each embedding model gets its own persistent Docker volume (the DB schema bakes in vector dimensions,
+  so models with different dimensions cannot share a bank).
+
+  IMPORTANT: The ground truth (GT) must be annotated per bank, not shared across embedding models.
+  This is because the retain LLM is non-deterministic — it phrases/summarizes facts differently per
+  ingest run, so fact texts in bank A will not exactly match fact texts in bank B even if the same
+  conversation was ingested. Exact string matching against a cross-bank GT would fail.
+
+  For each embedding model:
+    Phase 1 (ingest + annotate, once per model):
+      - Start a Hindsight container with the target embedding model + RRF reranker
+      - Ingest conv-43 into a persistent bank
+      - Annotate ground truth: recall(budget="high") per question, LLM identifies relevant facts
+      - Save data_dir + bank_id to datasets/embedding_banks.json
+      - Save per-model GT to datasets/locomo_embeddings_gt_{embedding_id}.json
+
+    Phase 2 (benchmark, reusable):
+      - Start container with same embedding model + fixed reranker (MiniLM-L6)
+      - For each annotated question, call recall(budget="mid")
+      - Match results against the per-model GT by exact text
+      - Compute MRR and Recall@K metrics
+"""
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+from openai import OpenAI
+
+from .benchmark import DATASETS_DIR
+
+EMBEDDINGS_RESULTS_DIR = Path(__file__).parent.parent.parent.parent / "results" / "leaderboard" / "embeddings"
+# Metadata file: tracks data_dir + bank_id + gt_path per embedding model
+BANKS_META_PATH = DATASETS_DIR / "embedding_banks.json"
+
+TARGET_CONVERSATION = "conv-43"
+DATASET_PATH = DATASETS_DIR / "locomo_quality.json"
+ANNOTATION_MODEL = "gemini-2.5-flash"
+
+# Fixed reranker used for all embedding benchmark runs
+FIXED_RERANKER_ID = "local-minilm-l6"
+FIXED_RERANKER_PROVIDER = "local"
+FIXED_RERANKER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+def gt_path_for_model(embedding_id: str) -> Path:
+    """Return the per-model GT path for a given embedding model id."""
+    safe_id = embedding_id.replace("/", "-").replace(".", "-")
+    return DATASETS_DIR / f"locomo_embeddings_gt_{safe_id}.json"
+
+
+class EmbeddingsBenchmark:
+    """Measures retrieval quality of embedding models via Hindsight recall() on LoComo conv-43.
+
+    The reranker is fixed (MiniLM-L6 cross-encoder) so only the embedding model changes.
+    Each model gets its own GT annotation since fact texts differ per ingest.
+    """
+
+    def __init__(self, gemini_api_key: str = None):
+        if gemini_api_key:
+            self.llm_client = OpenAI(
+                api_key=gemini_api_key,
+                base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+                timeout=120.0,
+            )
+            self.annotation_model = ANNOTATION_MODEL
+        else:
+            self.llm_client = None
+            self.annotation_model = None
+
+    def load_banks_meta(self) -> Dict[str, Any]:
+        if not BANKS_META_PATH.exists():
+            return {}
+        with open(BANKS_META_PATH) as f:
+            return json.load(f)
+
+    def save_banks_meta(self, meta: Dict[str, Any]) -> None:
+        BANKS_META_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(BANKS_META_PATH, "w") as f:
+            json.dump(meta, f, indent=2)
+
+    def get_bank_for_model(self, embedding_id: str) -> tuple[str, str] | tuple[None, None]:
+        """Return (data_dir, bank_id) for an embedding model if it exists and data_dir is valid."""
+        meta = self.load_banks_meta()
+        entry = meta.get(embedding_id, {})
+        data_dir = entry.get("data_dir")
+        bank_id = entry.get("bank_id")
+        if data_dir and bank_id and Path(data_dir).exists():
+            return data_dir, bank_id
+        return None, None
+
+    def save_bank_for_model(self, embedding_id: str, data_dir: str, bank_id: str) -> None:
+        meta = self.load_banks_meta()
+        meta[embedding_id] = {"data_dir": data_dir, "bank_id": bank_id, "embedding_id": embedding_id}
+        self.save_banks_meta(meta)
+
+    def ingest_bank(self, api_url: str, embedding_id: str, run_ts: int) -> str:
+        """Ingest LoComo conv-43 into a new bank. Returns bank_id."""
+        from hindsight_client import Hindsight
+        from .quality import _parse_date
+
+        with open(DATASET_PATH) as f:
+            dataset = json.load(f)
+
+        item = next((i for i in dataset if i["sample_id"] == TARGET_CONVERSATION), None)
+        if item is None:
+            raise ValueError(f"Conversation {TARGET_CONVERSATION} not found in dataset")
+
+        client = Hindsight(base_url=api_url)
+        safe_id = embedding_id.replace("/", "-").replace(".", "-")
+        bank_id = f"emb_{safe_id}_{run_ts}"
+        print(f"\nCreating bank: {bank_id}")
+        client.create_bank(bank_id=bank_id)
+
+        conv = item["conversation"]
+        speaker_a = conv["speaker_a"]
+        speaker_b = conv["speaker_b"]
+        session_keys = sorted(k for k in conv if k.startswith("session_") and not k.endswith("_date_time"))
+
+        print(f"Ingesting conversation for embedding model '{embedding_id}'...")
+        for session_key in session_keys:
+            if not isinstance(conv.get(session_key), list):
+                continue
+            session_date = _parse_date(conv[f"{session_key}_date_time"])
+            client.retain(
+                bank_id=bank_id,
+                content=json.dumps(conv[session_key]),
+                context=f"Conversation between {speaker_a} and {speaker_b} ({session_key})",
+                timestamp=session_date,
+                document_id=f"emb_{safe_id}_{session_key}_{run_ts}",
+            )
+            print(f"  ✓ Ingested {session_key}", flush=True)
+
+        return bank_id
+
+    def create_annotations(self, api_url: str, bank_id: str, embedding_id: str) -> Path:
+        """Annotate ground truth relevance for 178 non-adversarial QA pairs against this model's bank.
+
+        Same as the reranker annotation, but stored per-model. Skips if file already exists.
+        Returns the path to the saved GT file.
+        """
+        if not self.llm_client:
+            raise RuntimeError("LLM client required for annotation (set GEMINI_API_KEY)")
+
+        gt_path = gt_path_for_model(embedding_id)
+        if gt_path.exists():
+            print(f"  GT already exists at {gt_path}, skipping annotation.")
+            return gt_path
+
+        with open(DATASET_PATH) as f:
+            dataset = json.load(f)
+
+        item = next((i for i in dataset if i["sample_id"] == TARGET_CONVERSATION), None)
+        if item is None:
+            raise ValueError(f"Conversation {TARGET_CONVERSATION} not found in dataset")
+
+        qa_pairs = [qa for qa in item["qa"] if "answer" in qa]
+        print(f"\nAnnotating {len(qa_pairs)} non-adversarial questions (budget=high)...")
+
+        annotations = []
+        for i, qa in enumerate(qa_pairs, 1):
+            question = qa["question"]
+            expected_answer = qa["answer"]
+
+            recall_response = None
+            for attempt in range(2):
+                try:
+                    recall_response = _direct_recall_raw(
+                        api_url, bank_id, question, budget="high", max_tokens=16000
+                    )
+                    break
+                except Exception as e:
+                    if attempt < 1:
+                        print(f"  Q{i} recall attempt failed ({e}), retrying...", flush=True)
+                        time.sleep(2)
+                    else:
+                        print(f"  Q{i} recall failed after 2 attempts: {e}", flush=True)
+                        recall_response = {"results": []}
+
+            results = recall_response.get("results", [])
+            if not results:
+                print(f"  Q{i}: No results, skipping", flush=True)
+                annotations.append({
+                    "q_idx": i - 1, "question": question,
+                    "expected_answer": expected_answer, "relevant_facts": [],
+                })
+                continue
+
+            relevant_facts = self._annotate_relevant_facts(question, expected_answer, results)
+            annotations.append({
+                "q_idx": i - 1, "question": question,
+                "expected_answer": expected_answer, "relevant_facts": relevant_facts,
+            })
+            found = len(relevant_facts)
+            print(f"  Q{i}/{len(qa_pairs)}: {len(results)} candidates → {found} relevant | {question[:50]}...", flush=True)
+
+        gt_data = {"annotations": annotations, "embedding_id": embedding_id, "bank_id": bank_id}
+        gt_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(gt_path, "w") as f:
+            json.dump(gt_data, f, indent=2)
+        print(f"\nGT saved to {gt_path}")
+        return gt_path
+
+    def run_with_bank(
+        self,
+        embedding_id: str,
+        provider: str,
+        model: str,
+        api_url: str,
+        bank_id: str,
+    ) -> Dict[str, Any]:
+        """Run embedding benchmark against an already-ingested bank with per-model GT."""
+        gt_path = gt_path_for_model(embedding_id)
+        if not gt_path.exists():
+            raise FileNotFoundError(f"GT not found at {gt_path}. Run ingest+annotate first.")
+
+        with open(gt_path) as f:
+            gt_data = json.load(f)
+
+        annotations = gt_data["annotations"]
+        eval_annotations = [a for a in annotations if a["relevant_facts"]]
+        skipped = len(annotations) - len(eval_annotations)
+        if skipped:
+            print(f"  Skipping {skipped} questions with no annotated relevant facts")
+
+        print(f"\n=== Embeddings Benchmark ===")
+        print(f"Embedding: {embedding_id} (provider={provider}, model={model})")
+        print(f"Reranker: {FIXED_RERANKER_ID} ({FIXED_RERANKER_PROVIDER}/{FIXED_RERANKER_MODEL})")
+        print(f"Bank: {bank_id}")
+        print(f"Questions: {len(eval_annotations)}")
+        print(f"Hindsight API: {api_url}")
+
+        ranks_first_match: List[Optional[int]] = []
+        recall_at_k = {1: 0, 3: 0, 5: 0}
+        total_latency = 0.0
+        successful_calls = 0
+        consecutive_failures = 0
+        MAX_CONSECUTIVE_FAILURES = 5
+
+        for i, ann in enumerate(eval_annotations, 1):
+            question = ann["question"]
+            relevant_set = set(ann["relevant_facts"])
+
+            recall_response = None
+            latency = 0.0
+            call_succeeded = False
+            for attempt in range(2):
+                try:
+                    t0 = time.time()
+                    recall_response = _direct_recall_raw(
+                        api_url, bank_id, question, budget="mid", max_tokens=8192
+                    )
+                    latency = time.time() - t0
+                    call_succeeded = True
+                    break
+                except Exception as e:
+                    err_str = str(e)
+                    is_connection_err = any(
+                        kw in err_str for kw in ("Connect call failed", "Cannot connect", "Connection refused")
+                    )
+                    if attempt < 1:
+                        print(f"  Q{i} recall attempt failed ({err_str[:80]}), retrying...", flush=True)
+                        time.sleep(2)
+                    else:
+                        print(f"  Q{i} recall failed after 2 attempts: {err_str[:80]}", flush=True)
+                        recall_response = {"results": []}
+                        if is_connection_err:
+                            consecutive_failures += 1
+
+            if call_succeeded:
+                consecutive_failures = 0
+                total_latency += latency
+                successful_calls += 1
+
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                print(f"\n  ABORT: {consecutive_failures} consecutive connection failures.", flush=True)
+                break
+
+            results = recall_response.get("results", []) if recall_response else []
+            returned_texts = [r.get("text", "") for r in results]
+
+            first_rank = None
+            for rank, text in enumerate(returned_texts, 1):
+                if text in relevant_set:
+                    first_rank = rank
+                    break
+
+            ranks_first_match.append(first_rank)
+
+            top_texts = set(returned_texts[:1])
+            if relevant_set & top_texts:
+                recall_at_k[1] += 1
+            top_texts = set(returned_texts[:3])
+            if relevant_set & top_texts:
+                recall_at_k[3] += 1
+            top_texts = set(returned_texts[:5])
+            if relevant_set & top_texts:
+                recall_at_k[5] += 1
+
+            rank_str = f"rank={first_rank}" if first_rank is not None else "not found"
+            print(f"  Q{i}/{len(eval_annotations)} ({latency:.1f}s) {rank_str}: {question[:55]}...", flush=True)
+
+        total = len(ranks_first_match)
+        mrr = round(
+            sum(1.0 / r for r in ranks_first_match if r is not None) / total, 4
+        ) if total > 0 else 0.0
+        r_at_1 = round(recall_at_k[1] / total, 4) if total > 0 else 0.0
+        r_at_3 = round(recall_at_k[3] / total, 4) if total > 0 else 0.0
+        r_at_5 = round(recall_at_k[5] / total, 4) if total > 0 else 0.0
+        avg_latency_s = round(total_latency / successful_calls, 3) if successful_calls > 0 else 0.0
+
+        print(f"\n=== Results ===")
+        print(f"MRR:         {mrr:.4f}")
+        print(f"Recall@1:    {r_at_1:.4f}")
+        print(f"Recall@3:    {r_at_3:.4f}")
+        print(f"Recall@5:    {r_at_5:.4f}")
+        print(f"Avg latency: {avg_latency_s}s")
+
+        result = {
+            "embedding_id": embedding_id,
+            "provider": provider,
+            "model": model,
+            "reranker_id": FIXED_RERANKER_ID,
+            "recall_at_1": r_at_1,
+            "recall_at_3": r_at_3,
+            "recall_at_5": r_at_5,
+            "mrr": mrr,
+            "avg_latency_s": avg_latency_s,
+            "total_questions": total,
+            "sample_id": TARGET_CONVERSATION,
+        }
+
+        EMBEDDINGS_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        out_path = EMBEDDINGS_RESULTS_DIR / f"{embedding_id}.json"
+        with open(out_path, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"Results saved to {out_path}")
+        return result
+
+    def _annotate_relevant_facts(
+        self, question: str, expected_answer: str, results: list
+    ) -> List[str]:
+        fact_lines = "\n".join(
+            f"[{i+1}] {r.get('text', '')}" for i, r in enumerate(results)
+        )
+        prompt = f"""Given a question and its expected answer, identify which of the following recalled facts contain information that is relevant to answering the question correctly.
+
+Question: {question}
+Expected answer: {expected_answer}
+
+Recalled facts:
+{fact_lines}
+
+Return a JSON object with a "relevant_indices" key containing a list of 1-based indices of the relevant facts.
+Only include facts that directly contain the information needed to answer the question.
+If no facts are relevant, return {{"relevant_indices": []}}.
+
+Respond with JSON only: {{"relevant_indices": [1, 3, ...]}}"""
+
+        try:
+            response = self.llm_client.chat.completions.create(
+                model=self.annotation_model,
+                messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
+                temperature=0,
+            )
+            data = json.loads(response.choices[0].message.content)
+            indices = data.get("relevant_indices", [])
+            relevant = []
+            for idx in indices:
+                if isinstance(idx, int) and 1 <= idx <= len(results):
+                    relevant.append(results[idx - 1].get("text", ""))
+            return [t for t in relevant if t]
+        except Exception as e:
+            print(f"  Warning: Annotation LLM call failed ({e}), returning empty", flush=True)
+            return []
+
+
+def _direct_recall_raw(
+    api_url: str, bank_id: str, query: str, budget: str = "mid", max_tokens: int = 8192, timeout: float = 180.0
+) -> dict:
+    url = f"{api_url}/v1/default/banks/{bank_id}/memories/recall"
+    payload = {"query": query, "budget": budget, "max_tokens": max_tokens}
+    resp = requests.post(url, json=payload, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()

--- a/results/leaderboard/embeddings/all-minilm-l6-v2.json
+++ b/results/leaderboard/embeddings/all-minilm-l6-v2.json
@@ -1,0 +1,13 @@
+{
+  "embedding_id": "all-minilm-l6-v2",
+  "provider": "local",
+  "model": "sentence-transformers/all-MiniLM-L6-v2",
+  "reranker_id": "local-minilm-l6",
+  "recall_at_1": 0.6265,
+  "recall_at_3": 0.8675,
+  "recall_at_5": 0.9277,
+  "mrr": 0.7538,
+  "avg_latency_s": 1.901,
+  "total_questions": 166,
+  "sample_id": "conv-43"
+}

--- a/results/leaderboard/embeddings/bge-base-en-v1.5.json
+++ b/results/leaderboard/embeddings/bge-base-en-v1.5.json
@@ -1,0 +1,13 @@
+{
+  "embedding_id": "bge-base-en-v1.5",
+  "provider": "local",
+  "model": "BAAI/bge-base-en-v1.5",
+  "reranker_id": "local-minilm-l6",
+  "recall_at_1": 0.6667,
+  "recall_at_3": 0.8571,
+  "recall_at_5": 0.9286,
+  "mrr": 0.7754,
+  "avg_latency_s": 2.483,
+  "total_questions": 168,
+  "sample_id": "conv-43"
+}

--- a/results/leaderboard/embeddings/bge-large-en-v1.5.json
+++ b/results/leaderboard/embeddings/bge-large-en-v1.5.json
@@ -1,0 +1,13 @@
+{
+  "embedding_id": "bge-large-en-v1.5",
+  "provider": "local",
+  "model": "BAAI/bge-large-en-v1.5",
+  "reranker_id": "local-minilm-l6",
+  "recall_at_1": 0.6168,
+  "recall_at_3": 0.8263,
+  "recall_at_5": 0.9102,
+  "mrr": 0.7358,
+  "avg_latency_s": 3.77,
+  "total_questions": 167,
+  "sample_id": "conv-43"
+}

--- a/results/leaderboard/embeddings/bge-small-en-v1.5.json
+++ b/results/leaderboard/embeddings/bge-small-en-v1.5.json
@@ -1,0 +1,13 @@
+{
+  "embedding_id": "bge-small-en-v1.5",
+  "provider": "local",
+  "model": "BAAI/bge-small-en-v1.5",
+  "reranker_id": "local-minilm-l6",
+  "recall_at_1": 0.6527,
+  "recall_at_3": 0.8683,
+  "recall_at_5": 0.9102,
+  "mrr": 0.7703,
+  "avg_latency_s": 2.083,
+  "total_questions": 167,
+  "sample_id": "conv-43"
+}

--- a/results/leaderboard/embeddings/cohere-embed-english-light-v3.0.json
+++ b/results/leaderboard/embeddings/cohere-embed-english-light-v3.0.json
@@ -1,0 +1,13 @@
+{
+  "embedding_id": "cohere-embed-english-light-v3.0",
+  "provider": "cohere",
+  "model": "embed-english-light-v3.0",
+  "reranker_id": "local-minilm-l6",
+  "recall_at_1": 0.6946,
+  "recall_at_3": 0.8802,
+  "recall_at_5": 0.9222,
+  "mrr": 0.7905,
+  "avg_latency_s": 1.985,
+  "total_questions": 167,
+  "sample_id": "conv-43"
+}

--- a/results/leaderboard/embeddings/cohere-embed-english-v3.0.json
+++ b/results/leaderboard/embeddings/cohere-embed-english-v3.0.json
@@ -1,0 +1,13 @@
+{
+  "embedding_id": "cohere-embed-english-v3.0",
+  "provider": "cohere",
+  "model": "embed-english-v3.0",
+  "reranker_id": "local-minilm-l6",
+  "recall_at_1": 0.6446,
+  "recall_at_3": 0.8614,
+  "recall_at_5": 0.9157,
+  "mrr": 0.7641,
+  "avg_latency_s": 1.95,
+  "total_questions": 166,
+  "sample_id": "conv-43"
+}

--- a/results/leaderboard/embeddings/text-embedding-3-small.json
+++ b/results/leaderboard/embeddings/text-embedding-3-small.json
@@ -1,0 +1,13 @@
+{
+  "embedding_id": "text-embedding-3-small",
+  "provider": "openai",
+  "model": "text-embedding-3-small",
+  "reranker_id": "local-minilm-l6",
+  "recall_at_1": 0.6316,
+  "recall_at_3": 0.8947,
+  "recall_at_5": 0.9474,
+  "mrr": 0.7639,
+  "avg_latency_s": 3.188,
+  "total_questions": 171,
+  "sample_id": "conv-43"
+}

--- a/visualizer/app/leaderboard/embeddings/page.tsx
+++ b/visualizer/app/leaderboard/embeddings/page.tsx
@@ -90,6 +90,17 @@ export default function EmbeddingsLeaderboardPage() {
                   R@5 asks: <em>&ldquo;is any of the top 5 results relevant?&rdquo;</em>
                 </td>
               </tr>
+              <tr className="align-top">
+                <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">Cost</td>
+                <td className="px-6 py-4 whitespace-nowrap">$ per recall()</td>
+                <td className="px-6 py-4">
+                  Published list price per embedding API call for the query vector only (ingestion is a one-time cost not measured here).
+                  Local models score 100 (free). API pricing is estimated at ~50 tokens per query:
+                  OpenAI <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">text-embedding-3-small</code> ($0.02/1M tokens ≈ $0.000001/query).
+                  Cohere <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">embed-english-*-v3.0</code> ($0.10/1M tokens ≈ $0.000005/query).
+                  Scores use <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 0.0001 / (0.0001 + price)</code> — embedding queries are very cheap so cost rarely dominates.
+                </td>
+              </tr>
               <tr className="align-top bg-secondary/20">
                 <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">Latency</td>
                 <td className="px-6 py-4 whitespace-nowrap">avg s/recall</td>
@@ -105,6 +116,7 @@ export default function EmbeddingsLeaderboardPage() {
                   Benchmark uses the <strong className="text-foreground">LoComo</strong> long-term conversation
                   dataset (conv-43, 165 questions with annotated ground truth).
                   Each embedding model ingests the conversation into its own bank (separate volume, since dimensions are fixed at schema creation).
+                  Models above <strong className="text-foreground">2000 dimensions</strong> are excluded due to pgvector&apos;s HNSW index limit.
                   Fixed reranker: <strong className="text-foreground">MiniLM-L6</strong> (cross-encoder/ms-marco-MiniLM-L-6-v2) for all runs.
                   Candidates per recall: <strong className="text-foreground">300</strong> (budget=mid).
                   Ground truth is annotated <strong className="text-foreground">per model</strong> — each model gets its own GT file,
@@ -118,38 +130,6 @@ export default function EmbeddingsLeaderboardPage() {
         </div>
       </div>
 
-      {/* Interpretation notes */}
-      <div className="mt-8 space-y-4">
-        <h2 className="text-xl font-heading font-bold text-foreground">Interpreting the results</h2>
-
-        <div className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground space-y-2">
-          <p className="font-semibold text-foreground">Why does each embedding model need its own bank?</p>
-          <p>
-            Hindsight stores vectors in a PostgreSQL table with a fixed-width column set at bank creation time.
-            The vector dimension is determined by the embedding model used during the first <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">retain()</code> call
-            and cannot change afterwards. Switching embedding models requires a fresh database volume and
-            re-ingesting the entire conversation from scratch.
-          </p>
-          <p className="text-xs pt-1 border-t border-border">
-            <strong className="text-foreground">Practical implication:</strong> the ingestion latency is not counted in the benchmark results —
-            only <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">recall()</code> latency is measured, which includes
-            vector search + reranking. Ingestion is a one-time cost per model per conversation.
-          </p>
-        </div>
-
-        <div className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground space-y-2">
-          <p className="font-semibold text-foreground">Why is the reranker fixed (MiniLM-L6)?</p>
-          <p>
-            To isolate the contribution of the embedding model. By holding the reranker constant across all runs,
-            differences in MRR and Recall@K reflect only the quality of the embedding model&apos;s vector space —
-            how well it represents semantic similarity for short conversational facts.
-            The reranker is the top performer from the{' '}
-            <a href="/leaderboard/reranker" className="text-foreground underline underline-offset-2 hover:text-primary transition-colors">
-              Reranker Leaderboard
-            </a>.
-          </p>
-        </div>
-      </div>
     </main>
   )
 }

--- a/visualizer/app/leaderboard/embeddings/page.tsx
+++ b/visualizer/app/leaderboard/embeddings/page.tsx
@@ -1,0 +1,155 @@
+import { loadEmbeddingsData } from '@/lib/embeddings'
+import EmbeddingsTable from '@/components/leaderboard/EmbeddingsTable'
+
+export default function EmbeddingsLeaderboardPage() {
+  const embeddings = loadEmbeddingsData()
+
+  return (
+    <main className="container mx-auto max-w-7xl px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-4xl font-heading font-bold text-foreground mb-2 gradient-primary-text">
+          Embeddings Leaderboard
+        </h1>
+        <p className="text-lg text-muted-foreground">
+          Which embedding model retrieves the most relevant facts from{' '}
+          <code className="px-1.5 py-0.5 bg-secondary rounded text-sm font-mono">recall()</code>?
+        </p>
+      </div>
+
+      <div className="mb-6 flex items-center gap-3 rounded-lg border border-border bg-secondary/30 px-4 py-3 text-sm text-muted-foreground">
+        <span>Want to see another embedding model here?</span>
+        <a
+          href="https://github.com/vectorize-io/hindsight-benchmarks/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-foreground underline underline-offset-4 hover:text-primary transition-colors"
+        >
+          Open a GitHub issue
+        </a>
+      </div>
+
+      {embeddings.length > 0 ? (
+        <EmbeddingsTable embeddings={embeddings} />
+      ) : (
+        <div className="border border-border rounded-xl p-12 text-center bg-card">
+          <h3 className="text-xl font-heading text-foreground mb-2">No Embeddings Benchmark Results</h3>
+          <p className="text-muted-foreground">
+            Run{' '}
+            <code className="px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">
+              uv run python3 -u run_all_embeddings.py
+            </code>{' '}
+            to generate embeddings benchmark data.
+          </p>
+        </div>
+      )}
+
+      {/* About Section */}
+      <div className="mt-12 pt-8 border-t border-border">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-2xl font-heading font-bold text-foreground">About This Benchmark</h2>
+        </div>
+        <div className="border border-border rounded-lg overflow-hidden bg-card">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-secondary/50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider w-32">Metric</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider w-40">Value shown</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">How it is measured</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border text-sm text-muted-foreground">
+              <tr className="align-top">
+                <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">MRR</td>
+                <td className="px-6 py-4 whitespace-nowrap">0 – 1</td>
+                <td className="px-6 py-4">
+                  <strong className="text-foreground">Mean Reciprocal Rank</strong> — for each question the
+                  rank of the first relevant fact in the <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">recall()</code> results
+                  is recorded, then averaged as 1/rank across all questions.
+                  Higher is better; 1.0 means the relevant fact is always the top result.
+                </td>
+              </tr>
+              <tr className="align-top bg-secondary/20">
+                <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">Total Score</td>
+                <td className="px-6 py-4 whitespace-nowrap">0 – 100</td>
+                <td className="px-6 py-4">
+                  Weighted composite: <strong className="text-foreground">MRR 70%</strong> + <strong className="text-foreground">Speed 15%</strong> + <strong className="text-foreground">Cost 15%</strong>.
+                  MRR is scaled directly to 0–100 (MRR × 100).
+                  Speed uses <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 1 / (1 + latency_s)</code> (1s reference).
+                  Cost uses <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 0.0001 / (0.0001 + price_per_query)</code>.
+                  R@K metrics are shown for reference but not included in the total score.
+                </td>
+              </tr>
+              <tr className="align-top">
+                <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">R@K</td>
+                <td className="px-6 py-4 whitespace-nowrap">% of questions</td>
+                <td className="px-6 py-4">
+                  <strong className="text-foreground">Recall at K</strong> — the fraction of questions
+                  where at least one relevant fact appears in the top-K results returned by{' '}
+                  <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">recall()</code>.
+                  R@1 asks: <em>&ldquo;is the very first result relevant?&rdquo;</em>
+                  R@5 asks: <em>&ldquo;is any of the top 5 results relevant?&rdquo;</em>
+                </td>
+              </tr>
+              <tr className="align-top bg-secondary/20">
+                <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">Latency</td>
+                <td className="px-6 py-4 whitespace-nowrap">avg s/recall</td>
+                <td className="px-6 py-4">
+                  Mean wall-clock time per <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">recall()</code> call,
+                  including reranking. All models run with <strong className="text-foreground">MiniLM-L6</strong> cross-encoder reranker on CPU inside Docker — latency would be lower with GPU support.
+                </td>
+              </tr>
+              <tr className="align-top">
+                <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">Setup</td>
+                <td className="px-6 py-4 whitespace-nowrap">—</td>
+                <td className="px-6 py-4">
+                  Benchmark uses the <strong className="text-foreground">LoComo</strong> long-term conversation
+                  dataset (conv-43, 165 questions with annotated ground truth).
+                  Each embedding model ingests the conversation into its own bank (separate volume, since dimensions are fixed at schema creation).
+                  Fixed reranker: <strong className="text-foreground">MiniLM-L6</strong> (cross-encoder/ms-marco-MiniLM-L-6-v2) for all runs.
+                  Candidates per recall: <strong className="text-foreground">300</strong> (budget=mid).
+                  Ground truth is annotated <strong className="text-foreground">per model</strong> — each model gets its own GT file,
+                  because the retain LLM is non-deterministic and phrases facts differently each run.
+                  Annotation uses <strong className="text-foreground">gemini-2.5-flash</strong> to identify relevant facts
+                  from a high-budget recall on each model&apos;s own bank.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Interpretation notes */}
+      <div className="mt-8 space-y-4">
+        <h2 className="text-xl font-heading font-bold text-foreground">Interpreting the results</h2>
+
+        <div className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground space-y-2">
+          <p className="font-semibold text-foreground">Why does each embedding model need its own bank?</p>
+          <p>
+            Hindsight stores vectors in a PostgreSQL table with a fixed-width column set at bank creation time.
+            The vector dimension is determined by the embedding model used during the first <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">retain()</code> call
+            and cannot change afterwards. Switching embedding models requires a fresh database volume and
+            re-ingesting the entire conversation from scratch.
+          </p>
+          <p className="text-xs pt-1 border-t border-border">
+            <strong className="text-foreground">Practical implication:</strong> the ingestion latency is not counted in the benchmark results —
+            only <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">recall()</code> latency is measured, which includes
+            vector search + reranking. Ingestion is a one-time cost per model per conversation.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground space-y-2">
+          <p className="font-semibold text-foreground">Why is the reranker fixed (MiniLM-L6)?</p>
+          <p>
+            To isolate the contribution of the embedding model. By holding the reranker constant across all runs,
+            differences in MRR and Recall@K reflect only the quality of the embedding model&apos;s vector space —
+            how well it represents semantic similarity for short conversational facts.
+            The reranker is the top performer from the{' '}
+            <a href="/leaderboard/reranker" className="text-foreground underline underline-offset-2 hover:text-primary transition-colors">
+              Reranker Leaderboard
+            </a>.
+          </p>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/visualizer/app/leaderboard/embeddings/page.tsx
+++ b/visualizer/app/leaderboard/embeddings/page.tsx
@@ -92,13 +92,13 @@ export default function EmbeddingsLeaderboardPage() {
               </tr>
               <tr className="align-top">
                 <td className="px-6 py-4 font-semibold text-foreground whitespace-nowrap">Cost</td>
-                <td className="px-6 py-4 whitespace-nowrap">$ per recall()</td>
+                <td className="px-6 py-4 whitespace-nowrap">$ per 1M tokens</td>
                 <td className="px-6 py-4">
-                  Published list price per embedding API call for the query vector only (ingestion is a one-time cost not measured here).
-                  Local models score 100 (free). API pricing is estimated at ~50 tokens per query:
-                  OpenAI <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">text-embedding-3-small</code> ($0.02/1M tokens ≈ $0.000001/query).
-                  Cohere <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">embed-english-*-v3.0</code> ($0.10/1M tokens ≈ $0.000005/query).
-                  Scores use <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 0.0001 / (0.0001 + price)</code> — embedding queries are very cheap so cost rarely dominates.
+                  Published list price per 1M tokens — the same rate applies to both <strong className="text-foreground">ingestion</strong> (embedding facts during <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">retain()</code>) and <strong className="text-foreground">queries</strong> (embedding the search query on each <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">recall()</code>).
+                  Local models score 100 (free).
+                  OpenAI <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">text-embedding-3-small</code>: $0.02/1M tokens.
+                  Cohere <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">embed-english-*-v3.0</code>: $0.10/1M tokens.
+                  Score formula: <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 0.10 / (0.10 + price)</code> — $0.10/1M reference, so Cohere scores ~50 and OpenAI small scores ~83.
                 </td>
               </tr>
               <tr className="align-top bg-secondary/20">

--- a/visualizer/app/leaderboard/embeddings/page.tsx
+++ b/visualizer/app/leaderboard/embeddings/page.tsx
@@ -75,7 +75,7 @@ export default function EmbeddingsLeaderboardPage() {
                   Weighted composite: <strong className="text-foreground">MRR 70%</strong> + <strong className="text-foreground">Speed 15%</strong> + <strong className="text-foreground">Cost 15%</strong>.
                   MRR is scaled directly to 0–100 (MRR × 100).
                   Speed uses <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 1 / (1 + latency_s)</code> (1s reference).
-                  Cost uses <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 0.0001 / (0.0001 + price_per_query)</code>.
+                  Cost uses <code className="mx-1 px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">100 × 0.10 / (0.10 + price_per_1m_tokens)</code> ($0.10/1M reference).
                   R@K metrics are shown for reference but not included in the total score.
                 </td>
               </tr>
@@ -114,7 +114,7 @@ export default function EmbeddingsLeaderboardPage() {
                 <td className="px-6 py-4 whitespace-nowrap">—</td>
                 <td className="px-6 py-4">
                   Benchmark uses the <strong className="text-foreground">LoComo</strong> long-term conversation
-                  dataset (conv-43, 165 questions with annotated ground truth).
+                  dataset (conv-43). 178 non-adversarial questions are annotated per model; questions with zero relevant facts are skipped, leaving ~165–171 evaluated per model.
                   Each embedding model ingests the conversation into its own bank (separate volume, since dimensions are fixed at schema creation).
                   Models above <strong className="text-foreground">2000 dimensions</strong> are excluded due to pgvector&apos;s HNSW index limit.
                   Fixed reranker: <strong className="text-foreground">MiniLM-L6</strong> (cross-encoder/ms-marco-MiniLM-L-6-v2) for all runs.

--- a/visualizer/app/leaderboard/embeddings/page.tsx
+++ b/visualizer/app/leaderboard/embeddings/page.tsx
@@ -11,8 +11,8 @@ export default function EmbeddingsLeaderboardPage() {
           Embeddings Leaderboard
         </h1>
         <p className="text-lg text-muted-foreground">
-          Which embedding model retrieves the most relevant facts from{' '}
-          <code className="px-1.5 py-0.5 bg-secondary rounded text-sm font-mono">recall()</code>?
+          Which embedding model works best with Hindsight? Rankings cover retrieval quality, speed, and cost —
+          the embedding model affects both memory storage (<code className="px-1.5 py-0.5 bg-secondary rounded text-sm font-mono">retain()</code>) and search (<code className="px-1.5 py-0.5 bg-secondary rounded text-sm font-mono">recall()</code>).
         </p>
       </div>
 

--- a/visualizer/app/page.tsx
+++ b/visualizer/app/page.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { loadLongMemEval, loadLoComo } from '@/lib/data'
 import { loadLeaderboardData, getLeaderboardStats } from '@/lib/leaderboard'
 import { loadRerankerData, getRerankerStats } from '@/lib/reranker'
+import { loadEmbeddingsData, getEmbeddingsStats } from '@/lib/embeddings'
 
 function StatBlock({ value, label, highlight }: { value: string | number; label: string; highlight?: boolean }) {
   return (
@@ -93,6 +94,8 @@ export default function Home() {
   const leaderboardStats = getLeaderboardStats(leaderboardModels)
   const rerankers = loadRerankerData()
   const rerankerStats = getRerankerStats(rerankers)
+  const embeddingModels = loadEmbeddingsData()
+  const embeddingsStats = getEmbeddingsStats(embeddingModels)
 
   return (
     <main className="min-h-screen">
@@ -186,6 +189,17 @@ export default function Home() {
                 stats={[
                   { value: rerankerStats.count, label: 'Rerankers', highlight: true },
                   ...(rerankerStats.topReranker ? [{ value: rerankerStats.topReranker.score.toFixed(1), label: 'Top Score' }] : []),
+                ]}
+                cta="View leaderboard"
+              />
+              <BenchmarkCard
+                href="/leaderboard/embeddings"
+                tag="Leaderboard"
+                title="Embeddings Leaderboard"
+                description={<>Ranked embedding models for <span className="gradient-primary-text font-semibold">recall()</span> — which embedding retrieves the most relevant facts.</>}
+                stats={[
+                  { value: embeddingsStats.count, label: 'Models', highlight: true },
+                  ...(embeddingsStats.topEmbedding ? [{ value: embeddingsStats.topEmbedding.score.toFixed(1), label: 'Top Score' }] : []),
                 ]}
                 cta="View leaderboard"
               />

--- a/visualizer/app/page.tsx
+++ b/visualizer/app/page.tsx
@@ -188,8 +188,12 @@ export default function Home() {
                 description={<>Ranked rerankers for <span className="gradient-primary-text font-semibold">recall()</span> — which reranker surfaces the most relevant facts first.</>}
                 stats={[
                   { value: rerankerStats.count, label: 'Rerankers', highlight: true },
-                  ...(rerankerStats.topReranker ? [{ value: rerankerStats.topReranker.score.toFixed(1), label: 'Top Score' }] : []),
                 ]}
+                winner={rerankerStats.topReranker ? {
+                  name: rerankerStats.topReranker.name,
+                  providerIcon: rerankerStats.topReranker.providerIcon,
+                  providerName: rerankerStats.topReranker.providerName,
+                } : null}
                 cta="View leaderboard"
               />
               <BenchmarkCard
@@ -199,8 +203,12 @@ export default function Home() {
                 description={<>Ranked embedding models for <span className="gradient-primary-text font-semibold">recall()</span> — which embedding retrieves the most relevant facts.</>}
                 stats={[
                   { value: embeddingsStats.count, label: 'Models', highlight: true },
-                  ...(embeddingsStats.topEmbedding ? [{ value: embeddingsStats.topEmbedding.score.toFixed(1), label: 'Top Score' }] : []),
                 ]}
+                winner={embeddingsStats.topEmbedding ? {
+                  name: embeddingsStats.topEmbedding.name,
+                  providerIcon: embeddingsStats.topEmbedding.providerIcon,
+                  providerName: embeddingsStats.topEmbedding.providerName,
+                } : null}
                 cta="View leaderboard"
               />
             </div>

--- a/visualizer/app/page.tsx
+++ b/visualizer/app/page.tsx
@@ -200,7 +200,7 @@ export default function Home() {
                 href="/leaderboard/embeddings"
                 tag="Leaderboard"
                 title="Embeddings Leaderboard"
-                description={<>Ranked embedding models for <span className="gradient-primary-text font-semibold">recall()</span> — which embedding retrieves the most relevant facts.</>}
+                description={<>Ranked embedding models for Hindsight — affects both <span className="gradient-primary-text font-semibold">retain()</span> storage and <span className="gradient-primary-text font-semibold">recall()</span> retrieval quality.</>}
                 stats={[
                   { value: embeddingsStats.count, label: 'Models', highlight: true },
                 ]}

--- a/visualizer/components/leaderboard/EmbeddingsTable.tsx
+++ b/visualizer/components/leaderboard/EmbeddingsTable.tsx
@@ -218,6 +218,35 @@ export default function EmbeddingsTable({ embeddings }: EmbeddingsTableProps) {
       },
       size: 130,
     },
+    {
+      id: 'costScore',
+      accessorFn: row => row.score.costScore,
+      header: () => (
+        <div>
+          <div>Cost</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">$ per recall()</div>
+        </div>
+      ),
+      cell: ({ getValue, row }) => {
+        const score = getValue() as number
+        const { pricePerQuery, pricingType } = row.original.score
+        const priceLabel = pricingType === 'free' || pricePerQuery === 0
+          ? 'Free'
+          : pricePerQuery < 0.0001
+            ? `$${(pricePerQuery * 1_000_000).toFixed(2)}/1M`
+            : `$${pricePerQuery.toFixed(5)}`
+        return (
+          <div className="relative px-6 py-4" style={{ backgroundColor: scoreToBackground(score) }}>
+            <div className="absolute inset-0" style={{ width: `${score}%`, backgroundColor: scoreToBar(score) }} />
+            <div className="relative z-10">
+              <div className="text-sm font-semibold" style={{ color: scoreToText(score) }}>{score.toFixed(1)}</div>
+              <div className="text-xs text-muted-foreground">{priceLabel}</div>
+            </div>
+          </div>
+        )
+      },
+      size: 130,
+    },
   ]
 
   const table = useReactTable({

--- a/visualizer/components/leaderboard/EmbeddingsTable.tsx
+++ b/visualizer/components/leaderboard/EmbeddingsTable.tsx
@@ -224,17 +224,15 @@ export default function EmbeddingsTable({ embeddings }: EmbeddingsTableProps) {
       header: () => (
         <div>
           <div>Cost</div>
-          <div className="text-xs font-normal text-muted-foreground normal-case">$ per recall()</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">$ per 1M tokens</div>
         </div>
       ),
       cell: ({ getValue, row }) => {
         const score = getValue() as number
-        const { pricePerQuery, pricingType } = row.original.score
-        const priceLabel = pricingType === 'free' || pricePerQuery === 0
+        const { pricePer1mTokens, pricingType } = row.original.score
+        const priceLabel = pricingType === 'free' || pricePer1mTokens === 0
           ? 'Free'
-          : pricePerQuery < 0.0001
-            ? `$${(pricePerQuery * 1_000_000).toFixed(2)}/1M`
-            : `$${pricePerQuery.toFixed(5)}`
+          : `$${pricePer1mTokens.toFixed(2)}/1M tok`
         return (
           <div className="relative px-6 py-4" style={{ backgroundColor: scoreToBackground(score) }}>
             <div className="absolute inset-0" style={{ width: `${score}%`, backgroundColor: scoreToBar(score) }} />

--- a/visualizer/components/leaderboard/EmbeddingsTable.tsx
+++ b/visualizer/components/leaderboard/EmbeddingsTable.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  flexRender,
+  ColumnDef,
+} from '@tanstack/react-table'
+import { useState, useMemo } from 'react'
+import { EmbeddingRow } from '@/lib/embeddings'
+
+function scoreToBackground(score: number): string {
+  const hue = Math.round(score * 1.2)
+  return `hsl(${hue}, 45%, 12%)`
+}
+
+function scoreToBar(score: number): string {
+  const hue = Math.round(score * 1.2)
+  return `hsl(${hue}, 55%, 22%)`
+}
+
+function scoreToText(score: number): string {
+  const hue = Math.round(score * 1.2)
+  return `hsl(${hue}, 70%, 65%)`
+}
+
+function metricCell(value: number, label: string) {
+  const score = value * 100
+  return (
+    <div className="relative px-6 py-4" style={{ backgroundColor: scoreToBackground(score) }}>
+      <div className="absolute inset-0" style={{ width: `${score}%`, backgroundColor: scoreToBar(score) }} />
+      <div className="relative z-10">
+        <div className="text-sm font-semibold" style={{ color: scoreToText(score) }}>{label}</div>
+      </div>
+    </div>
+  )
+}
+
+interface EmbeddingsTableProps {
+  embeddings: EmbeddingRow[]
+}
+
+interface TableRow extends EmbeddingRow {
+  fixedRank: number
+}
+
+export default function EmbeddingsTable({ embeddings }: EmbeddingsTableProps) {
+  const tableData: TableRow[] = useMemo(() => {
+    const sorted = [...embeddings].sort((a, b) => b.score.totalScore - a.score.totalScore)
+    const rankMap = new Map<string, number>()
+    sorted.forEach((r, i) => rankMap.set(r.embedding_id, i + 1))
+    return embeddings.map(r => ({ ...r, fixedRank: rankMap.get(r.embedding_id) ?? 999 }))
+  }, [embeddings])
+
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'totalScore', desc: true }])
+
+  const columns: ColumnDef<TableRow>[] = [
+    {
+      id: 'fixedRank',
+      accessorFn: row => row.fixedRank,
+      header: 'Rank',
+      cell: ({ row }) => {
+        const rank = row.original.fixedRank
+        return (
+          <div className="flex items-center gap-2 px-6 py-4">
+            <span className="text-base font-semibold text-foreground">{rank}</span>
+            {rank === 1 && <span className="text-xl">🏆</span>}
+            {rank === 2 && <span className="text-xl">🥈</span>}
+            {rank === 3 && <span className="text-xl">🥉</span>}
+          </div>
+        )
+      },
+      size: 80,
+    },
+    {
+      id: 'name',
+      accessorFn: row => row.embedding_id,
+      header: 'Embedding Model',
+      cell: ({ row }) => (
+        <div className="px-6 py-4">
+          <div className="text-sm font-medium text-foreground">{row.original.config.display_name}</div>
+          {row.original.model && (
+            <div className="text-xs text-muted-foreground font-mono mt-0.5">{row.original.model}</div>
+          )}
+          {row.original.config.dimensions && (
+            <div className="text-xs text-muted-foreground mt-0.5">{row.original.config.dimensions}-dim</div>
+          )}
+        </div>
+      ),
+      size: 280,
+    },
+    {
+      id: 'provider',
+      accessorFn: row => row.config.provider_name,
+      header: 'Provider',
+      cell: ({ row }) => {
+        const { provider_name, provider_icon } = row.original.config
+        if (!provider_name) return <div className="px-6 py-4" />
+        return (
+          <div className="flex items-center gap-2 px-6 py-4">
+            {provider_icon && (
+              <img src={provider_icon} alt={provider_name} className="w-5 h-5 object-contain" />
+            )}
+            <span className="text-sm text-muted-foreground">{provider_name}</span>
+          </div>
+        )
+      },
+      size: 140,
+    },
+    {
+      id: 'totalScore',
+      accessorFn: row => row.score.totalScore,
+      header: () => (
+        <div>
+          <div>Total Score</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">MRR + Speed + Cost</div>
+        </div>
+      ),
+      cell: ({ getValue }) => {
+        const value = getValue() as number
+        return (
+          <div className="flex items-center gap-2 px-6 py-4">
+            <div className="w-20 bg-secondary rounded-full h-2">
+              <div
+                className="h-2 rounded-full transition-all"
+                style={{ width: `${value}%`, background: 'linear-gradient(to right, #0074d9, #009296)' }}
+              />
+            </div>
+            <span className="text-sm font-bold text-foreground min-w-[3rem]">{value.toFixed(1)}</span>
+          </div>
+        )
+      },
+      size: 200,
+    },
+    {
+      id: 'mrr',
+      accessorFn: row => row.mrr,
+      header: () => (
+        <div>
+          <div>MRR</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">Mean Reciprocal Rank</div>
+        </div>
+      ),
+      cell: ({ getValue }) => {
+        const v = getValue() as number
+        return metricCell(v, v.toFixed(3))
+      },
+      size: 130,
+    },
+    {
+      id: 'recall_at_1',
+      accessorFn: row => row.recall_at_1,
+      header: () => (
+        <div>
+          <div>R@1</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">Recall at 1</div>
+        </div>
+      ),
+      cell: ({ getValue }) => {
+        const v = getValue() as number
+        return metricCell(v, `${(v * 100).toFixed(1)}%`)
+      },
+      size: 110,
+    },
+    {
+      id: 'recall_at_3',
+      accessorFn: row => row.recall_at_3,
+      header: () => (
+        <div>
+          <div>R@3</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">Recall at 3</div>
+        </div>
+      ),
+      cell: ({ getValue }) => {
+        const v = getValue() as number
+        return metricCell(v, `${(v * 100).toFixed(1)}%`)
+      },
+      size: 110,
+    },
+    {
+      id: 'recall_at_5',
+      accessorFn: row => row.recall_at_5,
+      header: () => (
+        <div>
+          <div>R@5</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">Recall at 5</div>
+        </div>
+      ),
+      cell: ({ getValue }) => {
+        const v = getValue() as number
+        return metricCell(v, `${(v * 100).toFixed(1)}%`)
+      },
+      size: 110,
+    },
+    {
+      id: 'speedScore',
+      accessorFn: row => row.score.speedScore,
+      header: () => (
+        <div>
+          <div>Speed</div>
+          <div className="text-xs font-normal text-muted-foreground normal-case">avg s/recall</div>
+        </div>
+      ),
+      cell: ({ getValue, row }) => {
+        const score = getValue() as number
+        const latency = row.original.avg_latency_s
+        return (
+          <div className="relative px-6 py-4" style={{ backgroundColor: scoreToBackground(score) }}>
+            <div className="absolute inset-0" style={{ width: `${score}%`, backgroundColor: scoreToBar(score) }} />
+            <div className="relative z-10">
+              <div className="text-sm font-semibold" style={{ color: scoreToText(score) }}>{score.toFixed(1)}</div>
+              <div className="text-xs text-muted-foreground">{latency.toFixed(2)}s/call</div>
+            </div>
+          </div>
+        )
+      },
+      size: 130,
+    },
+  ]
+
+  const table = useReactTable({
+    data: tableData,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  })
+
+  return (
+    <div className="bg-card rounded-lg border border-border overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border">
+          <thead className="bg-secondary/40">
+            {table.getHeaderGroups().map(headerGroup => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map(header => (
+                  <th
+                    key={header.id}
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider cursor-pointer hover:bg-secondary/60 select-none transition-colors"
+                    onClick={header.column.getToggleSortingHandler()}
+                    style={{ width: header.getSize() }}
+                  >
+                    <div className="flex items-center gap-2">
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      {header.column.getIsSorted() && (
+                        <span className="text-primary text-base">
+                          {header.column.getIsSorted() === 'asc' ? '↑' : '↓'}
+                        </span>
+                      )}
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="divide-y divide-border">
+            {table.getRowModel().rows.map(row => (
+              <tr key={row.id} className="hover:bg-secondary/20 transition-colors">
+                {row.getVisibleCells().map(cell => (
+                  <td key={cell.id} className="whitespace-nowrap text-left">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/visualizer/lib/embeddings.ts
+++ b/visualizer/lib/embeddings.ts
@@ -5,8 +5,9 @@ import { EmbeddingsResult } from './types'
 // Speed reference: a model at this latency scores 50.
 const LATENCY_REFERENCE = 1.0
 
-// Cost reference: a model at this price per query scores 50.
-const COST_REFERENCE = 0.0001
+// Cost reference: a model at this price per 1M tokens scores 50.
+// $0.10/1M tokens (roughly Cohere pricing) → score ~50.
+const COST_REFERENCE_PER_1M = 0.10
 
 export interface EmbeddingConfig {
   embedding_id: string
@@ -15,34 +16,34 @@ export interface EmbeddingConfig {
   provider_name: string
   provider_icon: string
   pricing_type: 'free' | 'pay-per-use'
-  price_per_query: number
+  price_per_1m_tokens: number  // $ per 1M tokens (applies to both ingestion and queries)
   model?: string
   dimensions?: number
   notes?: string
 }
 
 export interface EmbeddingScore {
-  totalScore: number    // 0–100 composite
-  rankingScore: number  // 0–100 from MRR
-  speedScore: number    // 0–100 from latency
-  costScore: number     // 0–100 from price per query
-  pricePerQuery: number
+  totalScore: number       // 0–100 composite
+  rankingScore: number     // 0–100 from MRR
+  speedScore: number       // 0–100 from latency
+  costScore: number        // 0–100 from price per 1M tokens
+  pricePer1mTokens: number
   pricingType: 'free' | 'pay-per-use'
 }
 
 export function calculateEmbeddingScore(
   mrr: number,
   avg_latency_s: number,
-  price_per_query: number,
+  price_per_1m_tokens: number,
   pricing_type: 'free' | 'pay-per-use',
 ): EmbeddingScore {
   const rankingScore = mrr * 100
   const speedScore = avg_latency_s === 0
     ? 0
     : (LATENCY_REFERENCE / (LATENCY_REFERENCE + avg_latency_s)) * 100
-  const costScore = price_per_query === 0
+  const costScore = price_per_1m_tokens === 0
     ? 100
-    : (COST_REFERENCE / (COST_REFERENCE + price_per_query)) * 100
+    : (COST_REFERENCE_PER_1M / (COST_REFERENCE_PER_1M + price_per_1m_tokens)) * 100
 
   // Weights: MRR 70%, Speed 15%, Cost 15%
   const totalScore = rankingScore * 0.70 + speedScore * 0.15 + costScore * 0.15
@@ -52,7 +53,7 @@ export function calculateEmbeddingScore(
     rankingScore: Math.round(rankingScore * 10) / 10,
     speedScore: Math.round(speedScore * 10) / 10,
     costScore: Math.round(costScore * 10) / 10,
-    pricePerQuery: price_per_query,
+    pricePer1mTokens: price_per_1m_tokens,
     pricingType: pricing_type,
   }
 }
@@ -93,7 +94,7 @@ export function loadEmbeddingsData(): EmbeddingRow[] {
       score: calculateEmbeddingScore(
         result.mrr,
         result.avg_latency_s,
-        config.price_per_query,
+        config.price_per_1m_tokens,
         config.pricing_type,
       ),
     }
@@ -105,6 +106,12 @@ export function getEmbeddingsStats(rows: EmbeddingRow[]) {
   const top = [...rows].sort((a, b) => b.score.totalScore - a.score.totalScore)[0]
   return {
     count: rows.length,
-    topEmbedding: top ? { id: top.embedding_id, score: top.score.totalScore } : null,
+    topEmbedding: top ? {
+      id: top.embedding_id,
+      name: top.config.display_name,
+      providerIcon: top.config.provider_icon,
+      providerName: top.config.provider_name,
+      score: top.score.totalScore,
+    } : null,
   }
 }

--- a/visualizer/lib/embeddings.ts
+++ b/visualizer/lib/embeddings.ts
@@ -1,0 +1,110 @@
+import fs from 'fs'
+import path from 'path'
+import { EmbeddingsResult } from './types'
+
+// Speed reference: a model at this latency scores 50.
+const LATENCY_REFERENCE = 1.0
+
+// Cost reference: a model at this price per query scores 50.
+const COST_REFERENCE = 0.0001
+
+export interface EmbeddingConfig {
+  embedding_id: string
+  display_name: string
+  provider: string
+  provider_name: string
+  provider_icon: string
+  pricing_type: 'free' | 'pay-per-use'
+  price_per_query: number
+  model?: string
+  dimensions?: number
+  notes?: string
+}
+
+export interface EmbeddingScore {
+  totalScore: number    // 0–100 composite
+  rankingScore: number  // 0–100 from MRR
+  speedScore: number    // 0–100 from latency
+  costScore: number     // 0–100 from price per query
+  pricePerQuery: number
+  pricingType: 'free' | 'pay-per-use'
+}
+
+export function calculateEmbeddingScore(
+  mrr: number,
+  avg_latency_s: number,
+  price_per_query: number,
+  pricing_type: 'free' | 'pay-per-use',
+): EmbeddingScore {
+  const rankingScore = mrr * 100
+  const speedScore = avg_latency_s === 0
+    ? 0
+    : (LATENCY_REFERENCE / (LATENCY_REFERENCE + avg_latency_s)) * 100
+  const costScore = price_per_query === 0
+    ? 100
+    : (COST_REFERENCE / (COST_REFERENCE + price_per_query)) * 100
+
+  // Weights: MRR 70%, Speed 15%, Cost 15%
+  const totalScore = rankingScore * 0.70 + speedScore * 0.15 + costScore * 0.15
+
+  return {
+    totalScore: Math.round(totalScore * 10) / 10,
+    rankingScore: Math.round(rankingScore * 10) / 10,
+    speedScore: Math.round(speedScore * 10) / 10,
+    costScore: Math.round(costScore * 10) / 10,
+    pricePerQuery: price_per_query,
+    pricingType: pricing_type,
+  }
+}
+
+export interface EmbeddingRow extends EmbeddingsResult {
+  config: EmbeddingConfig
+  score: EmbeddingScore
+}
+
+function loadEmbeddingConfigs(): Map<string, EmbeddingConfig> {
+  const configPath = path.join(process.cwd(), '..', 'benchmark-runner', 'embedding_models.json')
+  if (!fs.existsSync(configPath)) return new Map()
+  const data = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+  return new Map((data.embeddings as EmbeddingConfig[]).map(e => [e.embedding_id, e]))
+}
+
+export function loadEmbeddingsData(): EmbeddingRow[] {
+  const dir = path.join(process.cwd(), '..', 'results', 'leaderboard', 'embeddings')
+  if (!fs.existsSync(dir)) return []
+
+  const configs = loadEmbeddingConfigs()
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'))
+
+  return files.map(file => {
+    const result: EmbeddingsResult = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8'))
+    const config: EmbeddingConfig = configs.get(result.embedding_id) ?? {
+      embedding_id: result.embedding_id,
+      display_name: result.embedding_id,
+      provider: result.provider,
+      provider_name: result.provider,
+      provider_icon: '',
+      pricing_type: 'free',
+      price_per_query: 0,
+    }
+    return {
+      ...result,
+      config,
+      score: calculateEmbeddingScore(
+        result.mrr,
+        result.avg_latency_s,
+        config.price_per_query,
+        config.pricing_type,
+      ),
+    }
+  })
+}
+
+export function getEmbeddingsStats(rows: EmbeddingRow[]) {
+  if (rows.length === 0) return { count: 0, topEmbedding: null }
+  const top = [...rows].sort((a, b) => b.score.totalScore - a.score.totalScore)[0]
+  return {
+    count: rows.length,
+    topEmbedding: top ? { id: top.embedding_id, score: top.score.totalScore } : null,
+  }
+}

--- a/visualizer/lib/reranker.ts
+++ b/visualizer/lib/reranker.ts
@@ -106,6 +106,12 @@ export function getRerankerStats(rows: RerankerRow[]) {
   const top = [...rows].sort((a, b) => b.score.totalScore - a.score.totalScore)[0]
   return {
     count: rows.length,
-    topReranker: top ? { id: top.reranker_id, score: top.score.totalScore } : null,
+    topReranker: top ? {
+      id: top.reranker_id,
+      name: top.config.display_name,
+      providerIcon: top.config.provider_icon,
+      providerName: top.config.provider_name,
+      score: top.score.totalScore,
+    } : null,
   }
 }

--- a/visualizer/lib/types.ts
+++ b/visualizer/lib/types.ts
@@ -138,6 +138,20 @@ export interface RerankerResult {
   sample_id: string
 }
 
+export interface EmbeddingsResult {
+  embedding_id: string
+  provider: string
+  model: string
+  reranker_id: string
+  recall_at_1: number
+  recall_at_3: number
+  recall_at_5: number
+  mrr: number
+  avg_latency_s: number
+  total_questions: number
+  sample_id: string
+}
+
 export interface ModelWithResult {
   config: ModelConfig
   result: BenchmarkRun | null


### PR DESCRIPTION
## Summary
- New **Embeddings Leaderboard** page at `/leaderboard/embeddings` ranking embedding models by MRR, Recall@K, speed, and cost on the LoComo conv-43 dataset
- 7 models benchmarked: `bge-small-en-v1.5`, `all-MiniLM-L6-v2`, `bge-base-en-v1.5`, `bge-large-en-v1.5`, `text-embedding-3-small`, `cohere-embed-english-light-v3.0`, `cohere-embed-english-v3.0`
- Cost column added to the leaderboard table (free vs. pay-per-use API models)
- Fixed reranker (MiniLM-L6) used across all runs to isolate embedding quality
- Per-model ground truth annotation (non-deterministic retain LLM means fact texts differ per ingest)
- Host HF cache mounted into containers to avoid re-downloading models
- Models >2000 dims excluded due to pgvector HNSW index limit (drops `text-embedding-3-large` at 3072-dim)
- Embeddings leaderboard card added to home page

## Benchmark orchestrator (`run_all_embeddings.py`)
- Phase 1: ingest + annotate GT per model (skipped if already exists)
- Phase 2: benchmark with fixed MiniLM-L6 reranker
- Supports `local`, `openai`, `cohere` providers; skips API models when keys are absent

## Test plan
- [ ] Visit `/leaderboard/embeddings` — table shows 7 models sorted by total score
- [ ] Cost column shows "Free" for local models and price label for API models
- [ ] Home page embeddings card shows correct model count and top score
- [ ] Run `uv run python3 -u run_all_embeddings.py <id>` to add a new model